### PR TITLE
Fix/rc1 tweaks 1

### DIFF
--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -283,17 +283,14 @@ class Setup_Wizard {
 			? array_map( fn( $type ) => sanitize_text_field( wp_unslash( $type ) ), $_POST['wlf_wizard_post_types'] )
 			: array();
 		$enable_routine_update = isset( $_POST['wlf_wizard_recurring_backup'] );
-		$routine_frequency     = isset( $_POST['wlf_wizard_backup_frequency'] ) ? absint( $_POST['wlf_wizard_backup_frequency'] ) : 7;
 
 		// Update all the settings.
 		update_option( Settings::ALLOW_OWN_CONTENT_SUBMISSIONS, $is_active );
 		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, $allowed_post_types );
 		update_option( Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE, $enable_routine_update );
-		update_option( Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL, $routine_frequency );
 
 		// Update the step.
-		$next = sanitize_text_field( wp_unslash( $_POST['wlf-next-step'] ) );
-		update_option( self::OPTION_NAME, $next );
+		update_option( self::OPTION_NAME, 'complete' );
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
@@ -362,20 +359,15 @@ class Setup_Wizard {
 	private function get_step_data(): array {
 		$state = get_option( self::OPTION_NAME, 'step-1' );
 
-		// Get the next step, if finished, return the finished template.
-		if ( 'finish' === $state ) {
-			return 'finish';
-		}
-
 		$index      = array_keys( self::STEPS );
 		$next_index = array_search( $state, $index, true ) + 1;
 
 		return array(
 			'template' => self::STEPS[ $state ],
 			'step'     => $state,
-			'next'     => $index[ $next_index ],
+			'next'     => array_key_exists( $next_index, $index ) ? $index[ $next_index ] : $state,
 			'progress' => array(
-				'current' => $next_index,
+				'current' => array_key_exists( $next_index, $index ) ? $next_index : array_key_last( $index ),
 				'total'   => count( $index ) - 1,
 			),
 		);

--- a/src/Event/Scan_Own_Posts_Event.php
+++ b/src/Event/Scan_Own_Posts_Event.php
@@ -94,7 +94,12 @@ class Scan_Own_Posts_Event {
 		// Run setup.
 		$this->setup();
 
-		$allowed_delay      = Settings::own_link_routine_update_interval();
+		$allowed_delay = Settings::own_link_routine_update_interval();
+		// Cast delay to seconds.
+		$allowed_delay = 0 === $allowed_delay
+			? 0
+			: $allowed_delay * DAY_IN_SECONDS;
+
 		$allowed_post_types = Settings::own_link_allowed_post_types();
 		$posts_per_call     = absint( apply_filters( 'wlf_scan_own_posts_per_call', 10 ) );
 

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -383,7 +383,7 @@ class Settings {
 		return absint(
 			apply_filters(
 				'wlf_routinely_update_wayback_machine_interval',
-				get_option( self::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL, 7 * \DAY_IN_SECONDS )
+				get_option( self::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL, 7 )
 			)
 		);
 	}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -373,17 +373,15 @@ class Settings {
 	/**
 	 * Gets the interval between updates.
 	 *
-	 * Time in seconds.
-	 *
 	 * @since 1.3.0
 	 *
-	 * @return integer
+	 * @return integer Time in days.
 	 */
 	public static function own_link_routine_update_interval(): int {
 		return absint(
 			apply_filters(
 				'wlf_routinely_update_wayback_machine_interval',
-				get_option( self::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL, 7 )
+				get_option( self::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL, 28 )
 			)
 		);
 	}

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -328,11 +328,8 @@ class Settings_Page {
 			Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL,
 			array(
 				'type'              => 'integer',
-				'sanitize_callback' => function ( $value ): int {
-					// Covert from days to seconds.
-					return absint( $value ) * DAY_IN_SECONDS;
-				},
-				'default'           => 7,
+				'sanitize_callback' => 'absint',
+				'default'           => 28,
 				'show_in_rest'      => array(
 					'name'   => Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL,
 					'schema' => array(
@@ -824,8 +821,6 @@ class Settings_Page {
 	 * @return void
 	 */
 	public function render_own_link_routinely_update(): void {
-		$interval = Settings::own_link_routine_update_interval();
-
 		?>
 		<label for="<?php echo esc_attr( Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE ); ?>">
 			<input
@@ -850,8 +845,6 @@ class Settings_Page {
 	 */
 	public function render_own_link_routinely_update_interval(): void {
 		$interval = Settings::own_link_routine_update_interval();
-		// Cast to days.
-		$interval = 0 === $interval ? 0 : $interval / DAY_IN_SECONDS;
 		?>
 		<input
 			type="number"

--- a/templates/admin/wizard/footer.php
+++ b/templates/admin/wizard/footer.php
@@ -45,7 +45,3 @@ $wlf_progress_pc = ( $step_data['progress']['current'] / $step_data['progress'][
 	</div>
 	</form> <!-- END Wizard form -->
 </div> <!-- END Wizard container -->
-
-<script>
-
-</script>

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -13,15 +13,6 @@
  */
 
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
-
-$wlf_interval = absint( Settings::own_link_routine_update_interval() );
-
-// If greater than 0, convert to days from seconds.
-if ( $wlf_interval > 0 ) {
-	$wlf_interval = $wlf_interval / DAY_IN_SECONDS;
-} else {
-	$wlf_interval = 28;
-}
 ?>
 
 <?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -66,15 +57,6 @@ if ( $wlf_interval > 0 ) {
 	<p class="description"><?php esc_html_e( 'If enabled, your posts will be routinely updated on the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 		<input type="checkbox" name="wlf_wizard_recurring_backup" value="1" <?php checked( Settings::is_link_processing_enabled() ); ?> />
 	</div>
-</div>
-
-<div class="wlf-wizard__content__field is_optional" >
-	<label for="wlf_wizard_backup_frequency">
-		<?php esc_html_e( 'Backup interval', 'wpcomsp_wayback_link_fixer' ); ?>
-	</label>
-	<p class="description"><?php esc_html_e( 'Please enter how many days between each routine archive of your posts.', 'wpcomsp_wayback_link_fixer' ); ?></p>
-	<input type="number" min="1" name="wlf_wizard_backup_frequency" value="<?php echo esc_attr( $wlf_interval ); ?>" />
-
 </div>
 
 <?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes various bugs found in 1.3-RC1
This pull request includes several changes to the `src` and `templates` directories, primarily focusing on the removal of the backup frequency setting and related updates. The most important changes are:

### Removal of Backup Frequency Setting:

* [`src/Dashboard/Setup_Wizard.php`](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5L286-R293): Removed the handling of `wlf_wizard_backup_frequency` and its associated update option. (`[src/Dashboard/Setup_Wizard.phpL286-R293](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5L286-R293)`)
* [`templates/admin/wizard/step-3.php`](diffhunk://#diff-ad7b1aabbf8c1b40eb4bb4b12771fb72b048cd3bc6a4bf82abd6703f29e18424L71-L79): Removed the input field for the backup interval from the wizard step 3 template. (`[templates/admin/wizard/step-3.phpL71-L79](diffhunk://#diff-ad7b1aabbf8c1b40eb4bb4b12771fb72b048cd3bc6a4bf82abd6703f29e18424L71-L79)`)

### Code Simplification:

* [`src/Settings/Settings.php`](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aL376-R384): Updated the `own_link_routine_update_interval` method to return the interval in days directly, removing the conversion from seconds. (`[src/Settings/Settings.phpL376-R384](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aL376-R384)`)
* [`src/Settings/Settings_Page.php`](diffhunk://#diff-8307ddb5c68d706658e6c432b2c27a8470093e6b015c1ac17dabb3e4c93c55acL331-R332): Simplified the registration of the settings field by removing the conversion logic from days to seconds. (`[src/Settings/Settings_Page.phpL331-R332](diffhunk://#diff-8307ddb5c68d706658e6c432b2c27a8470093e6b015c1ac17dabb3e4c93c55acL331-R332)`)

### Minor Cleanups:

* [`templates/admin/wizard/footer.php`](diffhunk://#diff-bcb5d640acce345641afd15db783d624491107e17bf40cd6aade2e087c4f8311L48-L51): Removed an empty script tag from the footer template. (`[templates/admin/wizard/footer.phpL48-L51](diffhunk://#diff-bcb5d640acce345641afd15db783d624491107e17bf40cd6aade2e087c4f8311L48-L51)`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
