### PR TITLE
remove the offline message in header of settings pages.

### DIFF
--- a/src/Report/Report_Page.php
+++ b/src/Report/Report_Page.php
@@ -180,7 +180,6 @@ class Report_Page {
 
 		// Render any notices.
 		$table->render_notices();
-		wpcomsp_wayback_link_fixer_render_wayback_offline_notice();
 		wpcomsp_wayback_link_fixer_render_not_authenticated_notice();
 
 		echo '<div class="wrap">';

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -133,7 +133,6 @@ class Settings_Page {
 	 * @return  void
 	 */
 	public function render_page(): void {
-		wpcomsp_wayback_link_fixer_render_wayback_offline_notice();
 		wpcomsp_wayback_link_fixer_render_not_authenticated_notice();
 
 		echo '<div class="wrap"><h1>' . esc_html__( 'Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ) . '</h1><form action="options.php" method="post">';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides the offline notice on settings and link pages

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
