### PR TITLE
user postbox style formatting for settings

### DIFF
--- a/assets/css/build/style-style.scss.css
+++ b/assets/css/build/style-style.scss.css
@@ -1,1 +1,659 @@
-.http_100,.http_101,.http_102,.http_103{background-color:#e6f7ff}.http_200,.http_201,.http_202,.http_203,.http_204,.http_205,.http_206,.http_207,.http_208,.http_226{background-color:#e6ffe6}.http_300,.http_301,.http_302,.http_303,.http_304,.http_305,.http_306,.http_307,.http_308{background-color:#fff2e6}.http_400,.http_401,.http_402,.http_403,.http_404,.http_405,.http_406,.http_407,.http_408,.http_409,.http_410,.http_411,.http_412,.http_413,.http_414,.http_415,.http_416,.http_417,.http_418,.http_421,.http_422,.http_423,.http_424,.http_425,.http_426,.http_428,.http_429,.http_431,.http_451{background-color:#ffe6e6}.http_500,.http_501,.http_502,.http_503,.http_504,.http_505,.http_506,.http_507,.http_508,.http_510,.http_511{background-color:#ffe6ff}.http_none{background-color:#e6e6e6}div.wlf-report-list-pagination ul{align-items:center;display:flex;min-width:300px;justify-content:center}div.wlf-report-list-pagination ul li span,div.wlf-report-list-pagination ul li a{display:inline-block;padding:0 5px;text-align:center;width:15px;height:15px;text-decoration:none;font-size:15px;color:#000}div.wlf-report-list-pagination ul li span:hover,div.wlf-report-list-pagination ul li a:hover{cursor:pointer;color:#636363}div.wlf-report-list-pagination ul li span span,div.wlf-report-list-pagination ul li a span{padding:0;width:auto}div.wlf-report-list-pagination ul li .dashicons{padding-top:2px}div.wlf-report-list-pagination ul li.active{background-color:#d9d9d9;border-radius:10px}#wlf-report #wlf-report-logs .wlf-report-link{border:1px solid rgba(75,88,99,.6);margin-bottom:5px}#wlf-report #wlf-report-logs .wlf-report-link__header{display:flex;align-items:center;justify-content:space-between;padding:0 5px;font-size:large;font-weight:700}#wlf-report #wlf-report-logs .wlf-report-link__header .dashicons.updated{color:#3c7f37}#wlf-report #wlf-report-logs .wlf-report-link__header.updated{background-color:#3c7f37}#wlf-report #wlf-report-logs .wlf-report-link__body{padding:0 5px}#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__comments-header,#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__replacements-header{margin:5px 0}#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__comments-row,#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__replacements-row{margin:0;margin-bottom:2px;padding-left:5px}#wlf-report #wlf-report-logs .wlf-report-log{border:1px solid rgba(75,88,99,.6)}#wlf-report #wlf-report-logs .wlf-report-log__header{display:flex;align-items:center;justify-content:space-between;padding:0 5px;font-size:large;font-weight:700;border-bottom:1px solid rgba(75,88,99,.6)}#wlf-report #wlf-report-logs .wlf-report-log__header-post-title{display:flex}#wlf-report #wlf-report-logs .wlf-report-log__header-post-title .dashicons{padding-right:5px;cursor:pointer}#wlf-report #wlf-report-logs .wlf-report-log__links{padding:5px}#wlf-report #wlf-report-logs .wlf-report-log .show-log{display:none}#wlf-report #wlf-report-logs .wlf-report-log .hide-log{display:block}#wlf-report #wlf-report-logs .wlf-report-log.closed .wlf-report-log__links{display:none}#wlf-report #wlf-report-logs .wlf-report-log.closed .wlf-report-log__header{border-bottom:0px}#wlf-report #wlf-report-logs .wlf-report-log.closed .show-log{display:block}#wlf-report #wlf-report-logs .wlf-report-log.closed .hide-log{display:none}@keyframes pulse{0%{background-color:#ebffff}50%{background-color:#f8ebff}50%{background-color:rgba(255,255,255,0)}}#wlf-meta-box-results h2{padding:0;margin-bottom:1em;font-size:19px;color:#db7093}#wlf-meta-box-results .report{border:1px solid #000;padding:5px 7px}#wlf-meta-box-results .report p{margin-bottom:2px}#wlf-meta-box-results .report a{text-align:center;display:block}#wlf-meta-box-results div{margin-bottom:5px}#wlf-meta-box-results.updated-results{animation:pulse 5s}#wlf-meta-box-runner div{margin-bottom:5px}#wlf-meta-box-runner .checkbox_container{display:flex;align-items:flex-end;justify-content:space-between}#wlf-meta-box-runner .text_container label{line-height:25px}#wlf-meta-box-runner .button_container{text-align:center;padding-top:5px}#wlf-meta-box-results__progress{padding:5px;text-align:center;background-color:#00891d;color:#fff;font-weight:500;margin-top:10px;border-radius:10px}#wlf_excluded_links{padding:5px;border:1px solid #cfcfcf;margin:5px 0}#wlf_excluded_links #wlf_excluded_empty{text-align:center;color:#cfcfcf}#wlf_excluded_links .link,#wlf_excluded_links .new-link{display:flex}#wlf_excluded_links .link input,#wlf_excluded_links .new-link input{max-width:100%;width:-webkit-fill-available}#wlf_excluded_links .new-link{margin-bottom:10px;background-color:#cfcfcf;padding:10px}.wlf_settings_card{box-shadow:0 4px 12px rgba(0,0,0,.06),0 0 2px rgba(0,0,0,.16);border-radius:8px;overflow:hidden;padding:5px 10px;background-color:#fff;margin-bottom:20px}.wlf_settings_post_types{display:grid;grid-template-columns:auto auto;gap:16px;width:-moz-fit-content;width:fit-content}.wlf_read-only{pointer-events:none;background-color:#f9f9f9}#wlf-events-trigger{padding:5px;border:1px solid #000;background:#d9d9d9}#wlf-events-trigger h2{margin-top:0}#wlf-events-trigger .wlf-event-trigger-row{padding:2px;margin-bottom:5px}#wlf-events-trigger .wlf-event-trigger-row p{margin:0;margin-top:3px}#wlf-events-trigger .wlf-event-trigger-row p span.description{color:#646970}#wlf-events-trigger .wlf-event-trigger-row input[type=text]{width:100%}#wlf-events-trigger .wlf-event-trigger-row p.with-checkbox input[type=checkbox]{margin-left:5px}#wlf-events-trigger .wlf-event-trigger-row .checkbox-grid{display:flex}#wlf-events-trigger .wlf-event-trigger-row .checkbox-grid label{display:block;padding:5px}#wlf-events-trigger .wlf-event-trigger-row #wlf-event-select2-errors{font-size:medium;text-align:center;color:red;font-weight:700}#wlf-events-trigger .select2-container--default .select2-selection--multiple{padding-bottom:0px}.wlf-filters{display:flex;align-items:center;flex-grow:1}.wlf-filters .wlf-filter{margin-right:10px}.wlf-filters .wlf-filter .select2-selection--single{height:32px}.wlf-filters .wlf-filter.select-single .select2-container{width:auto !important;min-width:110px}.wlf-filters .wlf-filter.select-multi.wide .select2-container{min-width:200px}.wlf-filters .wlf-filter.select-multi .select2-selection--multiple{padding-bottom:0}#wlf-modal{position:fixed;width:100%;height:100%;z-index:99999;background-color:rgba(157,157,157,.7137254902);top:0;left:0;display:flex;align-items:center;justify-content:center}#wlf-modal .wlf-modal__inner{min-height:-moz-fit-content;min-height:fit-content;min-width:50vw;background-color:#fff;border-radius:5px;padding:15px}#wlf-modal .wlf-modal__inner #wlf-modal__inner-header{display:flex;flex-direction:row;flex-wrap:nowrap}#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-title{flex-grow:1;padding:5px;font-size:larger;font-weight:bolder;margin:0}#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-close{display:flex;justify-content:flex-end;align-items:center;padding:5px;font-size:20px;line-height:20px}#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-close .dashicons{cursor:pointer}#wlf-modal .wlf-modal__inner #wlf-modal__inner-content{padding:10px;display:flex;flex-direction:column}#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form{flex-direction:column;display:flex}#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form select,#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form input{width:100%;min-width:-webkit-fill-available;margin-bottom:5px}#wlf_wizard{padding:20px 30px;background:#fff;border-radius:10px;width:500px;min-width:250px;max-width:calc(100% - 60px);margin-left:auto;margin-right:auto}#wlf_wizard input[type=checkbox]{-webkit-appearance:none;appearance:none;width:40px;height:20px;background:#ccc;border-radius:20px;position:relative;cursor:pointer;transition:background .3s;margin:inherit}#wlf_wizard input[type=checkbox]::before{content:"";position:absolute;width:16px;height:16px;background:#fff;border-radius:50%;top:1px;left:2px;transition:transform .3s}#wlf_wizard input[type=checkbox]:checked{background:#2271b1}#wlf_wizard input[type=checkbox]:checked::before{transform:translateX(20px);top:4px;left:5px}#wlf_wizard input[type=text],#wlf_wizard input[type=password],#wlf_wizard select{width:100%;padding:10px;font-size:19px;max-width:unset}#wlf-wizard__footer{display:flex;width:100%;align-items:center;justify-content:space-between}.wlf-wizard__footer__progress{flex-grow:1;display:flex;align-items:center;justify-content:center;padding:0 25px;width:100%}@media(max-width: 499px){.wlf-wizard__footer__progress{display:none}}.wlf-wizard__footer__progress__bar{width:100%;justify-content:center;align-items:center;display:inline;text-align:center}.wlf-wizard__footer__progress__bar__inner{background-color:#a7a7a7;height:5px}.wlf-wizard__content form{display:flex;flex-direction:column}.wlf-wizard__content__field{display:flex;flex-direction:column;margin-bottom:20px;justify-content:center;align-items:flex-start}.wlf-wizard__content__field label{font-size:17px;line-height:20px;margin-bottom:6px;font-weight:400}.wlf-wizard__content__inner-field .inner-spaced-between__list{display:flex;align-items:center;justify-content:space-between;padding:3px 25px}.wlf-wizard__content__inner-field .inner-spaced-between__list:hover{background-color:#f9f9f9}.wlf-wizard__content__inner-field .inner-spaced-between{display:flex;align-items:center;justify-content:space-between;width:100%}.wlf-wizard__content__inner-field.checkbox{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%}.wlf-wizard__content__inner-field.checkbox input{margin:10px}.wlf-wizard__content__inner-field.checkboxes{width:100%}.wlf-wizard__content__inner-field p.description{width:100%}.wlf-wizard__content__field.is_optional.disabled{display:none}
+.http_100,
+.http_101,
+.http_102,
+.http_103 {
+    background-color: #e6f7ff
+}
+
+.http_200,
+.http_201,
+.http_202,
+.http_203,
+.http_204,
+.http_205,
+.http_206,
+.http_207,
+.http_208,
+.http_226 {
+    background-color: #e6ffe6
+}
+
+.http_300,
+.http_301,
+.http_302,
+.http_303,
+.http_304,
+.http_305,
+.http_306,
+.http_307,
+.http_308 {
+    background-color: #fff2e6
+}
+
+.http_400,
+.http_401,
+.http_402,
+.http_403,
+.http_404,
+.http_405,
+.http_406,
+.http_407,
+.http_408,
+.http_409,
+.http_410,
+.http_411,
+.http_412,
+.http_413,
+.http_414,
+.http_415,
+.http_416,
+.http_417,
+.http_418,
+.http_421,
+.http_422,
+.http_423,
+.http_424,
+.http_425,
+.http_426,
+.http_428,
+.http_429,
+.http_431,
+.http_451 {
+    background-color: #ffe6e6
+}
+
+.http_500,
+.http_501,
+.http_502,
+.http_503,
+.http_504,
+.http_505,
+.http_506,
+.http_507,
+.http_508,
+.http_510,
+.http_511 {
+    background-color: #ffe6ff
+}
+
+.http_none {
+    background-color: #e6e6e6
+}
+
+div.wlf-report-list-pagination ul {
+    align-items: center;
+    display: flex;
+    min-width: 300px;
+    justify-content: center
+}
+
+div.wlf-report-list-pagination ul li span,
+div.wlf-report-list-pagination ul li a {
+    display: inline-block;
+    padding: 0 5px;
+    text-align: center;
+    width: 15px;
+    height: 15px;
+    text-decoration: none;
+    font-size: 15px;
+    color: #000
+}
+
+div.wlf-report-list-pagination ul li span:hover,
+div.wlf-report-list-pagination ul li a:hover {
+    cursor: pointer;
+    color: #636363
+}
+
+div.wlf-report-list-pagination ul li span span,
+div.wlf-report-list-pagination ul li a span {
+    padding: 0;
+    width: auto
+}
+
+div.wlf-report-list-pagination ul li .dashicons {
+    padding-top: 2px
+}
+
+div.wlf-report-list-pagination ul li.active {
+    background-color: #d9d9d9;
+    border-radius: 10px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link {
+    border: 1px solid rgba(75, 88, 99, .6);
+    margin-bottom: 5px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 5px;
+    font-size: large;
+    font-weight: 700
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__header .dashicons.updated {
+    color: #3c7f37
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__header.updated {
+    background-color: #3c7f37
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__body {
+    padding: 0 5px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__comments-header,
+#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__replacements-header {
+    margin: 5px 0
+}
+
+#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__comments-row,
+#wlf-report #wlf-report-logs .wlf-report-link__body .wlf-report-link__replacements-row {
+    margin: 0;
+    margin-bottom: 2px;
+    padding-left: 5px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log {
+    border: 1px solid rgba(75, 88, 99, .6)
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 5px;
+    font-size: large;
+    font-weight: 700;
+    border-bottom: 1px solid rgba(75, 88, 99, .6)
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log__header-post-title {
+    display: flex
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log__header-post-title .dashicons {
+    padding-right: 5px;
+    cursor: pointer
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log__links {
+    padding: 5px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log .show-log {
+    display: none
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log .hide-log {
+    display: block
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log.closed .wlf-report-log__links {
+    display: none
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log.closed .wlf-report-log__header {
+    border-bottom: 0px
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log.closed .show-log {
+    display: block
+}
+
+#wlf-report #wlf-report-logs .wlf-report-log.closed .hide-log {
+    display: none
+}
+
+@keyframes pulse {
+    0% {
+        background-color: #ebffff
+    }
+    50% {
+        background-color: #f8ebff
+    }
+    50% {
+        background-color: rgba(255, 255, 255, 0)
+    }
+}
+
+#wlf-meta-box-results h2 {
+    padding: 0;
+    margin-bottom: 1em;
+    font-size: 19px;
+    color: #db7093
+}
+
+#wlf-meta-box-results .report {
+    border: 1px solid #000;
+    padding: 5px 7px
+}
+
+#wlf-meta-box-results .report p {
+    margin-bottom: 2px
+}
+
+#wlf-meta-box-results .report a {
+    text-align: center;
+    display: block
+}
+
+#wlf-meta-box-results div {
+    margin-bottom: 5px
+}
+
+#wlf-meta-box-results.updated-results {
+    animation: pulse 5s
+}
+
+#wlf-meta-box-runner div {
+    margin-bottom: 5px
+}
+
+#wlf-meta-box-runner .checkbox_container {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between
+}
+
+#wlf-meta-box-runner .text_container label {
+    line-height: 25px
+}
+
+#wlf-meta-box-runner .button_container {
+    text-align: center;
+    padding-top: 5px
+}
+
+#wlf-meta-box-results__progress {
+    padding: 5px;
+    text-align: center;
+    background-color: #00891d;
+    color: #fff;
+    font-weight: 500;
+    margin-top: 10px;
+    border-radius: 10px
+}
+
+#wlf_excluded_links {
+    padding: 5px;
+    border: 1px solid #cfcfcf;
+    margin: 5px 0
+}
+
+#wlf_excluded_links #wlf_excluded_empty {
+    text-align: center;
+    color: #cfcfcf
+}
+
+#wlf_excluded_links .link,
+#wlf_excluded_links .new-link {
+    display: flex
+}
+
+#wlf_excluded_links .link input,
+#wlf_excluded_links .new-link input {
+    max-width: 100%;
+    width: -webkit-fill-available
+}
+
+#wlf_excluded_links .new-link {
+    margin-bottom: 10px;
+    background-color: #cfcfcf;
+    padding: 10px
+}
+
+.wlf_settings_postbox {
+    position: relative;
+    min-width: 255px;
+    border: 1px solid #c3c4c7;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+    background: #fff;
+    margin-bottom: 20px;
+    padding-top: 0
+}
+
+.wlf_settings_postbox h2 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #c3c4c7;
+    padding: 10px;
+    margin: 0;
+    font-size: 14px;
+    padding: 8px 12px;
+    line-height: 1.4
+}
+
+.wlf_settings_postbox table.form-table th {
+    padding-left: 10px;
+    font-size: 13px
+}
+
+.wlf_settings_postbox>p.description {
+    padding: 10px 15px 5px
+}
+
+.wlf_settings_card {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .06), 0 0 2px rgba(0, 0, 0, .16);
+    border-radius: 8px;
+    overflow: hidden;
+    padding: 5px 10px;
+    background-color: #fff;
+    margin-bottom: 20px
+}
+
+.wlf_settings_post_types {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 16px;
+    width: -moz-fit-content;
+    width: fit-content
+}
+
+.wlf_read-only {
+    pointer-events: none;
+    background-color: #f9f9f9
+}
+
+#wlf-events-trigger {
+    padding: 5px;
+    border: 1px solid #000;
+    background: #d9d9d9
+}
+
+#wlf-events-trigger h2 {
+    margin-top: 0
+}
+
+#wlf-events-trigger .wlf-event-trigger-row {
+    padding: 2px;
+    margin-bottom: 5px
+}
+
+#wlf-events-trigger .wlf-event-trigger-row p {
+    margin: 0;
+    margin-top: 3px
+}
+
+#wlf-events-trigger .wlf-event-trigger-row p span.description {
+    color: #646970
+}
+
+#wlf-events-trigger .wlf-event-trigger-row input[type=text] {
+    width: 100%
+}
+
+#wlf-events-trigger .wlf-event-trigger-row p.with-checkbox input[type=checkbox] {
+    margin-left: 5px
+}
+
+#wlf-events-trigger .wlf-event-trigger-row .checkbox-grid {
+    display: flex
+}
+
+#wlf-events-trigger .wlf-event-trigger-row .checkbox-grid label {
+    display: block;
+    padding: 5px
+}
+
+#wlf-events-trigger .wlf-event-trigger-row #wlf-event-select2-errors {
+    font-size: medium;
+    text-align: center;
+    color: red;
+    font-weight: 700
+}
+
+#wlf-events-trigger .select2-container--default .select2-selection--multiple {
+    padding-bottom: 0px
+}
+
+.wlf-filters {
+    display: flex;
+    align-items: center;
+    flex-grow: 1
+}
+
+.wlf-filters .wlf-filter {
+    margin-right: 10px
+}
+
+.wlf-filters .wlf-filter .select2-selection--single {
+    height: 32px
+}
+
+.wlf-filters .wlf-filter.select-single .select2-container {
+    width: auto !important;
+    min-width: 110px
+}
+
+.wlf-filters .wlf-filter.select-multi.wide .select2-container {
+    min-width: 200px
+}
+
+.wlf-filters .wlf-filter.select-multi .select2-selection--multiple {
+    padding-bottom: 0
+}
+
+#wlf-modal {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    z-index: 99999;
+    background-color: rgba(157, 157, 157, .7137254902);
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center
+}
+
+#wlf-modal .wlf-modal__inner {
+    min-height: -moz-fit-content;
+    min-height: fit-content;
+    min-width: 50vw;
+    background-color: #fff;
+    border-radius: 5px;
+    padding: 15px
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-header {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-title {
+    flex-grow: 1;
+    padding: 5px;
+    font-size: larger;
+    font-weight: bolder;
+    margin: 0
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-close {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 5px;
+    font-size: 20px;
+    line-height: 20px
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-header-close .dashicons {
+    cursor: pointer
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-content {
+    padding: 10px;
+    display: flex;
+    flex-direction: column
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form {
+    flex-direction: column;
+    display: flex
+}
+
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form select,
+#wlf-modal .wlf-modal__inner #wlf-modal__inner-content #wlf-report-fix-form input {
+    width: 100%;
+    min-width: -webkit-fill-available;
+    margin-bottom: 5px
+}
+
+#wlf_wizard {
+    padding: 20px 30px;
+    background: #fff;
+    border-radius: 10px;
+    width: 500px;
+    min-width: 250px;
+    max-width: calc(100% - 60px);
+    margin-left: auto;
+    margin-right: auto
+}
+
+#wlf_wizard input[type=checkbox] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 40px;
+    height: 20px;
+    background: #ccc;
+    border-radius: 20px;
+    position: relative;
+    cursor: pointer;
+    transition: background .3s;
+    margin: inherit
+}
+
+#wlf_wizard input[type=checkbox]::before {
+    content: "";
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    background: #fff;
+    border-radius: 50%;
+    top: 1px;
+    left: 2px;
+    transition: transform .3s
+}
+
+#wlf_wizard input[type=checkbox]:checked {
+    background: #2271b1
+}
+
+#wlf_wizard input[type=checkbox]:checked::before {
+    transform: translateX(20px);
+    top: 4px;
+    left: 5px
+}
+
+#wlf_wizard input[type=text],
+#wlf_wizard input[type=password],
+#wlf_wizard select {
+    width: 100%;
+    padding: 10px;
+    font-size: 19px;
+    max-width: unset
+}
+
+#wlf-wizard__footer {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between
+}
+
+.wlf-wizard__footer__progress {
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 25px;
+    width: 100%
+}
+
+@media(max-width: 499px) {
+    .wlf-wizard__footer__progress {
+        display: none
+    }
+}
+
+.wlf-wizard__footer__progress__bar {
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    display: inline;
+    text-align: center
+}
+
+.wlf-wizard__footer__progress__bar__inner {
+    background-color: #a7a7a7;
+    height: 5px
+}
+
+.wlf-wizard__content form {
+    display: flex;
+    flex-direction: column
+}
+
+.wlf-wizard__content__field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 20px;
+    justify-content: center;
+    align-items: flex-start
+}
+
+.wlf-wizard__content__field label {
+    font-size: 17px;
+    line-height: 20px;
+    margin-bottom: 6px;
+    font-weight: 400
+}
+
+.wlf-wizard__content__inner-field .inner-spaced-between__list {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 3px 25px
+}
+
+.wlf-wizard__content__inner-field .inner-spaced-between__list:hover {
+    background-color: #f9f9f9
+}
+
+.wlf-wizard__content__inner-field .inner-spaced-between {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%
+}
+
+.wlf-wizard__content__inner-field.checkbox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%
+}
+
+.wlf-wizard__content__inner-field.checkbox input {
+    margin: 10px
+}
+
+.wlf-wizard__content__inner-field.checkboxes {
+    width: 100%
+}
+
+.wlf-wizard__content__inner-field p.description {
+    width: 100%
+}
+
+.wlf-wizard__content__field.is_optional.disabled {
+    display: none
+}

