### PR TITLE
Handle null or empty string values for archive links in repo

### DIFF
--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -404,7 +404,7 @@ class Link_Repository {
 		// If we have archive statuses, add to the query.
 		if ( ! empty( $archive_status ) ) {
 			$query .= true === $where ? ' AND' : ' WHERE';
-			$query .= boolval( $archive_status[0] ) ? ' archived != ""' : ' archived = ""';
+			$query .= boolval( $archive_status[0] ) ? ' archived != "" or archived IS NOT NULL' : ' archived = "" OR archived IS NULL';
 			$where  = true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure that queries for links with or without archives, handles both empty strings and null

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
