### PR TITLE
Added new event which is used to either find an existing archive or c…

### DIFF
--- a/src/Event/Event_Controller.php
+++ b/src/Event/Event_Controller.php
@@ -27,13 +27,9 @@ class Event_Controller {
 		add_action( Update_Archive_URL_Event::HANDLE, new Update_Archive_URL_Event(), 10, 2 );
 		add_action( Scan_Posts_Event::HANDLE, new Scan_Posts_Event(), 10, 1 );
 		add_action( Check_Snapshot_Status_Event::HANDLE, new Check_Snapshot_Status_Event(), 10, 3 );
+		add_action( Find_Or_Create_Snapshot_Event::HANDLE, new Find_Or_Create_Snapshot_Event(), 10, 1 );
 
 		// Ensure the post scan event is added to the action scheduler.
-		add_action(
-			'init',
-			function () {
-				Scan_Posts_Event::add_to_action_scheduler();
-			}
-		);
+		add_action( 'init', array( Scan_Posts_Event::class, 'add_to_action_scheduler' ) );
 	}
 }

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Attempts to either find or create a snapshot for a given URL and date.
+ *
+ * @since 1.2.0
+ *
+ * @package Wayback_Machine
+ */
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Event;
+
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Wayback_Machine_Service;
+
+/**
+ * Find or Create Snapshot Event class.
+ */
+class Find_Or_Create_Snapshot_Event {
+
+	public const HANDLE = 'wlf_find_or_create_snapshot';
+
+	/**
+	 * The link repository.
+	 *
+	 * @var Link_Repository
+	 */
+	private $link_repository;
+
+	/**
+	 * The wayback machine service.
+	 *
+	 * @var Wayback_Machine_Service
+	 */
+	private $wayback_machine;
+
+	/**
+	 * Sets up the events dependencies, but delayed until its called.
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+		$this->link_repository = new Link_Repository();
+		$this->wayback_machine = new Wayback_Machine_Service();
+	}
+
+	/**
+	 * Adds the event to the queue.
+	 *
+	 * @param integer $link_id The link id.
+	 *
+	 * @return void
+	 */
+	public static function add_to_queue( int $link_id ): void {
+		\as_enqueue_async_action(
+			self::HANDLE,
+			array(
+				'link_id' => $link_id,
+			)
+		);
+	}
+
+	/**
+	 * Runs the event.
+	 *
+	 * @param integer $link_id The link id.
+	 *
+	 * @return void
+	 */
+	public function __invoke( int $link_id ): void {
+		$this->setup();
+
+		$link = $this->link_repository->find_by_id( $link_id );
+
+		// If we have no link, throw an error.
+		if ( null === $link ) {
+			throw new \Exception( esc_html( 'Link not found with id ' . $link_id ) ); //
+		}
+
+		// Get the links latest snapshot.
+		$snapshot = $this->wayback_machine->get_latest_snapshot( $link->get_href() );
+
+		// If we have no snapshot, create one.
+		if ( null === $snapshot ) {
+			Create_New_Snapshot_Event::add_to_queue( $link_id );
+			return;
+		}
+
+		$link->set_archived_href( $snapshot['url'] );
+		$this->link_repository->upsert( $link );
+	}
+}

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -12,7 +12,7 @@ namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Link;
 
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Processor\Post_Handler;
-use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Create_New_Snapshot_Event;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Find_Or_Create_Snapshot_Event;
 
 /**
  * Link Response class.
@@ -252,7 +252,7 @@ class Link_Repository {
 			$link = $this->upsert( new Link( $url ) );
 
 			// Trigger the event to get the archived link.
-			Create_New_Snapshot_Event::add_to_queue( $link->get_id() );
+			Find_Or_Create_Snapshot_Event::add_to_queue( $link->get_id() );
 		}
 
 		return $link;

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -14,6 +14,7 @@ return array(
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Check_Snapshot_Status_Event' => $baseDir . '/src/Event/Check_Snapshot_Status_Event.php',
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Create_New_Snapshot_Event' => $baseDir . '/src/Event/Create_New_Snapshot_Event.php',
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Event_Controller' => $baseDir . '/src/Event/Event_Controller.php',
+    'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Find_Or_Create_Snapshot_Event' => $baseDir . '/src/Event/Find_Or_Create_Snapshot_Event.php',
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Scan_Posts_Event' => $baseDir . '/src/Event/Scan_Posts_Event.php',
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Update_Archive_URL_Event' => $baseDir . '/src/Event/Update_Archive_URL_Event.php',
     'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Integrations' => $baseDir . '/src/Integrations.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -34,6 +34,7 @@ class ComposerStaticInit4306a6418d6b9eb38703d40c88c8d2a0
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Check_Snapshot_Status_Event' => __DIR__ . '/../..' . '/src/Event/Check_Snapshot_Status_Event.php',
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Create_New_Snapshot_Event' => __DIR__ . '/../..' . '/src/Event/Create_New_Snapshot_Event.php',
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Event_Controller' => __DIR__ . '/../..' . '/src/Event/Event_Controller.php',
+        'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Find_Or_Create_Snapshot_Event' => __DIR__ . '/../..' . '/src/Event/Find_Or_Create_Snapshot_Event.php',
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Scan_Posts_Event' => __DIR__ . '/../..' . '/src/Event/Scan_Posts_Event.php',
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Event\\Update_Archive_URL_Event' => __DIR__ . '/../..' . '/src/Event/Update_Archive_URL_Event.php',
         'WPCOMSpecialProjects\\Wayback_Link_Fixer\\Integrations' => __DIR__ . '/../..' . '/src/Integrations.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'a8cteam51/wayback-link-fixer',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => 'ad147a644ee7efc9fe6c68e777400b56978f6a9c',
+        'reference' => '1a5d474ab3af0ab48ea4ce380ba89ce4fed94246',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'a8cteam51/wayback-link-fixer' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => 'ad147a644ee7efc9fe6c68e777400b56978f6a9c',
+            'reference' => '1a5d474ab3af0ab48ea4ce380ba89ce4fed94246',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
…reate a new one. Thisreduces the load on sites with lots of posts

#### Changes proposed in this Pull Request

* Adds a new event which will first check if a link snapshot exsits, before creating a new one.
This was added due to the issues where we are getting rate-limited and exceding free creations per day. Attempting to reduce the load.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
