### PR TITLE
Updated the link checker to now use curl and follow redirects with a …

### DIFF
--- a/src/Analyser/Content_Analyser.php
+++ b/src/Analyser/Content_Analyser.php
@@ -10,6 +10,10 @@
 namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Analyser;
 
 use Symfony\Component\DomCrawler\Crawler;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
+
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Link;
+
 use DOMNode;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,11 +31,11 @@ class Content_Analyser {
 	private string $content_raw;
 
 	/**
-	 * All errors
+	 * All links
 	 *
-	 * @var array<int, array{element: DOMNode, index: int, message: string}> $errors
+	 * @var array<int, Link> $links
 	 */
-	private array $errors = array();
+	private array $links = array();
 
 	/**
 	 * Create instance of Content_Analyser.
@@ -45,34 +49,85 @@ class Content_Analyser {
 	}
 
 	/**
-	 * Add an error.
+	 * Add a broken link.
 	 *
-	 * @since 1.0.0
+	 * @since
 	 *
-	 * @param DOMNode     $element The element which contains the error.
-	 * @param integer     $index   The index of the error.
-	 * @param string      $url     The URL which is causing the error.
-	 * @param string|null $message The error message.
+	 * @param integer     $index    The index of the link.
+	 * @param string|null $href     The href of the link.
+	 * @param string|null $contents The contents of the link.
+	 * @param string      $message  The error message.
 	 *
 	 * @return void
 	 */
-	public function add_error( DOMNode $element, int $index, string $url, ?string $message = '' ) {
-		$this->errors[] = array(
-			'element' => $element,
-			'index'   => $index,
-			'message' => $message ?? '',
-			'url'     => $url,
+	public function add_broken_link( int $index, ?string $href, ?string $contents, string $message ) {
+		$this->links[] = new Link(
+			$index,
+			$href,
+			$contents,
+			true,
+			null,
+			null,
+			array(),
+			false,
+			array( $message )
 		);
 	}
 
 	/**
-	 * Analyse the content.
+	 * Adds a redirection link.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param integer            $index             The index of the link.
+	 * @param string|null        $href              The href of the link.
+	 * @param string|null        $contents          The contents of the link.
+	 * @param array<int, string> $redirects         The redirects.
+	 * @param integer            $redirect_type     The redirect type.
+	 * @param integer            $final_status_code The status code of the final url.
+	 * @param string|null        $details           The details of the redirection.
+	 *
+	 * @return void
+	 */
+	public function add_redirection_link( int $index, ?string $href, ?string $contents, array $redirects, int $redirect_type, int $final_status_code, ?string $details = null ) {
+		$chain = array_merge( array( $href ), $redirects );
+
+		// Get final url and trim it
+		$final_url = $redirects[ array_key_last( $redirects ) ] ?? null;
+		if ( $final_url ) {
+			$final_url = trim( $final_url );
+		}
+
+		$this->links[] = new Link(
+			$index,
+			$href,
+			$contents,
+			200 <= $final_status_code && 300 > $final_status_code,
+			$final_url,
+			$redirect_type,
+			array(),
+			false,
+			array_filter(
+				array(
+					$details,
+					'Redirection chain:',
+					join( ' >> ', array_map( 'trim', $chain ) ),
+					"Final status code: {$final_status_code}",
+				)
+			)
+		);
+	}
+
+	/**
+	 * Analyze the content.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	public function analyse() {
+	public function analyze() {
+
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Convert to a DomDocument Model.
 		$crawler = new Crawler( $this->content_raw );
@@ -85,63 +140,143 @@ class Content_Analyser {
 			$attributes = $link_node->attributes;
 
 			// If we have no attributes, add as an error.
-			if ( ! $attributes ) {
-				$this->add_error( $link_node, $index, 'n/a', 'no_href' );
+			if ( 0 === count( $attributes ) ) {
+				$this->add_broken_link( $index, null, $link_node->nodeValue, 'no_attributes' );
 				continue;
 			}
 
-			$node = $attributes->getNamedItem( 'href' );
+			$href_node = $attributes->getNamedItem( 'href' );
 
 			// If we have no node, add as an error.
-			if ( ! $node ) {
-				$this->add_error( $link_node, $index, 'n/a', 'no_href' );
+			if ( ! $href_node ) {
+				$this->add_broken_link( $index, null, $link_node->nodeValue, 'no_href' );
 				continue;
 			}
 
 			// Get the node value.
-			$src = $node->nodeValue;  // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$src = $href_node->nodeValue;
 
 			// If we dont have a valid URL, add as an error.
 			if ( ! is_string( $src ) || ! filter_var( $src, FILTER_VALIDATE_URL ) ) {
-				$this->add_error( $link_node, $index, 'n/a', 'malformed_url' );
+				$this->add_broken_link( $index, $src, $link_node->nodeValue, 'malformed_href' );
+				continue;
 			}
 
-			/** @var string $src */ // phpcs:ignore
-			$src = $src;
+			// Try to get the link details.
+			try {
+				$link_details = $this->get_link_details( $src );
 
-			$response = wp_remote_get( $src );
-			// If response is a WP_Error, add as an error.
-			if ( is_wp_error( $response ) ) {
-				$this->add_error( $link_node, $index, $src, 'invalid_url' );
-			}
+				// If we have any 30* status code, treat as a redirect
+				if ( 300 <= $link_details['http_code'] && 400 > $link_details['http_code'] ) {
+					$redirect_details = $this->get_link_details( $src, true );
+					$this->add_redirection_link(
+						$index,
+						$src,
+						$link_node->nodeValue,
+						$redirect_details['redirects'],
+						$link_details['http_code'],
+						$redirect_details['http_code']
+					);
+					continue;
+				}
 
-			// Check we have a valid 200 response.
-			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				$this->add_error( $link_node, $index, $src, 'non_200' );
+				// If we have a valid link 20* status code, add as a link.
+				if ( 200 <= $link_details['http_code'] && 300 > $link_details['http_code'] ) {
+					$this->links[] = new Link(
+						$index,
+						$src,
+						$link_node->nodeValue,
+						false,
+						null,
+						null,
+						array(),
+						false,
+						array( 'valid_link', "status_code: {$link_details['http_code']}" )
+					);
+					continue;
+				}
+
+				// Assume we have a 400 or 500 error.
+				$this->add_broken_link(
+					$index,
+					$src,
+					$link_node->nodeValue,
+					"status_code: {$link_details['http_code']}"
+				);
+				continue;
+			} catch ( \Throwable $th ) {
+				$this->add_broken_link(
+					$index,
+					$src,
+					$link_node->nodeValue,
+					"Error getting link details : {$th->getMessage()}"
+				);
 			}
 		}
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	/**
-	 * Checks if there are any errors.
+	 * Get link details.
+	 * Follows a url, collects data on its status and will follow any redirects if requested.
+	 *
+	 * @param string  $url              The URL of the link.
+	 * @param boolean $follow_redirects Whether to follow redirects or not.
+	 *
+	 * @return array<string, string> An array of data about the link.
+	 */
+	private function get_link_details( string $url, bool $follow_redirects = false ): array {
+		// phpcs:disable
+		$ch = curl_init( $url );
+		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, $follow_redirects );
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+		curl_setopt( $ch, CURLOPT_TIMEOUT_MS, Settings::get_link_checker_timeout() );
+		curl_setopt( $ch, CURLOPT_HEADER, true );
+		curl_setopt( $ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (X11; Linux x86_64; rv:21.0) Gecko/20100101 Firefox/21.0' ); // Necessary. The server checks for a valid User-Agent.
+		curl_exec( $ch );
+
+		// If we get a timeout throw exception.
+		if ( curl_errno( $ch ) ) {
+			curl_close( $ch );
+			throw new \Exception( curl_error( $ch ) );
+		}
+
+		$redirect_url = curl_getinfo( $ch, CURLINFO_REDIRECT_URL );
+		$http_code    = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		$response     = curl_exec( $ch );
+		preg_match_all( '/^Location:(.*)$/mi', $response, $matches );
+		curl_close( $ch );
+
+		// Collect the statuses
+		return array(
+			'url'          => $url,
+			'redirects'    => $matches[1] ?? array(),
+			'http_code'    => $http_code,
+			'redirect_url' => $redirect_url,
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Checks if there are any links.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return boolean
 	 */
-	public function has_errors() {
-		return ! empty( $this->errors );
+	public function has_links() {
+		return ! empty( $this->links );
 	}
 
 	/**
-	 * Get all errors.
+	 * Get all links.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array<int, array{element: DOMNode, index: int}>
+	 * @return Link[]
 	 */
-	public function get_errors() {
-		return $this->errors;
+	public function get_links() {
+		return $this->links;
 	}
 
 	/**

--- a/src/Report/Link.php
+++ b/src/Report/Link.php
@@ -15,13 +15,22 @@ namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Report;
 class Link {
 
 	/**
+	 * The index/position of the link in the content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var integer
+	 */
+	private int $index;
+
+	/**
 	 * The existing link href
 	 *
 	 * @since 1.0.0
 	 *
 	 * @var string
 	 */
-	private string $href;
+	private ?string $href;
 
 	/**
 	 * The links contents.
@@ -30,7 +39,7 @@ class Link {
 	 *
 	 * @var string
 	 */
-	private string $contents;
+	private ?string $contents;
 
 	/**
 	 * Is the link broken.
@@ -78,27 +87,41 @@ class Link {
 	private bool $fixed = false;
 
 	/**
+	 * Comments on the link
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string[]
+	 */
+	private array $comments = array();
+
+	/**
 	 * Create instance of Report_Logs_Link.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string             $href                The link href.
-	 * @param string             $contents            The link contents.
+	 * @param integer            $index               The index/position of the link in the content.
+	 * @param string|null        $href                The link href.
+	 * @param string|null        $contents            The link contents.
 	 * @param boolean            $broken              Is the link broken.
 	 * @param string|null        $redirect_target     The link redirection target.
 	 * @param integer|null       $redirect_type       The link redirection type.
 	 * @param array<int, string> $replacement_options The link replacement options.
 	 * @param boolean            $fixed               Was the link fixed.
+	 * @param string[]           $comments            Comments on the link.
 	 */
 	public function __construct(
-		string $href,
-		string $contents,
+		int $index,
+		?string $href,
+		?string $contents,
 		bool $broken = false,
 		?string $redirect_target = null,
 		?int $redirect_type = null,
 		array $replacement_options = array(),
-		bool $fixed = false
+		bool $fixed = false,
+		array $comments = array()
 	) {
+		$this->index               = $index;
 		$this->href                = $href;
 		$this->contents            = $contents;
 		$this->broken              = $broken;
@@ -106,6 +129,18 @@ class Link {
 		$this->redirect_type       = $redirect_type;
 		$this->replacement_options = $replacement_options;
 		$this->fixed               = $fixed;
+		$this->comments            = $comments;
+	}
+
+	/**
+	 * Get the index/position of the link in the content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return integer
+	 */
+	public function get_index(): int {
+		return $this->index;
 	}
 
 	/**
@@ -113,9 +148,9 @@ class Link {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function get_href(): string {
+	public function get_href(): ?string {
 		return $this->href;
 	}
 
@@ -124,9 +159,9 @@ class Link {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	public function get_contents(): string {
+	public function get_contents(): ?string {
 		return $this->contents;
 	}
 
@@ -183,5 +218,16 @@ class Link {
 	 */
 	public function is_fixed(): bool {
 		return $this->fixed;
+	}
+
+	/**
+	 * Get the comments on the link.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string[]
+	 */
+	public function get_comments(): array {
+		return $this->comments;
 	}
 }

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -25,6 +25,7 @@ class Settings {
 	public const POST_TYPES_OPTION_KEY        = self::SETTINGS_PREFIX . 'post_types';
 	public const DROP_TABLES_ON_UNINSTALL_KEY = self::SETTINGS_PREFIX . 'drop_tables_uninstall';
 	public const MIGRATIONS_KEY               = self::SETTINGS_PREFIX . 'migration_log';
+	public const LINK_CHECKER_TIMEOUT         = self::SETTINGS_PREFIX . 'link_checker_timeout';
 
 	## Table names.
 	public const SCAN_LOG_TABLE_NAME    = self::SETTINGS_PREFIX . 'scan_log';
@@ -76,5 +77,16 @@ class Settings {
 	 */
 	public static function update_migrations( array $migrations ): void {
 		update_option( self::MIGRATIONS_KEY, $migrations );
+	}
+
+	/**
+	 * Get the link checker timeout in MS
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return integer
+	 */
+	public static function get_link_checker_timeout(): int {
+		return absint( get_option( self::LINK_CHECKER_TIMEOUT, 1000 ) );
 	}
 }

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -135,6 +135,22 @@ class Settings_Page {
 				),
 			)
 		);
+
+		\register_setting(
+			self::PAGE_SLUG,
+			Settings::LINK_CHECKER_TIMEOUT,
+			array(
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'default'           => 1000,
+				'show_in_rest'      => array(
+					'name'   => Settings::LINK_CHECKER_TIMEOUT,
+					'schema' => array(
+						'type' => 'integer',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -164,6 +180,14 @@ class Settings_Page {
 			Settings::DROP_TABLES_ON_UNINSTALL_KEY,
 			__( 'Drop Tables on Uninstall', 'wpcomsp_wayback_link_fixer' ),
 			array( $this, 'render_drop_tables_on_uninstall_field' ),
+			self::PAGE_SLUG,
+			self::SETTINGS_SECTION
+		);
+
+		\add_settings_field(
+			Settings::LINK_CHECKER_TIMEOUT,
+			__( 'Link Checker Timeout in MS', 'wpcomsp_wayback_link_fixer' ),
+			array( $this, 'render_link_checker_timeout_field' ),
 			self::PAGE_SLUG,
 			self::SETTINGS_SECTION
 		);
@@ -213,6 +237,26 @@ class Settings_Page {
 			/>
 			<?php esc_html_e( 'Drop tables on uninstall', 'wpcomsp_wayback_link_fixer' ); ?>
 		</label>
+		<?php
+	}
+
+	/**
+	 * Render the link checker timeout field.
+	 *
+	 * @since   1.0.0
+	 *-+
+	 * @return  void
+	 */
+	public function render_link_checker_timeout_field(): void {
+		?>
+		<input
+			type="number"
+			id="<?php echo esc_attr( Settings::LINK_CHECKER_TIMEOUT ); ?>"
+			name="<?php echo esc_attr( Settings::LINK_CHECKER_TIMEOUT ); ?>"
+			value="<?php echo absint( Settings::get_link_checker_timeout() ); ?>"
+			min="0"
+			max="5000"
+		/>
 		<?php
 	}
 }


### PR DESCRIPTION
…custom timeout setting

#### Changes proposed in this Pull Request

* Changes how links are analyzed, makes use of core curl, to give more granular control and details collected.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When analyzing this #
```html
<a href="https://weareaptn.gq/eventfffff">404 </a>
<a href="https://bitly.ws/ZDwh">dd</a>
<a href="https://evertpot.com/curl-redirect-requestbody/">Google</a> 
<a>Foo</a>
```
results in the following 
![image](https://github.com/a8cteam51/wayback-link-fixer/assets/28779094/53df8693-da83-4f41-81a4-ebdfe75e2109)


Mentions #
