### PR TITLE
No longer passes large lists of link ids to the url, we only use the …

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -252,4 +252,27 @@ function wpcomsp_wayback_link_fixer_render_not_authenticated_notice(): void {
 	<?php
 }
 
+/**
+ * Checks if a link is already an internet archive link.
+ *
+ * @since 1.3.0
+ *
+ * @param string $url The URL to check.
+ *
+ * @return boolean
+ */
+function wpcomsp_wayback_link_fixer_is_archive_link( string $url ): bool {
+	$urls = array(
+		'https://web.archive.org/web/',
+		'http://web.archive.org/web/',
+	);
+
+	foreach ( $urls as $archive_url ) {
+		if ( 0 === strpos( $url, $archive_url ) ) {
+			return true;
+		}
+	}
+		return false;
+}
+
 // endregion

--- a/src/Action/Link_Check_Action.php
+++ b/src/Action/Link_Check_Action.php
@@ -60,6 +60,15 @@ class Link_Check_Action {
 			);
 		}
 
+		// If the link is an internet archive link, we don't need to check it.
+		if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
+			return array(
+				'link'    => $link,
+				'checked' => false,
+				'valid'   => $link->is_valid(),
+			);
+		}
+
 		// Get the current status.
 		try {
 			$status = $this->link_checker->check_single( $link->get_href() );

--- a/src/Action/Link_Latest_Snapshot_Action.php
+++ b/src/Action/Link_Latest_Snapshot_Action.php
@@ -63,6 +63,15 @@ class Link_Latest_Snapshot_Action {
 				'message' => __( 'Link not found.', 'wpcomsp_wayback_link_fixer' ),
 			);
 		}
+		// If the lik is an internet archive link, we don't need to check it.
+		if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
+			return array(
+				'link'    => $link,
+				'found'   => true,
+				'updated' => false,
+				'message' => __( 'Link is already an archived link.', 'wpcomsp_wayback_link_fixer' ),
+			);
+		}
 
 		$archive_url = $this->wayback_machine->find_archive( $link->get_href() );
 

--- a/src/Action/Link_New_Snapshot_Action.php
+++ b/src/Action/Link_New_Snapshot_Action.php
@@ -65,6 +65,15 @@ class Link_New_Snapshot_Action {
 			);
 		}
 
+		// If we have an internet archive link, we don't need to check it.
+		if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
+			return array(
+				'link'    => $link,
+				'job_id'  => null,
+				'message' => __( 'Link is an archive link already', 'wpcomsp_wayback_link_fixer' ),
+			);
+		}
+
 		// Attempt to create a new snapshot.
 		try {
 			$job_id = $this->wayback_machine->create_snapshot( $link->get_href() );

--- a/src/Ajax/Link_Check_Ajax.php
+++ b/src/Ajax/Link_Check_Ajax.php
@@ -121,6 +121,11 @@ class Link_Check_Ajax {
 			return true;
 		}
 
+		// If the link is an archive link, return false.
+		if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
+			return false;
+		}
+
 		// Check if the last check was more than the duration ago.
 		$duration   = Settings::get_link_check_duration();
 		$last_check = new \DateTime( $last_check['date'] );

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -79,7 +79,7 @@ class Find_Or_Create_Snapshot_Event {
 		}
 
 		// If the link is an archive.org link, add message and throw error.
