### PR TITLE
Develop

### DIFF
--- a/src/Report/Report_Page.php
+++ b/src/Report/Report_Page.php
@@ -180,7 +180,6 @@ class Report_Page {
 
 		// Render any notices.
 		$table->render_notices();
-		wpcomsp_wayback_link_fixer_render_wayback_offline_notice();
 		wpcomsp_wayback_link_fixer_render_not_authenticated_notice();
 
 		echo '<div class="wrap">';

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -133,7 +133,6 @@ class Settings_Page {
 	 * @return  void
 	 */
 	public function render_page(): void {
-		wpcomsp_wayback_link_fixer_render_wayback_offline_notice();
 		wpcomsp_wayback_link_fixer_render_not_authenticated_notice();
 
 		echo '<div class="wrap"><h1>' . esc_html__( 'Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ) . '</h1><form action="options.php" method="post">';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request includes some changes to the `Report_Page` and `Settings_Page` classes to remove the rendering of the wayback offline notice.

Changes to `Report_Page`:

* Removed the call to `wpcomsp_wayback_link_fixer_render_wayback_offline_notice` in the `render_list_page` method.

Changes to `Settings_Page`:

* Removed the call to `wpcomsp_wayback_link_fixer_render_wayback_offline_notice` in the `render_page` method.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
