### PR TITLE
Fixed textdomain mismatch and generated .pot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,7 @@
         "psr-4": {
             "WPCOMSpecialProjects\\Wayback_Link_Fixer\\": "src",
             "WPCOMSpecialProjects\\Wayback_Link_Fixer_Migration\\": "migrations"
-        },
-        "classmap": [
-            "models"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {
@@ -81,7 +78,7 @@
             "@updatepo",
             "@makejson"
         ],
-        "makepot": "wp i18n make-pot . --exclude=vendor,node_modules,pack,tests,lib,migrations,coverage,coverate-reports ",
+        "makepot": "wp i18n make-pot . --include=src,templates,assets --exclude=vendor,node_modules,pack,tests,lib,migrations,coverage,coverate-reports ",
         "updatepo": "wp i18n update-po ./languages/wayback-link-fixer.pot",
         "makejson": "wp i18n make-json ./languages --pretty-print --no-purge",
         "makemo": "wp i18n make-mo ./languages",

--- a/languages/wayback-link-fixer.pot
+++ b/languages/wayback-link-fixer.pot
@@ -1,28 +1,745 @@
-# Copyright (C) 2023 WordPress.com Special Projects
+# Copyright (C) 2025 WordPress.com Special Projects
 # This file is distributed under the GPL v3 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: wayback-link-fixer 1.0.0\n"
+"Project-Id-Version: Internet Archive Wayback Machine Link Fixer 1.3.0-RC2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wayback-link-fixer\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-10-19T11:35:41+00:00\n"
+"POT-Creation-Date: 2025-04-02T10:14:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.8.1\n"
-"X-Domain: wpcomsp-wayback-link-fixer\n"
+"X-Generator: WP-CLI 2.11.0\n"
+"X-Domain: wpcomsp_wayback_link_fixer\n"
 
 #. Plugin Name of the plugin
-msgid "wayback-link-fixer"
+#: wayback-link-fixer.php
+msgid "Internet Archive Wayback Machine Link Fixer"
 msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
+#: wayback-link-fixer.php
 msgid "https://wpspecialprojects.wordpress.com"
 msgstr ""
 
+#. Description of the plugin
+#: wayback-link-fixer.php
+msgid "This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility."
+msgstr ""
+
 #. Author of the plugin
+#: wayback-link-fixer.php
 msgid "WordPress.com Special Projects"
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:65
+msgid "Link not found."
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:75
+#: src/Action/Link_New_Snapshot_Action.php:76
+msgid "Service is offline."
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:85
+msgid "Link is already an archived link."
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:97
+msgid "No archive URL found."
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:107
+msgid "Archive URL is the same."
+msgstr ""
+
+#: src/Action/Link_Latest_Snapshot_Action.php:121
+msgid "Link updated."
+msgstr ""
+
+#: src/Action/Link_New_Snapshot_Action.php:67
+#: src/Action/Validate_Link_Action.php:76
+msgid "Link not found"
+msgstr ""
+
+#: src/Action/Link_New_Snapshot_Action.php:85
+#: src/Action/Validate_Link_Action.php:85
+msgid "Link is an archive link already"
+msgstr ""
+
+#: src/Action/Link_New_Snapshot_Action.php:98
+#: src/Action/Validate_Link_Action.php:98
+msgid "Exceeded snapshot limit"
+msgstr ""
+
+#: src/Action/Link_New_Snapshot_Action.php:115
+msgid "Snapshot created, Link will be processed soon"
+msgstr ""
+
+#: src/Action/Validate_Link_Action.php:68
+msgid "Service is offline"
+msgstr ""
+
+#: src/Action/Validate_Link_Action.php:115
+msgid "Validation request created, link will be updated ASAP"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:39
+#: src/Settings/Settings_Page.php:75
+msgid "Wayback Link Fixer"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:61
+msgid "You are using Link Fixer in unauthenticated mode, which restricts you to 200 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org."
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:71
+msgid "The status of the link fixer is currently pending, please check again shortly"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:81
+msgid "The link fixer service is currently offline, all checks and snapshot creation processes are paused."
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:88
+msgid "Link Checker"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:94
+msgid "Snapshot Service"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:100
+msgid "Last Checked"
+msgstr ""
+
+#: src/Dashboard/Dashboard_Notifications.php:101
+msgid "Never"
+msgstr ""
+
+#. translators: %s is the URL to the setup wizard.
+#: src/Dashboard/Setup_Wizard.php:73
+msgid "The Wayback Link Fixer plugin is almost ready. Please <a href=\"%s\">run the setup wizard</a> to complete the installation."
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:93
+#: src/Dashboard/Setup_Wizard.php:94
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:307
+msgid "Link Fixer Setup Wizard"
+msgstr ""
+
+#: src/Report/Report_Page.php:89
+#: src/Report/Report_Page.php:188
+msgid "Link Fixer :: Links"
+msgstr ""
+
+#: src/Report/Report_Page.php:90
+#: src/Settings/Settings_Page.php:382
+msgid "Link Fixer"
+msgstr ""
+
+#: src/Report/Report_Page.php:117
+msgid "API Offline, options disabled"
+msgstr ""
+
+#: src/Report/Report_Page.php:159
+#: src/WP_Post/WP_Post_Table_Controller.php:114
+msgid "Links"
+msgstr ""
+
+#. translators: %1$s is the post title, %2$s is the link to view all links.
+#: src/Report/Report_Page.php:204
+msgid "Showing links for %1$s <a href=\"%2$s\">(Show all links)</a>"
+msgstr ""
+
+#: src/Report/Report_Page.php:221
+msgid "Search"
+msgstr ""
+
+#: src/Report/Report_Page.php:244
+msgid "The link does not exist."
+msgstr ""
+
+#: src/Report/Report_Page.php:256
+msgid "The link is not valid."
+msgstr ""
+
+#: src/Report/Report_Table.php:158
+msgid "Something went wrong, please try again"
+msgstr ""
+
+#: src/Report/Report_Table.php:177
+msgid "No links selected."
+msgstr ""
+
+#: src/Report/Report_Table.php:206
+msgid "No action selected, are services offline?"
+msgstr ""
+
+#: src/Report/Report_Table.php:215
+msgid "Unknown action."
+msgstr ""
+
+#. translators: %d is the link id.
+#: src/Report/Report_Table.php:289
+#: src/Report/Report_Table.php:359
+#: src/Report/Report_Table.php:436
+#: src/Report/Report_Table.php:488
+msgid "Link not found with id:%d"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:302
+msgid "It was not possible to check %s"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:318
+msgid "Link %s has no checks."
+msgstr ""
+
+#. translators: %1$s is the link url, %2$s is the last check date, %3$s is the last check http code.
+#: src/Report/Report_Table.php:330
+msgid "Link %1$s checked successfully on %2$s with %3$s status"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:372
+msgid "Link %s is already an archived link."
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:385
+msgid "No archived link found for %s"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:398
+msgid "It was not possible to update %s, the latest archive link is the same"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:410
+msgid "Link %s updated successfully"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:449
+msgid "Link %1$s could not have a new snapshot created: %2$s"
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:462
+msgid "Link %s added to the queue for updating, please wait."
+msgstr ""
+
+#. translators: %s is the link url.
+#: src/Report/Report_Table.php:500
+msgid "Validating %s to ensure we can check its current status"
+msgstr ""
+
+#: src/Report/Report_Table.php:556
+msgid "URL"
+msgstr ""
+
+#: src/Report/Report_Table.php:557
+msgid "Has Archived Link"
+msgstr ""
+
+#: src/Report/Report_Table.php:558
+msgid "Link Health"
+msgstr ""
+
+#: src/Report/Report_Table.php:559
+msgid "Check Count"
+msgstr ""
+
+#: src/Report/Report_Table.php:560
+msgid "Last Check"
+msgstr ""
+
+#: src/Report/Report_Table.php:561
+msgid "Link Excluded"
+msgstr ""
+
+#: src/Report/Report_Table.php:580
+msgid "Filter by status"
+msgstr ""
+
+#: src/Report/Report_Table.php:582
+msgid "Show valid and broken links"
+msgstr ""
+
+#: src/Report/Report_Table.php:585
+msgid "Show Broken links "
+msgstr ""
+
+#: src/Report/Report_Table.php:586
+msgid "Show Valid links"
+msgstr ""
+
+#: src/Report/Report_Table.php:599
+msgid "Filter by archived link"
+msgstr ""
+
+#: src/Report/Report_Table.php:601
+msgid "Show with or without archived link"
+msgstr ""
+
+#: src/Report/Report_Table.php:604
+msgid "Show links with archived link"
+msgstr ""
+
+#: src/Report/Report_Table.php:605
+msgid "Show links without archived link"
+msgstr ""
+
+#: src/Report/Report_Table.php:619
+msgid "Filter by excluded"
+msgstr ""
+
+#: src/Report/Report_Table.php:621
+msgid "Show with or without excluded link"
+msgstr ""
+
+#: src/Report/Report_Table.php:624
+msgid "Show links that are excluded"
+msgstr ""
+
+#: src/Report/Report_Table.php:625
+msgid "Show links that are not excluded"
+msgstr ""
+
+#: src/Report/Report_Table.php:642
+msgid "Filter"
+msgstr ""
+
+#: src/Report/Report_Table.php:756
+msgid "Update To Latest Snapshot"
+msgstr ""
+
+#: src/Report/Report_Table.php:757
+msgid "Create New Snapshot"
+msgstr ""
+
+#: src/Report/Report_Table.php:758
+msgid "Check Link Status"
+msgstr ""
+
+#: src/Report/Report_Table.php:759
+msgid "Verify Link Allows Checking"
+msgstr ""
+
+#: src/Report/Report_Table.php:881
+msgid "Broken"
+msgstr ""
+
+#: src/Report/Report_Table.php:882
+msgid "Not Broken"
+msgstr ""
+
+#: src/Report/Report_Table.php:932
+msgid "N/a"
+msgstr ""
+
+#. translators: %1$s is the last check date, %2$s is the last check http code.
+#: src/Report/Report_Table.php:937
+msgid "%1$s with %2$s status"
+msgstr ""
+
+#: src/Report/Report_Table.php:940
+msgid "Missing date"
+msgstr ""
+
+#: src/Report/Report_Table.php:943
+msgid "No HTTP Code"
+msgstr ""
+
+#: src/Report/Report_Table.php:955
+msgid "No links have been created yet."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:76
+#: src/Settings/Settings_Page.php:138
+msgid "Link Fixer Settings"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:143
+msgid "Save Changes"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:356
+msgid "Plugin Settings"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:367
+msgid "Internet Archive API"
+msgstr ""
+
+#. Translators: %s is the link to the Internet account setup.
+#: src/Settings/Settings_Page.php:374
+msgid "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new S3 access key."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:384
+msgid "Automatically scan all links in your content to detect and replace broken ones. Find or create archived versions on the Internet Archive and ensure your links remain accessible. Keep your content reliable and up-to-date effortlessly."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:395
+msgid "Auto Archiver"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:397
+msgid "Keep your content securely archived with the Auto Archiver. Each time you update a post, a fresh copy is saved to the Wayback Machine. Ensure your work remains accessible and preserved over time."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:408
+msgid "Process Links"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:416
+#: templates/admin/wizard/step-2.php:45
+#: templates/admin/wizard/step-3.php:44
+msgid "Post Types"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:425
+msgid "Wipe Data on Uninstall"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:434
+msgid "Existing Posts"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:443
+msgid "Fixer Option"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:452
+msgid "Link Exclusions"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:461
+#: templates/admin/wizard/step-1.php:33
+msgid "Archive.org Access Key"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:469
+#: templates/admin/wizard/step-1.php:39
+msgid "Archive.org Secret Key"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:477
+msgid "Auto Archive Posts"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:485
+msgid "Routinely Archive"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:494
+msgid "Routine Interval"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:503
+msgid "Allowed Post Types"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:528
+msgid "When active all links found in your content will be added to the Wayback Machine as an alternative if the content is removed in the future."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:557
+msgid "Please choose which post types will have its content checked and links added to the Wayback Machine."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:584
+msgid "Please choose which post types will be auto archived on publish, to the Wayback Machine.."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:603
+msgid "If checked this will remove all local data when plugin is uninstalled. Leave unchecked if you plan to re-install this plugin."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:626
+msgid "When enabled, all posts of the allowed types will be scanned, and their links will be archived in the Wayback Machine."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:629
+msgid "This runs in the background and may take hours or days, depending on post and link count."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:647
+msgid "Enter a list of URLs to exclude from the link checker. These can be added using <code>*</code> wildcards such as <code>https://x.com*</code> to exclude any x/twitter link"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:662
+msgid "Add a new exclusion (https://x.com*)"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:665
+msgid "Add"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:670
+msgid "No exclusions found."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:734
+msgid "Remove"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:755
+msgid "Archive.org S3 Secret Key"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:777
+msgid "Archive.org S3 Access Key"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:797
+#: templates/admin/wizard/step-2.php:82
+msgid "Replace Link (No Notification)"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:800
+#: templates/admin/wizard/step-2.php:85
+msgid "Do Nothing"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:804
+msgid "Choose how to handle broken links."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:826
+msgid "When active, your own content will be archived on the Wayback Machine. This will be updated every time you make changes to your content."
+msgstr ""
+
+#: src/Settings/Settings_Page.php:849
+msgid "Routinely archive own posts in the wayback machine"
+msgstr ""
+
+#: src/Settings/Settings_Page.php:874
+msgid "The interval between updates in days."
+msgstr ""
+
+#: src/Wayback_Machine/Exception/Exceeded_Snapshot_Limit_Exception.php:30
+msgid "Snapshot creation limit exceeded"
+msgstr ""
+
+#: src/Wayback_Machine/Exception/Invalid_Response_Exception.php:31
+msgid "The response is invalid."
+msgstr ""
+
+#. translators: %s is the message.
+#: src/Wayback_Machine/Exception/Service_Offline_Exception.php:33
+msgid "The service is offline.%s"
+msgstr ""
+
+#: src/WP_Post/WP_Post_Table_Controller.php:151
+msgid "No links found"
+msgstr ""
+
+#. translators: %2$s is the url to view the links in a report, %2$s is the number of broken links, %3$s is the total number of links.
+#: src/WP_Post/WP_Post_Table_Controller.php:158
+msgid "<a href=\"%1$s\"><strong>%2$s</strong> broken out of <strong>%3$s</strong></a>"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:36
+msgid "Url"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:39
+#: templates/admin/reports/link-details.php:41
+msgid "Archived Url"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:41
+msgid "No Archived Link Found"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:45
+msgid "Has Redirect Url"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:49
+msgid "Message"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:53
+msgid "Excluded"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:53
+msgid "This link does not allow indexing"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:65
+#: templates/admin/reports/link-details.php:67
+msgid "Is Broken"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:72
+msgid "Date"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:73
+#: templates/admin/reports/link-details.php:122
+msgid "Status"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:79
+msgid "No checks found for this link."
+msgstr ""
+
+#: templates/admin/reports/link-details.php:87
+msgid "Show Previous Checks"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:115
+msgid "No posts found for this link."
+msgstr ""
+
+#: templates/admin/reports/link-details.php:120
+msgid "Post"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:121
+msgid "Post Type"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:123
+msgid "Actions"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:152
+msgid "Published"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:154
+msgid "Draft"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:156
+msgid "Pending"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:158
+msgid "Scheduled"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:165
+msgid "Edit"
+msgstr ""
+
+#: templates/admin/reports/link-details.php:169
+msgid "View"
+msgstr ""
+
+#: templates/admin/wizard/complete.php:16
+msgid "Setup complete."
+msgstr ""
+
+#. translators: %1$s is the page title, %2$s is the page URL.
+#: templates/admin/wizard/complete.php:24
+msgid "Setup is now complete, you can edit these settings at any times, %s"
+msgstr ""
+
+#: templates/admin/wizard/footer.php:14
+msgid "Finish"
+msgstr ""
+
+#: templates/admin/wizard/footer.php:15
+msgid "Next Step"
+msgstr ""
+
+#. translators: 1: current step, 2: total steps
+#: templates/admin/wizard/footer.php:19
+msgid "Step %1$d of %2$d"
+msgstr ""
+
+#: templates/admin/wizard/footer.php:30
+msgid "Previous Step"
+msgstr ""
+
+#: templates/admin/wizard/step-1.php:23
+msgid "Step 1: Configure the Wayback Machine API"
+msgstr ""
+
+#: templates/admin/wizard/step-1.php:27
+msgid "If you wish to create more than 200 links per month, you will need to get a free account with archive.org and enter the supplied credentials below."
+msgstr ""
+
+#: templates/admin/wizard/step-1.php:28
+msgid "Get your api keys here."
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:24
+msgid "Step 2: Configure the Link Fixer"
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:28
+msgid "You can set the Link Fixer to work only with specific post types and apply it to existing posts."
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:35
+msgid "Enable Link Fixer"
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:39
+msgid "When enabled, all links withing your content will be indexed."
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:47
+msgid "Select the post types you want to enable the link fixer for."
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:64
+msgid "Scan Existing Content"
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:68
+msgid "If enabled, all existing posts will be scanned and processed. Please note this process can take multiple days if you have a lot of content and links."
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:74
+msgid "Broken Link Outcome"
+msgstr ""
+
+#: templates/admin/wizard/step-2.php:76
+msgid "When a link is considered as broken, what should the outcome be?"
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:24
+msgid "Step 3: Configure the Auto Archiver"
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:28
+msgid "Easily preserve your website’s content by enabling automatic archiving with the Internet Archive, setting up routine backups, and choosing which post types to include."
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:35
+msgid "Enable auto archiver"
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:39
+msgid "When \"Auto Archiver\" is enabled, your content is automatically updated on the Internet Archive each time you save changes."
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:46
+msgid "Select which post types should be archived on the Wayback Machine."
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:63
+msgid "Routinely auto archive posts"
+msgstr ""
+
+#: templates/admin/wizard/step-3.php:67
+msgid "If enabled, your posts will be routinely updated on the Wayback Machine."
 msgstr ""

--- a/models/index.php
+++ b/models/index.php
@@ -1,1 +1,0 @@
-<?php // Silence is golden.

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -39,7 +39,6 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 		<p class="description"><?php esc_html_e( 'When "Auto Archiver" is enabled, your content is automatically updated on the Internet Archive each time you save changes.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	</div>
 </div>
-
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
 	<label for="wlf_wizard_post_types">
 		<?php esc_html_e( 'Post Types', 'wpcomsp_wayback_link_fixer' ); ?>

--- a/wayback-link-fixer.php
+++ b/wayback-link-fixer.php
@@ -13,7 +13,7 @@
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Plugin URI:              https://wpspecialprojects.wordpress.com
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.0-RC1
+ * Version:                 1.3.0-RC2
  * Requires at least:       6.2
  * Tested up to:            6.7
  * Requires PHP:            7.4
@@ -21,7 +21,7 @@
  * Author URI:              https://wpspecialprojects.wordpress.com
  * License:                 GPL v3 or later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
- * Text Domain:             wpcomsp-wayback-link-fixer
+ * Text Domain:             wpcomsp_wayback_link_fixer
  * Domain Path:             /languages
  **/
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This pull request includes several changes to the `Internet Archive Wayback Machine Link Fixer` plugin, focusing on codebase cleanup, configuration updates, and versioning adjustments. The most important changes include removing the classmap autoloading, updating the `makepot` script configuration, and adjusting the plugin version and text domain.

Configuration updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L52-R52): Removed the `classmap` autoloading for the `models` directory.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L84-R81): Updated the `makepot` script to include specific directories (`src`, `templates`, `assets`) and exclude others.

Versioning and text domain adjustments:

* [`wayback-link-fixer.php`](diffhunk://#diff-2708a44dcd20b3b5ca73a179f5fbe887a3844e039e7264c093b9062caf531887L16-R24): Updated the plugin version from `1.3.0-RC1` to `1.3.0-RC2` and changed the text domain from `wpcomsp-wayback-link-fixer` to `wpcomsp_wayback_link_fixer`.

Codebase cleanup:

* [`models/index.php`](diffhunk://#diff-ea293d82c8e68e422a67b971027ad6a4bcafc5c587abe3d8b364867d185a61c4L1): Removed the placeholder file.
* [`templates/admin/wizard/step-3.php`](diffhunk://#diff-ad7b1aabbf8c1b40eb4bb4b12771fb72b048cd3bc6a4bf82abd6703f29e18424L42): Removed an unnecessary blank line.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