--- a/assets/css/src/admin/_settings.scss
+++ b/assets/css/src/admin/_settings.scss
@@ -21,6 +21,36 @@
     }
 }
 
+.wlf_settings_postbox {
+    position: relative;
+    min-width: 255px;
+    border: 1px solid #c3c4c7;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    background: #fff;
+    margin-bottom: 20px;
+    padding-top: 0;
+    h2 {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid #c3c4c7;
+        padding: 10px;
+        margin: 0;
+        font-size: 14px;
+        padding: 8px 12px;
+        line-height: 14px;
+    }
+    table.form-table {
+        th {
+            padding-left: 10px;
+            font-size: 13px;
+        }
+    }
+    >p.description {
+        padding: 10px 15px 5px;
+    }
+}
+
 .wlf_settings_card {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06), 0 0 2px rgba(0, 0, 0, 0.16);
     border-radius: 8px;

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -357,7 +357,7 @@ class Settings_Page {
 			'__return_empty_string',
 			self::PAGE_SLUG,
 			array(
-				'before_section' => '<div id="wlf_settings_plugin_section" class="wlf_settings_card">',
+				'before_section' => '<div id="wlf_settings_plugin_section" class="wlf_settings_postbox">',
 				'after_section'  => '</div>',
 			)
 		);
