### PR TITLE
Move to correct settings method to remove direct apply_filter() call

### DIFF
--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -182,7 +182,7 @@ class WP_Post_Controller {
 				'links'           => wp_json_encode( $links ),
 				'linkCheckAjax'   => Link_Check_Ajax::ACTION,
 				'linkCheckNonce'  => wp_create_nonce( Link_Check_Ajax::ACTION ),
-				'linkDelayInDays' => \apply_filters( 'wlf_link_check_delay_in_days', 7 ),
+				'linkDelayInDays' => Settings::get_link_check_duration(),
 				'fixerOption'     => Settings::get_fixer_option(),
 				'ajaxUrl'         => \admin_url( 'admin-ajax.php' ),
 

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'a8cteam51/wayback-link-fixer',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => 'aa5947d136e6f06b847eb836a59d416d853e14b9',
+        'reference' => 'ee923eff9d6dde9abdf87316735caf865eaf36e4',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'a8cteam51/wayback-link-fixer' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => 'aa5947d136e6f06b847eb836a59d416d853e14b9',
+            'reference' => 'ee923eff9d6dde9abdf87316735caf865eaf36e4',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes use of `Settings::get_link_check_duration(),` in localized data.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #87 
