### PR TITLE
Feature/load as sooner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,6 +331,7 @@ GitHub.sublime-settings
 
 # Built Visual Studio Code Extensions
 *.vsix
+.vscode
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "css.validate": false,
+"less.validate": false,
+"scss.validate": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "css.validate": false,
-"less.validate": false,
-"scss.validate": false
-}

--- a/src/Event/Scan_Posts_Event.php
+++ b/src/Event/Scan_Posts_Event.php
@@ -72,6 +72,11 @@ class Scan_Posts_Event {
 			return;
 		}
 
+		// Bail if action scheduler is not available.
+		if ( ! \function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+
 		// If the event is not scheduled, schedule it.
 		if ( \as_has_scheduled_action( self::HANDLE ) ) {
 			return;

--- a/wayback-link-fixer.php
+++ b/wayback-link-fixer.php
@@ -40,6 +40,9 @@ define( 'WPCOMSP_WAYBACK_LINK_FIXER_URL', plugin_dir_url( __FILE__ ) );
 $wpcomsp_wayback_link_fixer_requirements = validate_plugin_requirements( WPCOMSP_WAYBACK_LINK_FIXER_BASENAME );
 define( 'WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS', $wpcomsp_wayback_link_fixer_requirements );
 
+// Include the action scheduler integration.
+require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . 'lib/action-scheduler/action-scheduler.php';
+
 // Load plugin translations so they are available even for the error admin notices.
 add_action(
 	'init',
@@ -49,9 +52,6 @@ add_action(
 			false,
 			dirname( WPCOMSP_WAYBACK_LINK_FIXER_BASENAME ) . WPCOMSP_WAYBACK_LINK_FIXER_METADATA['DomainPath']
 		);
-
-		// Include the action scheduler integration.
-		require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . 'lib/action-scheduler/action-scheduler.php';
 	}
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure that Action Shedular is loaded before init is called, this helps with a issue i found where other plugins include AS earlier and are of a lower version.
* Adds a check on the scan posts event when we ensure that `as_has_scheduled_action` exists as we could have an older version running which predates this function.

These were added as i tested this on another site, which had an older version of AS installed and threw some interesting erorrs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
