### PR TITLE
Added the exlusion column to a debug mode that is only accessible via…

### DIFF
--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -12,6 +12,7 @@ namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Report;
 
 use DateTimeImmutable;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Report_Page;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_Check_Action;
@@ -549,15 +550,34 @@ class Report_Table extends \WP_List_Table {
 	 * @return array<string, string>
 	 */
 	public function get_columns() {
-		return array(
+		$columns = array(
 			self::COLUMN_CHECKBOX         => '<input type="checkbox" />',
 			self::COLUMN_LINK_URL         => __( 'URL', 'wpcomsp_wayback_link_fixer' ),
 			self::COLUMN_LINK_ARCHIVE     => __( 'Has Archived', 'wpcomsp_wayback_link_fixer' ),
 			self::COLUMN_LINK_HEALTH      => __( 'Link Health', 'wpcomsp_wayback_link_fixer' ),
-			self::COLUMN_LINK_EXCLUDE     => __( 'Link Excluded', 'wpcomsp_wayback_link_fixer' ),
 			self::COLUMN_LINK_CHECKS      => __( 'Times Checked', 'wpcomsp_wayback_link_fixer' ),
 			self::COLUMN_LINK_CHECKS_LAST => __( 'Last Check', 'wpcomsp_wayback_link_fixer' ),
 		);
+
+		if ( Settings::show_link_table_debug_data() ) {
+			$exclude = array(
+				self::COLUMN_LINK_EXCLUDE => __( 'Link Excluded', 'wpcomsp_wayback_link_fixer' ),
+			);
+
+			// Add exclude after health.
+			$health_index = array_search( self::COLUMN_LINK_HEALTH, array_keys( $columns ), true );
+			if ( false !== $health_index ) {
+				$columns = array_merge(
+					array_slice( $columns, 0, $health_index + 1, true ),
+					$exclude,
+					array_slice( $columns, $health_index + 1, null, true )
+				);
+			} else {
+				// Add exclude at the end.
+				$columns = array_merge( $columns, $exclude );
+			}
+		}
+		return $columns;
 	}
 
 	/**
@@ -613,25 +633,26 @@ class Report_Table extends \WP_List_Table {
 			?>
 		</select>
 
-
-		<label for="wlf_is_excluded" class="screen-reader-text"><?php esc_html_e( 'Filter by excluded', 'wpcomsp_wayback_link_fixer' ); ?></label>
-		<select name="wlf_is_excluded" id="wlf_is_excluded">
-			<option value=""><?php esc_html_e( 'Show with or without excluded link', 'wpcomsp_wayback_link_fixer' ); ?></option>
-			<?php
-			$has_archive = array(
-				Link_Repository::LINK_IS_EXCLUDED  => __( 'Show links that are excluded', 'wpcomsp_wayback_link_fixer' ),
-				Link_Repository::LINK_NOT_EXCLUDED => __( 'Show links that are not excluded', 'wpcomsp_wayback_link_fixer' ),
-			);
-			foreach ( $has_archive as $archive => $label ) {
-				printf(
-					'<option value="%s"%s>%s</option>',
-					esc_attr( $archive ),
-					selected( $this->get_excluded_status_from_url(), $archive, false ),
-					esc_html( $label )
+		<?php if ( Settings::show_link_table_debug_data() ) : ?>
+			<label for="wlf_is_excluded" class="screen-reader-text"><?php esc_html_e( 'Filter by excluded', 'wpcomsp_wayback_link_fixer' ); ?></label>
+			<select name="wlf_is_excluded" id="wlf_is_excluded">
+				<option value=""><?php esc_html_e( 'Show with or without excluded link', 'wpcomsp_wayback_link_fixer' ); ?></option>
+				<?php
+				$has_archive = array(
+					Link_Repository::LINK_IS_EXCLUDED  => __( 'Show links that are excluded', 'wpcomsp_wayback_link_fixer' ),
+					Link_Repository::LINK_NOT_EXCLUDED => __( 'Show links that are not excluded', 'wpcomsp_wayback_link_fixer' ),
 				);
-			}
-			?>
-		</select>
+				foreach ( $has_archive as $archive => $label ) {
+					printf(
+						'<option value="%s"%s>%s</option>',
+						esc_attr( $archive ),
+						selected( $this->get_excluded_status_from_url(), $archive, false ),
+						esc_html( $label )
+					);
+				}
+				?>
+			</select>
+		<?php endif; ?>
 
 		<?php if ( array_key_exists( 'wlf_filtered_post_id', $_GET ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>
 			<input type="hidden" name="wlf_filtered_post_id" value="<?php echo esc_attr( $_GET['wlf_filtered_post_id'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>" />

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -388,4 +388,17 @@ class Settings {
 
 		return $interval <= 0 ? $default : $interval;
 	}
+
+	/**
+	 * Should the link table, show additional data?
+	 *
+	 * This is for debugging purposes only.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return boolean
+	 */
+	public static function show_link_table_debug_data(): bool {
+		return (bool) apply_filters( 'wlf_show_link_table_debug_data', false );
+	}
 }


### PR DESCRIPTION
… a hook.

#### Changes proposed in this Pull Request

* Adds a new filter `wlf_show_link_table_debug_data` this returns FALSE by default, but if made to be true, will show additional detail in the list table. Also adds as a base to show additional dev aimed data.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Not turned on
![image](https://github.com/user-attachments/assets/2714c31d-6f4e-464c-a6f8-59fc42495da9)

* Turned on
![image](https://github.com/user-attachments/assets/09f94376-03de-42cd-9472-d1b3891b071b)


Mentions #