-		if ( $this->is_archive_url( $link->get_href() ) ) {
+		if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
 			$link->set_message( esc_html( 'Already an Internet Archive Snapshot.' ) );
 			$this->link_repository->upsert( $link );
 			throw new \Exception( esc_html( 'Already an Internet Archive Snapshot.' ) );
@@ -96,26 +96,5 @@ class Find_Or_Create_Snapshot_Event {
 
 		$link->set_archived_href( $snapshot['url'] );
 		$this->link_repository->upsert( $link );
-	}
-
-	/**
-	 * Checks if a given url is an archive.org url.
-	 *
-	 * @param string $url The url to check.
-	 *
-	 * @return boolean
-	 */
-	public function is_archive_url( string $url ): bool {
-		$urls = array(
-			'https://web.archive.org/web/',
-			'http://web.archive.org/web/',
-		);
-
-		foreach ( $urls as $archive_url ) {
-			if ( 0 === strpos( $url, $archive_url ) ) {
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -16,7 +16,6 @@ use WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Report_Page;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_Check_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_New_Snapshot_Action;
-use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Create_New_Snapshot_Event;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_Latest_Snapshot_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Util\List_Table_Action_Notification_Cache;
 
@@ -225,8 +224,17 @@ class Report_Table extends \WP_List_Table {
 
 		// Redirect to the same page with all actions removed.
 		$redirect = remove_query_arg( array( 'action', 'action2', 'wlf_link_action', 'wlf_links', '_wpnonce', '_wp_http_referer' ) );
+
 		$redirect = add_query_arg( 'wlf_notification', $cache_key, $redirect );
 		$redirect = add_query_arg( 'wlf_completed_action', esc_attr( $this->current_action() ), $redirect );
+
+		// Get the previous url params.
+		$params = $this->get_previous_url_params();
+
+		// If we have a post id, add it and its links to the redirect.
+		if ( array_key_exists( 'wlf_filtered_post_id', $params ) ) {
+			$redirect = add_query_arg( 'wlf_filtered_post_id', absint( $params['wlf_filtered_post_id'] ), $redirect );
+		}
 
 		// Add to the redirect the current page.
 		$url = \home_url() . $redirect;
@@ -234,6 +242,19 @@ class Report_Table extends \WP_List_Table {
 		// Redirect to the page using JS as page already loaded headers.
 		echo "<script>window.location = '$url';</script>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this is just a redirect.
 		exit;
+	}
+
+	/**
+	 * Get the previous url params, from the referrer.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_previous_url_params(): array {
+		$referrer = wp_get_referer();
+		$referrer = wp_parse_url( $referrer );
+		$query    = $referrer['query'] ?? '';
+		parse_str( $query, $params );
+		return $params;
 	}
 
 	/**
@@ -328,6 +349,19 @@ class Report_Table extends \WP_List_Table {
 						absint( $link_id )
 					),
 					'type'    => 'error',
+				);
+				continue;
+			}
+
+			// If an internet archived link, show the message.
+			if ( wpcomsp_wayback_link_fixer_is_archive_link( $result['link']->get_href() ) ) {
+				$this->notices[] = array(
+					'message' => sprintf(
+						// translators: %s is the link url.
+						__( 'Link %s is already an archived link.', 'wpcomsp_wayback_link_fixer' ),
+						esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
+					),
+					'type'    => 'notice',
 				);
 				continue;
 			}
@@ -531,9 +565,9 @@ class Report_Table extends \WP_List_Table {
 			?>
 		</select>
 
-		<?php foreach ( $this->get_link_ids_from_url() as $link_id ) : ?>
-			<input type="hidden" name="wlf_links[]" value="<?php echo esc_attr( $link_id ); ?>" />
-		<?php endforeach; ?>
+		<?php if ( array_key_exists( 'wlf_filtered_post_id', $_GET ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>
+			<input type="hidden" name="wlf_filtered_post_id" value="<?php echo esc_attr( $_GET['wlf_filtered_post_id'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>" />
+		<?php endif; ?>
 
 		<input type="submit" class="button" value="<?php esc_attr_e( 'Filter', 'wpcomsp_wayback_link_fixer' ); ?>"  />
 
@@ -650,16 +684,22 @@ class Report_Table extends \WP_List_Table {
 	 * @return int[]
 	 */
 	private function get_link_ids_from_url(): array {
-		return \array_key_exists( 'wlf_links', $_GET ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? array_map(
-				function ( $id ): int {
-					return absint( $id );
-				},
-				\is_array( $_GET['wlf_links'] )   // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-					? $_GET['wlf_links']          // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-					: array( $_GET['wlf_links'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			)
-			: array();
+
+		// If we have the post id in the url, return the links ids.
+		if ( ! \array_key_exists( 'wlf_filtered_post_id', $_GET ) ) { // phpcs:ignore
+			return array();
+		}
+
+		$post_id = absint( $_GET['wlf_filtered_post_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+
+		$links = $this->links->get_links_for_post( $post_id );
+
+		return array_map(
+			function ( $link ): int {
+				return absint( $link->get_id() );
+			},
+			$links->get_links()
+		);
 	}
 
 

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -214,9 +214,6 @@ class WP_Post_Table_Controller {
 		// Add the initial post id.
 		$url = \add_query_arg( 'wlf_filtered_post_id', $post_id, $url );
 
-		// Add the link ids as a query arg.
-		// $url = \add_query_arg( 'wlf_links', join( ',', $ids ), $url );
-
 		return $url;
 	}
 }

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -211,14 +211,11 @@ class WP_Post_Table_Controller {
 
 		$url = Report_Page::get_page_url();
 
-		// Iterate over the ids and add them to the url as a valid php array.
-		foreach ( $ids as $key => $id ) {
-			$key = 'wlf_links[' . absint( $key ) . ']';
-			$url = \add_query_arg( $key, $id, $url );
-		}
-
-		// Add the post id.
+		// Add the initial post id.
 		$url = \add_query_arg( 'wlf_filtered_post_id', $post_id, $url );
+
+		// Add the link ids as a query arg.
+		// $url = \add_query_arg( 'wlf_links', join( ',', $ids ), $url );
 
 		return $url;
 	}

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'a8cteam51/wayback-link-fixer',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => 'ee923eff9d6dde9abdf87316735caf865eaf36e4',
+        'reference' => '56e37a4dcf1bbee86a8739bbd0478d1cd5fe405e',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'a8cteam51/wayback-link-fixer' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => 'ee923eff9d6dde9abdf87316735caf865eaf36e4',
+            'reference' => '56e37a4dcf1bbee86a8739bbd0478d1cd5fe405e',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
…post id to accountr for collections. Includes other code to handle retaining the list of post ids initially loaded and also extends the code which prevents ia links being processed

#### Changes proposed in this Pull Request

* Removes the links ids from URLS to avoid, overly large urls.
* Remember the previous post id of the links being shown
* Adds in additional checks to avoid trying process links that are already IA archived urls

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #90 
