### PR TITLE
Added in checks, now any archive.org snapshot will be skipped and not…

### DIFF
--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -80,9 +80,9 @@ class Find_Or_Create_Snapshot_Event {
 
 		// If the link is an archive.org link, add message and throw error.
 		if ( 0 === strpos( $link->get_href(), 'https://web.archive.org/web/' ) ) {
-			$link->set_message( esc_html( 'Link is already an archive.org link.' ) );
+			$link->set_message( esc_html( 'Already an Internet Archive Snapshot.' ) );
 			$this->link_repository->upsert( $link );
-			throw new \Exception( esc_html( 'Link is already an archive.org link.' ) );
+			throw new \Exception( esc_html( 'Already an Internet Archive Snapshot.' ) );
 		}
 
 		// Get the links latest snapshot.

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -78,6 +78,13 @@ class Find_Or_Create_Snapshot_Event {
 			throw new \Exception( esc_html( 'Link not found with id ' . $link_id ) ); //
 		}
 
+		// If the link is an archive.org link, add message and throw error.
+		if ( 0 === strpos( $link->get_href(), 'https://web.archive.org/web/' ) ) {
+			$link->set_message( esc_html( 'Link is already an archive.org link.' ) );
+			$this->link_repository->upsert( $link );
+			throw new \Exception( esc_html( 'Link is already an archive.org link.' ) );
+		}
+
 		// Get the links latest snapshot.
 		$snapshot = $this->wayback_machine->get_latest_snapshot( $link->get_href() );
 

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Testthe Find or Create Snapshot Event
+ *
+ * @since 1.2.0
+ *
+ * @coversDefaultClass \WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Find_Or_Create_Snapshot_Event
+ */
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Tests\Event;
+
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Find_Or_Create_Snapshot_Event;
+
+/**
+ * Test_Find_Or_Create_Snapshot
+ */
+class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
+
+	private $wpdb;
+
+	/**
+	 * Setup
+	 */
+	public function set_up(): void {
+		$this->wpdb = $GLOBALS['wpdb'];
+
+		// Clear the actionscheduler_actions table.
+		$this->wpdb->query( "TRUNCATE TABLE {$this->wpdb->prefix}actionscheduler_actions" );
+
+		parent::set_up();
+	}
+
+	/**
+	 * @testdox When a link is added to the queue and its url is already an archive.org url, it should not be added to the queue and a message added to the link object.
+	 *
+	 * @return void
+	 */
+	public function test_archive_org_links_are_not_added_to_queue(): void {
+		$link = new Link(
+			'https://web.archive.org/web/20210101000000/https://example.com',
+		);
+
+		// Add the link to the database.
+		$repo = new Link_Repository();
+		$link = $repo->upsert( $link );
+
+		// Create the event.
+		$event = new Find_Or_Create_Snapshot_Event();
+
+		$event->setup();
+
+		try {
+			$event( $link->get_id() );
+		} catch ( \Exception $e ) {
+			$this->assertEquals( 'Link is already an archive.org link.', $e->getMessage() );
+		}
+
+		// Get the link from the repository.
+		$link = $repo->find_by_id( $link->get_id() );
+
+		// The link should have a message.
+		$this->assertEquals( 'Link is already an archive.org link.', $link->get_message() );
+	}
+
+	/**
+	 * @testdox When a link is found on wayback machine, it should have its snapshot url added and not added to the queue to create.
+	 *
+	 * @return void
+	 */
+	public function test_link_is_found_on_wayback_machine(): void {
+
+		// Create mock snapshot client.
+		$client = $this->createMock( \WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
+		$client->method( 'get_latest_snapshot' )
+			->willReturn( array( 'url' => 'https://web.archive.org/web/wlf_glynn/https://example.com' ) );
+
+		// Set the mock client
+		add_filter(
+			'wlf_snapshot_client',
+			function () use ( $client ) {
+				return $client;
+			}
+		);
+
+		// Create a link.
+		$link = new Link( 'https://example.com' );
+
+		// Add the link to the database.
+		$repo = new Link_Repository();
+		$link = $repo->upsert( $link );
+
+		// Create the event.
+		$event = new Find_Or_Create_Snapshot_Event();
+		$event->setup();
+		$event( $link->get_id() );
+
+		// Get the link from the repository.
+		$link = $repo->find_by_id( $link->get_id() );
+
+		$this->assertEquals( 'https://web.archive.org/web/wlf_glynn/https://example.com', $link->get_archived_href() );
+
+		// Remove the filter.
+		remove_all_filters( 'wlf_snapshot_client' );
+	}
+
+	/**
+	 * @testdox When a link is not found on wayback machine, it should be added to the queue to create a snapshot.
+	 *
+	 * @return void
+	 */
+	public function test_link_is_not_found_on_wayback_machine(): void {
+
+		// Create mock snapshot client.
+		$client = $this->createMock( \WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
+		$client->method( 'get_latest_snapshot' )
+			->willReturn( null );
+
+		// Set the mock client
+		add_filter(
+			'wlf_snapshot_client',
+			function () use ( $client ) {
+				return $client;
+			}
+		);
+
+		// Create a link.
+		$link = new Link( 'https://example.com' );
+
+		// Add the link to the database.
+		$repo = new Link_Repository();
+		$link = $repo->upsert( $link );
+
+		// Create the event.
+		$event = new Find_Or_Create_Snapshot_Event();
+		$event->setup();
+		$event( $link->get_id() );
+
+		// Get the link from the repository.
+		$link = $repo->find_by_id( $link->get_id() );
+
+		// Check if event added to actionscheduler_actions  table.
+		global $wpdb;
+
+		// Look for a row with hook of wlf_create_new_snapshot and a args that contains the "link_id":$id key.
+		$results = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = 'wlf_create_new_snapshot' AND args LIKE '%\"link_id\":{$link->get_id()}%'" );
+
+		$this->assertCount( 1, $results );
+
+		// Remove the filter.
+		remove_all_filters( 'wlf_snapshot_client' );
+	}
+}

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -57,14 +57,14 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		try {
 			$event( $link->get_id() );
 		} catch ( \Exception $e ) {
-			$this->assertEquals( 'Link is already an archive.org link.', $e->getMessage() );
+			$this->assertEquals( 'Already an Internet Archive Snapshot.', $e->getMessage() );
 		}
 
 		// Get the link from the repository.
 		$link = $repo->find_by_id( $link->get_id() );
 
 		// The link should have a message.
-		$this->assertEquals( 'Link is already an archive.org link.', $link->get_message() );
+		$this->assertEquals( 'Already an Internet Archive Snapshot.', $link->get_message() );
 	}
 
 	/**

--- a/tests/Processor/Test_Post_Processor.php
+++ b/tests/Processor/Test_Post_Processor.php
@@ -91,4 +91,30 @@ class Test_Post_Processor extends \WP_UnitTestCase {
 		$this->assertEquals( 'http://from.post/content', $links[0]->get_href() );
 		$this->assertEquals( 'https://from.post/content_twice', $links[1]->get_href() );
 	}
+
+	/**
+	 * @testdox Any links which are already from the wayback machine should be ignored with a message added.
+	 *
+	 * @return void
+	 */
+	public function test_links_from_wayback_machine_are_ignored(): void {
+		// Create a post with some links.
+		$post_id = \WP_UnitTestCase_Base::factory()->post->create();
+
+		// Add some content to the post.
+		$content = 'This is a post with a link to <a href="https://web.archive.org/web/20190101000000/https://from.post/content">example</a>';
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+			)
+		);
+
+		$processor = new Post_Processor( $post_id );
+		$links     = $processor->process();
+
+		// Only the http and https links should be added.
+		$this->assertCount( 1, $links );
+	}
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'a8cteam51/wayback-link-fixer',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '5c26bc04a3bde4f9685176fc5635a5a930478153',
+        'reference' => '18936faa20636b224b27451bdc3a61e6920d6e07',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'a8cteam51/wayback-link-fixer' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '5c26bc04a3bde4f9685176fc5635a5a930478153',
+            'reference' => '18936faa20636b224b27451bdc3a61e6920d6e07',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'a8cteam51/wayback-link-fixer',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '18936faa20636b224b27451bdc3a61e6920d6e07',
+        'reference' => 'e7c1715106306a7b2ce3f8834a7633c75832b53b',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'a8cteam51/wayback-link-fixer' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '18936faa20636b224b27451bdc3a61e6920d6e07',
+            'reference' => 'e7c1715106306a7b2ce3f8834a7633c75832b53b',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
… attmpted to be found or created and will have a message added. There have been tests added for this

#### Changes proposed in this Pull Request

* Adds in a check on the find or create event, which checks if we already have an internet archive url and skips finding or creating, only leaving an error message.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a post with a link to a snapshot and it should be skipped
![image](https://github.com/user-attachments/assets/4d28a955-3ee0-488f-8451-471c7a415902)
* It should fail in the action scheduler with a message to denote its already a snapshot
![image](https://github.com/user-attachments/assets/b3b413d4-7501-4eca-8ba8-37e6d0aed42d)
* You should also see the same message on the link details
![image](https://github.com/user-attachments/assets/1bac9939-be55-4443-9112-275fea10cac3)


Mentions #78 
