### PR TITLE
Fix/drop tables on uninstall

### DIFF
--- a/migrations/Migration_1.php
+++ b/migrations/Migration_1.php
@@ -89,11 +89,15 @@ class Migration_1 extends Abstract_Migration {
 
 		// Drop the log table.
 
-		$log_table_name = $wpdb->prefix . Settings::SCAN_LOG_TABLE_NAME;
+		$log_table_name = Settings::SCAN_LOG_TABLE_NAME;
 		$wpdb->query( "DROP TABLE IF EXISTS $log_table_name" ); //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, cant due to table name.
 
 		// Drop the report table.
-		$report_table_name = $wpdb->prefix . Settings::SCAN_REPORT_TABLE_NAME;
+		$report_table_name = Settings::SCAN_REPORT_TABLE_NAME;
 		$wpdb->query( "DROP TABLE IF EXISTS $report_table_name" ); //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, cant due to table name.
+
+		// Drop the link cache table.
+		$link_cache_table_name = Settings::SCAN_LINK_CACHE_TABLE;
+		$wpdb->query( "DROP TABLE IF EXISTS $link_cache_table_name" ); //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, cant due to table name.
 	}
 }

--- a/src/Migration/Migrations.php
+++ b/src/Migration/Migrations.php
@@ -61,7 +61,6 @@ class Migrations {
 	 * @return void
 	 */
 	public static function down(): void {
-
 		// If we are not dropping tables on deactivation, do nothing.
 		if ( ! Settings::drop_tables_on_uninstall() ) {
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure that tables are dropped and the migration option is removed on uninstall. This was currently set to add the prefix to table names. This was removed for multisite support.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
