### PR TITLE
Added in event that will scan all posts that have not been scanned

### DIFF
--- a/src/Event/Archive_Link_Event.php
+++ b/src/Event/Archive_Link_Event.php
@@ -61,7 +61,7 @@ class Archive_Link_Event {
 	 * @return void
 	 */
 	public static function add_to_queue( int $link_id ): void {
-		as_enqueue_async_action( self::HANDLE, array( 'link_id' => $link_id ) );
+		as_enqueue_async_action( self::HANDLE, array( 'link_id' => $link_id ), 'wayback-link-fixer' );
 	}
 
 	/**

--- a/src/Event/Event_Controller.php
+++ b/src/Event/Event_Controller.php
@@ -25,5 +25,14 @@ class Event_Controller {
 	public function initialize(): void {
 		add_action( Archive_Link_Event::HANDLE, new Archive_Link_Event(), 10, 1 );
 		add_action( Update_Archive_URL_Event::HANDLE, new Update_Archive_URL_Event(), 10, 2 );
+		add_action( Scan_Posts_Event::HANDLE, new Scan_Posts_Event(), 10, 1 );
+
+		// Ensure the post scan event is added to the action scheduler.
+		add_action(
+			'init',
+			function () {
+				Scan_Posts_Event::add_to_action_scheduler();
+			}
+		);
 	}
 }

--- a/src/Event/Scan_Posts_Event.php
+++ b/src/Event/Scan_Posts_Event.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Action shceduler event for scanning posts for links.
+ *
+ * This will ensure that any old or imported posts are scanned for links.
+ *
+ * @since 1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Event;
+
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Processor\Post_Handler;
+
+/**
+ * Scan Posts Event class.
+ */
+class Scan_Posts_Event {
+
+	/**
+	 * The event handle.
+	 */
+	public const HANDLE = 'wpcomsp_wayback_link_fixer_scan_posts';
+
+	/**
+	 * Number of posts to process per call.
+	 *
+	 * @var integer
+	 */
+	private $posts_per_call = 10;
+
+	/**
+	 * Allowed post types.
+	 *
+	 * @var array
+	 */
+	private $allowed_post_types = array();
+
+	/**
+	 * The post handler.
+	 *
+	 * @var Post_Handler
+	 */
+	private $post_handler;
+
+
+	/**
+	 * Lazy setup of class
+	 * This is run at call time, to reduce load on every page load.
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+		$this->posts_per_call     = Settings::get_posts_per_batch();
+		$this->allowed_post_types = Settings::get_post_types();
+		$this->post_handler       = new Post_Handler();
+	}
+
+	/**
+	 * Add to action scheduler.
+	 *
+	 * @return void
+	 */
+	public static function add_to_action_scheduler(): void {
+		// Check if enabled in settings.
+		$allow = true;
+
+		if ( ! $allow ) {
+			return;
+		}
+
+		// If the event is not scheduled, schedule it.
+		if ( \as_has_scheduled_action( self::HANDLE ) ) {
+			return;
+		}
+
+		\as_enqueue_async_action( self::HANDLE, array(), 'wayback-link-fixer' );
+	}
+
+	/**
+	 * The invocation of the event.
+	 *
+	 * @return void
+	 */
+	public function __invoke(): void {
+		// Setup the class.
+		$this->setup();
+
+		// Look for more posts, which do not have the meta data.
+		$query = new \WP_Query(
+			array(
+				'post_type'      => $this->allowed_post_types,
+				'posts_per_page' => $this->posts_per_call,
+				'meta_query'     => array(
+					array(
+						'key'     => Settings::LINK_META_KEY,
+						'compare' => 'NOT EXISTS',
+					),
+				),
+			)
+		);
+
+		// If we have posts, process them.
+		if ( $query->have_posts() ) {
+			// Iterate over the posts.
+			foreach ( $query->posts as $post ) {
+				$this->post_handler->process_single_post( $post->ID );
+			}
+		}
+
+		// Add the event to the action scheduler again.
+		self::add_to_action_scheduler();
+	}
+}

--- a/src/Event/Update_Archive_URL_Event.php
+++ b/src/Event/Update_Archive_URL_Event.php
@@ -82,8 +82,8 @@ class Update_Archive_URL_Event {
 			array(
 				'link_id' => $link_id,
 				'attempt' => $attempt,
-				'why'     => 'Update Archive URL',
-			)
+			),
+			'wayback-link-fixer'
 		);
 	}
 

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -148,7 +148,7 @@ class Link implements \JsonSerializable {
 	 * @return boolean
 	 */
 	public function has_archived_href(): bool {
-		return null !== $this->archived_href;
+		return null !== $this->archived_href && '' !== $this->archived_href;
 	}
 
 	/**

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -455,8 +455,6 @@ class Link_Repository {
 			$this->wpdb->prepare( $query, Settings::LINK_META_KEY ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, wpdb called as $this->wpdb
 		);
 
-		dump($this->wpdb->prepare( $query, Settings::LINK_META_KEY ));
-
 		$return = array();
 
 		// If no rows, return an empty collection.

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -455,6 +455,8 @@ class Link_Repository {
 			$this->wpdb->prepare( $query, Settings::LINK_META_KEY ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, wpdb called as $this->wpdb
 		);
 
+		dump($this->wpdb->prepare( $query, Settings::LINK_META_KEY ));
+
 		$return = array();
 
 		// If no rows, return an empty collection.

--- a/src/Processor/Post_Handler.php
+++ b/src/Processor/Post_Handler.php
@@ -72,6 +72,17 @@ class Post_Handler {
 			return;
 		}
 
+		$this->process_single_post( $post_id );
+	}
+
+	/**
+	 * Process a single post.
+	 *
+	 * @param integer $post_id The post id.
+	 *
+	 * @return void
+	 */
+	public function process_single_post( int $post_id ): void {
 		// Create an instance of the processor.
 		$post_processor = new Post_Processor( $post_id );
 		$links          = $post_processor->process();
@@ -82,6 +93,7 @@ class Post_Handler {
 		// Update the link meta.
 		$this->update_link_meta( $post_id, $links );
 	}
+
 
 	/**
 	 * Remove any excluded links from the links array.

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -35,7 +35,16 @@
 			<?php foreach ( $wlf_posts as $wlf_post ) : ?>
 				<li>
 					<a href="<?php echo esc_url( get_edit_post_link( $wlf_post->ID ) ); ?>">
-						<?php echo esc_html( $wlf_post->post_title ); ?>
+						<?php if ( '' === $wlf_post->post_title ) : ?>
+							<?php echo sprintf(
+								// Translators: %1$d is the post ID, %2$s is the post type.
+								'No title [#%1$d - %2$s]',
+								absint($wlf_post->ID),
+								esc_html($wlf_post->post_type)
+							); ?>
+						<?php else : ?>
+							<?php echo esc_html( $wlf_post->post_title ); ?>
+						<?php endif; ?>
 					</a>
 				</li>
 			<?php endforeach; ?>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -36,12 +36,14 @@
 				<li>
 					<a href="<?php echo esc_url( get_edit_post_link( $wlf_post->ID ) ); ?>">
 						<?php if ( '' === $wlf_post->post_title ) : ?>
-							<?php echo sprintf(
+							<?php
+							printf(
 								// Translators: %1$d is the post ID, %2$s is the post type.
 								'No title [#%1$d - %2$s]',
-								absint($wlf_post->ID),
-								esc_html($wlf_post->post_type)
-							); ?>
+								absint( $wlf_post->ID ),
+								esc_html( $wlf_post->post_type )
+							);
+							?>
 						<?php else : ?>
 							<?php echo esc_html( $wlf_post->post_title ); ?>
 						<?php endif; ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added in AS event that will check a number of posts that have not been scanned already.
* This needs refining, as we have no way to turn this off and its done async to make it easier to test.
* Fixed an issue where an archivable link was showing as archived, now shows not archived.
* Fixed issue where posts with no title do not show (well any readable text) on a report page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Install on an existing site and see inside the action scheduler queue as should be a scan existing posts event.
![image](https://github.com/a8cteam51/wayback-link-fixer/assets/28779094/a91b5145-4db8-4142-a573-7411645754b1)


Mentions #