@@ -368,12 +368,12 @@ class Settings_Page {
 			'__return_empty_string',
 			self::PAGE_SLUG,
 			array(
-				'before_section' => '<div id="wlf_settings_ia_section" class="wlf_settings_card">',
-				'after_section'  => sprintf(
+				'before_section' => '<div id="wlf_settings_ia_section" class="wlf_settings_postbox">',
+				'after_section'  => '<p class="description">' . sprintf(
 						// Translators: %s is the link to the Internet account setup.
 					__( "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new S3 access key.", 'wpcomsp_wayback_link_fixer' ),
 					esc_url( 'https://archive.org/account/s3.php' )
-				) . '</div>',
+				) . '</p></div>',
 			)
 		);
 
@@ -385,7 +385,7 @@ class Settings_Page {
 			},
 			self::PAGE_SLUG,
 			array(
-				'before_section' => '<div id="wlf_settings_link_fixer_section" class="wlf_settings_card">',
+				'before_section' => '<div id="wlf_settings_link_fixer_section" class="wlf_settings_postbox">',
 				'after_section'  => '</div>',
 			)
 		);
@@ -398,7 +398,7 @@ class Settings_Page {
 			},
 			self::PAGE_SLUG,
 			array(
-				'before_section' => '<div id="wlf_settings_auto_archiver_section" class="wlf_settings_card">',
+				'before_section' => '<div id="wlf_settings_auto_archiver_section" class="wlf_settings_postbox">',
 				'after_section'  => '</div>',
 			)
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request includes changes to the styling and structure of the settings page. The main focus is on updating the CSS classes and HTML structure used for different sections of the settings page.

Changes to CSS and HTML structure:

* [`assets/css/src/admin/_settings.scss`](diffhunk://#diff-a8cf4eb00a4a5c64e89861111e41a7d58f0a74bdc4e06a9f206093e50841033aR24-R53): Added new styles for the `.wlf_settings_postbox` class, including positioning, border, box-shadow, background, margin, padding, and styles for nested elements such as `h2` and `table.form-table`.

* `src/Settings/Settings_Page.php`: Updated the `before_section` and `after_section` HTML structure for multiple sections to use the new `.wlf_settings_postbox` class instead of the previous `.wlf_settings_card` class. This change affects the following sections:
  - `wlf_settings_plugin_section`
  - `wlf_settings_ia_section`
  - `wlf_settings_link_fixer_section`
  - `wlf_settings_auto_archiver_section`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
