### PR TITLE
Refine user-facing wording for clarity and consistency

### DIFF
--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -174,7 +174,7 @@ function wpcomsp_wayback_link_fixer_scaffold_output_requirements_error( $error )
 						case 'plugin_wp_incompatible':
 							$error_message = wp_sprintf(
 								/* translators: 1: Current WP version, 2: Minimum WP version */
-								__( 'Current <em>WordPress version (%1$s)</em> does not meet minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
+								__( 'Current <em>WordPress version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
 								get_bloginfo( 'version' ),
 								$error_data['requires_wp']
 							);
@@ -182,7 +182,7 @@ function wpcomsp_wayback_link_fixer_scaffold_output_requirements_error( $error )
 						case 'plugin_php_incompatible':
 							$error_message = wp_sprintf(
 								/* translators: 1: Current PHP version, 2: Minimum PHP version */
-								__( 'Current <em>PHP version (%1$s)</em> does not meet minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
+								__( 'Current <em>PHP version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
 								PHP_VERSION,
 								$error_data['requires_php']
 							);

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -381,7 +381,7 @@ class Settings_Page {
 			self::GROUP_LINK_FIXER,
 			__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
 			function () {
-				echo '<p class="description">' . esc_html__( "Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.", 'wpcomsp_wayback_link_fixer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
 			},
 			self::PAGE_SLUG,
 			array(

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -371,7 +371,7 @@ class Settings_Page {
 				'before_section' => '<div id="wlf_settings_ia_section" class="wlf_settings_postbox">',
 				'after_section'  => '<p class="description">' . sprintf(
 						// Translators: %s is the link to the Internet account setup.
-					__( "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new S3 access key.", 'wpcomsp_wayback_link_fixer' ),
+					__( "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new 'S3 access key' (this is a type of credential used by Archive.org).", 'wpcomsp_wayback_link_fixer' ),
 					esc_url( 'https://archive.org/account/s3.php' )
 				) . '</p></div>',
 			)
@@ -381,7 +381,7 @@ class Settings_Page {
 			self::GROUP_LINK_FIXER,
 			__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
 			function () {
-				echo '<p class="description">' . esc_html__( 'Automatically scan all links in your content to detect and replace broken ones. Find or create archived versions on the Internet Archive and ensure your links remain accessible. Keep your content reliable and up-to-date effortlessly.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( "Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.", 'wpcomsp_wayback_link_fixer' ) . '</p>';
 			},
 			self::PAGE_SLUG,
 			array(
@@ -405,7 +405,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::PROCESS_LINKS,
-			__( 'Process Links', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Enable Link Fixer', 'wpcomsp_wayback_link_fixer' ),
 			array( $this, 'render_process_links_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER
@@ -525,7 +525,7 @@ class Settings_Page {
 				value="1"
 				<?php checked( Settings::is_link_processing_enabled() ); ?>
 			/>
-			<?php esc_html_e( 'When active, all links found in your content will be added to the Wayback Machine as an alternative if the content is removed in the future.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wpcomsp_wayback_link_fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -557,7 +557,7 @@ class Settings_Page {
 			</label>
 			<?php
 		}
-		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will have its content checked and links added to the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will have their content checked and links added to the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
 	}
 
 	/**
@@ -587,7 +587,7 @@ class Settings_Page {
 			</label>
 			<?php
 		}
-		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will be auto archived on publish, to the Wayback Machine..', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will be automatically archived to the Wayback Machine when they are published.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
 	}
 
 	/**
@@ -606,7 +606,7 @@ class Settings_Page {
 				name="<?php echo esc_attr( Settings::DROP_TABLES_ON_UNINSTALL_KEY ); ?>"
 				value="1"
 				<?php checked( Settings::drop_tables_on_uninstall() ); ?>
-			/><?php esc_html_e( 'If checked, this will remove all local data when plugin is uninstalled. Leave unchecked if you plan to re-install this plugin.', 'wpcomsp_wayback_link_fixer' ); ?>
+			/><?php esc_html_e( 'If checked, this will remove all local data when the plugin is uninstalled. Leave unchecked if you plan to reinstall this plugin.', 'wpcomsp_wayback_link_fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -650,7 +650,7 @@ class Settings_Page {
 		echo wp_kses(
 			sprintf(
 				'<div><p>%s</p></div>',
-				__( 'Enter a list of URLs to exclude from the link checker. These can be added using <code>*</code> wildcards such as <code>https://x.com*</code> to exclude any X/Twitter link.', 'wpcomsp_wayback_link_fixer' )
+				__( "Enter a list of URLs (or parts of URLs) to exclude from link processing. You can use an asterisk (<code>*</code>) as a wildcard. For example, <code>https://example.com/some-path/*</code> would exclude anything after '/some-path/', and <code>*twitter.com*</code> would exclude any URL containing 'twitter.com'.", 'wpcomsp_wayback_link_fixer' )
 			),
 			array(
 				'code' => array(),
@@ -758,7 +758,7 @@ class Settings_Page {
 			style="width:80%;"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Archive.org S3 Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Archive.org Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -780,7 +780,7 @@ class Settings_Page {
 			style="width:80%;"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Archive.org S3 Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Archive.org Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -829,7 +829,7 @@ class Settings_Page {
 				value="1"
 				<?php checked( Settings::add_own_links() ); ?>
 			/>
-			<?php esc_html_e( 'When active, your own content will be archived on the Wayback Machine. This will be updated every time you make changes to your content.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'When active, your own content will be automatically archived on the Wayback Machine each time you publish or update it.', 'wpcomsp_wayback_link_fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -852,7 +852,7 @@ class Settings_Page {
 				data-group="auto_archiver"
 				<?php checked( Settings::own_link_routinely_update() ); ?>
 			/>
-			<?php esc_html_e( 'Routinely archive own posts in the wayback machine', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Regularly archive your posts on the Wayback Machine', 'wpcomsp_wayback_link_fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -877,7 +877,7 @@ class Settings_Page {
 			data-group="auto_archiver"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'The interval between updates in days.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Interval in days for regular archiving.', 'wpcomsp_wayback_link_fixer' ); ?>
 		</p>
 		<?php
 	}

--- a/templates/admin/links-table/help-tab-bulk-actions.php
+++ b/templates/admin/links-table/help-tab-bulk-actions.php
@@ -11,11 +11,11 @@
 	<p><?php esc_html_e( 'When this option is selected, the link will have its archive updated to the latest snapshot available from the Internet Archive.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 
 	<h3><?php esc_html_e( 'Create new snapshot', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'When this option is selected, a new snapshot of the link will be created. This process may take a few minutes, and the link will be updated once the snapshot is complete.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'When this option is selected, a request to create a new snapshot of the link on the Internet Archive will be made. This process can take some time, depending on the Archive.org systems. The link\'s archived version in your records will be updated once the snapshot is complete and available.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 
 	<h3><?php esc_html_e( 'Check link status', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'This option checks the current health and availability of the link.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'This option checks the current status and availability of the live link.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 
-	<h3><?php esc_html_e( 'Verify link allows checking', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'Determines whether the link\'s host allows status checks. This will reassess if the link should be excluded based on host policies or your exclusion settings.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Verify Link Can Be Checked', 'wpcomsp_wayback_link_fixer' ); ?></h3>
+	<p><?php esc_html_e( 'This action checks if the link\'s host (e.g., via robots.txt or meta tags) or your plugin settings prevent the link from being archived or checked. It helps determine if a link should be excluded.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 </div>

--- a/templates/admin/links-table/help-tab-columns.php
+++ b/templates/admin/links-table/help-tab-columns.php
@@ -18,8 +18,8 @@ $wlf_check_frequency = \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Setting
 		<?php
 		echo esc_html(
 			sprintf(
-				// translators: %d is the number of errors encountered.
-				__( 'Indicates whether the link is active or broken. A link is marked as broken after more than %d errors have been recorded during checks.', 'wpcomsp_wayback_link_fixer' ),
+				// translators: %d is the number of consecutive failed checks required to mark a link as broken.
+				__( 'Indicates whether the live link is active or broken. A link is marked as broken after %d consecutive failed checks.', 'wpcomsp_wayback_link_fixer' ),
 				$wlf_failed_count
 			)
 		);
@@ -40,5 +40,5 @@ $wlf_check_frequency = \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Setting
 	</p>
 
 	<h3><?php esc_html_e( 'Last Check', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'Displays the most recent check, including the date and the returned status code, if available.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'Displays the date and result (e.g., HTTP status code) of the most recent check on the live link, if available.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 </div>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -22,7 +22,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 ?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( $wlf_link_title ); ?></h1>
-	<a class="page-title-action" href="<?php echo esc_url( $wlf_back_url ); ?>"><?php esc_html_e( 'Return to Links', 'wpcomsp_wayback_link_fixer' ); ?></a>
+	<a class="page-title-action" href="<?php echo esc_url( $wlf_back_url ); ?>"><?php esc_html_e( 'Back to All Links', 'wpcomsp_wayback_link_fixer' ); ?></a>
 	<hr class="wp-header-end">
 
 
@@ -40,11 +40,11 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 							<?php if ( '' !== $wlf_link->get_archived_href() && ! $wlf_link->is_excluded() ) : ?>
 								<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <a href="<?php echo esc_url( $wlf_link->get_archived_href() ); ?>" target="_blank"><?php echo esc_html( $wlf_link->get_archived_href() ); ?></a></p>
 							<?php else : ?>
-								<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'No Archived Link Found', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'No archived version found.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 							<?php endif; ?>
 
 							<?php if ( '' !== $wlf_link->get_redirect_href() ) : ?>
-								<p class="wlf_link_redirected_url"><strong><?php esc_html_e( 'Has Redirect URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_redirect_href() ); ?></p>
+								<p class="wlf_link_redirected_url"><strong><?php esc_html_e( 'Redirects To', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_redirect_href() ); ?></p>
 							<?php endif; ?>
 
 							<?php if ( '' !== $wlf_link->get_message() ) : ?>
@@ -52,7 +52,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 							<?php endif; ?>
 
 							<?php if ( $wlf_link->is_excluded() ) : ?>
-								<p class="wlf_link_excluded"><strong><?php esc_html_e( 'Excluded', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'This link does not allow indexing', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p class="wlf_link_excluded"><strong><?php esc_html_e( 'Excluded', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'This link is excluded from processing (e.g., by robots.txt or your exclusion settings).', 'wpcomsp_wayback_link_fixer' ); ?></p>
 							<?php endif; ?>
 						</div>
 					</div>
@@ -66,10 +66,10 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 							<p class="wlf_link_broken">
 								<?php
 								$wlf_normal_state_string = ( 0 === count( $wlf_link->get_checks() ) )
-									? esc_html__( 'Not Checked', 'wpcomsp_wayback_link_fixer' )
+									? esc_html__( 'Not yet checked', 'wpcomsp_wayback_link_fixer' )
 									: sprintf(
-										// translators: %d is the number of consecutive failures required to be considered "Broken".
-										esc_html__( 'Monitoring – Link will be marked as "Broken" after %d consecutive failures.', 'wpcomsp_wayback_link_fixer' ),
+										// translators: %d is the number of consecutive failures required to mark a link as 'Broken'.
+										esc_html__( 'Monitoring: Link will be marked as \'Broken\' after %d consecutive failures.', 'wpcomsp_wayback_link_fixer' ),
 										Settings::get_failed_count()
 									);
 								printf(
@@ -90,7 +90,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 								<tbody>
 									<?php if ( 0 === count( $wlf_link->get_checks() ) ) : ?>
 										<tr>
-											<td colspan="2"><?php esc_html_e( 'No checks found for this link.', 'wpcomsp_wayback_link_fixer' ); ?></td>
+											<td colspan="2"><?php esc_html_e( 'No check history for this link yet.', 'wpcomsp_wayback_link_fixer' ); ?></td>
 										</tr>
 									<?php endif; ?>
 
@@ -98,7 +98,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 										<tr id="wlf_reveal_hidden_checks">
 											<td colspan="2">
 												<button class="button" id="wlf_show_hidden_checks">
-													<?php esc_html_e( 'Show Previous Checks', 'wpcomsp_wayback_link_fixer' ); ?>
+													<?php esc_html_e( 'Show Older Checks', 'wpcomsp_wayback_link_fixer' ); ?>
 												</button>
 											</td>
 										</tr>
@@ -126,11 +126,11 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 
 					<div id="wlf_link_posts" class="postbox ">
 						<div class="postbox-header">
-							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Places This Link Appears', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Found In', 'wpcomsp_wayback_link_fixer' ); ?></h2>
 						</div>
 						<div class="inside">
 							<?php if ( empty( $wlf_posts ) ) : ?>
-								<p><?php esc_html_e( 'No posts found for this link.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p><?php esc_html_e( 'This link has not been found in any posts yet.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 							<?php else : ?>
 								<table class="wp-list-table widefat fixed striped">
 									<thead>
@@ -149,10 +149,10 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 														<?php if ( '' === $wlf_post->post_title ) : ?>
 															<?php
 															printf(
-																// Translators: %1$d is the post ID, %2$s is the post type.
-																'No title [#%1$d - %2$s]',
+																// Translators: %1$s is the post ID, %2$s is the post type label (e.g., "Post", "Page").
+																esc_html__( 'Untitled %2$s (ID: %1$d)', 'wpcomsp_wayback_link_fixer' ),
 																absint( $wlf_post->ID ),
-																esc_html( $wlf_post->post_type )
+																esc_html( get_post_type_object( $wlf_post->post_type )->labels->singular_name )
 															);
 															?>
 														<?php else : ?>

--- a/templates/admin/wizard/complete.php
+++ b/templates/admin/wizard/complete.php
@@ -20,9 +20,9 @@
 	<p>
 	<?php
 	printf(
-		// translators: %1$s is the page title, %2$s is the page URL.
-		esc_html__( 'Setup is now complete, you can edit these settings at any times, %s', 'wpcomsp_wayback_link_fixer' ),
-		'<a href="' . esc_url( menu_page_url( 'wpcomsp_wayback_link_fixer_settings', false ) ) . '">Wayback Link Fixer Settings</a>'
+		// translators: %s is a link to the plugin settings page.
+		esc_html__( 'Setup is now complete! You can edit these settings at any time from the %s page.', 'wpcomsp_wayback_link_fixer' ),
+		'<a href="' . esc_url( menu_page_url( 'wpcomsp_wayback_link_fixer_settings', false ) ) . '">' . esc_html__( 'Wayback Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ) . '</a>'
 	);
 	?>
 	</p>

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -24,19 +24,19 @@ $wlf_secret_type = '' === $settings->get_archive_secret_key() ? 'text' : 'passwo
 </div>
 
 <div class="wlf-wizard__content__intro">
-	<p><?php esc_html_e( 'If you wish to create more than 200 links per month, you will need to get a free account with archive.org and enter the supplied credentials below.', 'wpcomsp_wayback_link_fixer' ); ?>
-		<br /><a href="https://archive.org/account/s3.php" target="_blank"><?php esc_html_e( 'Get your api keys here.', 'wpcomsp_wayback_link_fixer' ); ?></a></p>
+	<p><?php esc_html_e( 'To archive more than 200 links from your site to the Wayback Machine per month, you\'ll need a free archive.org account. Once you have your account, enter the API Access Key and Secret Key below.', 'wpcomsp_wayback_link_fixer' ); ?>
+		<br /><a href="https://archive.org/account/s3.php" target="_blank"><?php esc_html_e( 'Get your API keys here.', 'wpcomsp_wayback_link_fixer' ); ?></a></p>
 </div>
 
 <div class="wlf-wizard__content__field">
 	<label for="wlf_wizard_archive_access_key">
-		<?php esc_html_e( 'Archive.org Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Archive.org API Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
 	</label>
 	<input type="<?php echo esc_html( $wlf_access_type ); ?>" name="wlf_wizard_archive_access_key" value="<?php echo esc_attr( $settings->get_archive_access_key() ); ?>" />
 </div>
 <div class="wlf-wizard__content__field">
 	<label for="wlf_wizard_archive_secret_key">
-		<?php esc_html_e( 'Archive.org Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Archive.org API Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
 	</label>
 	<input type="<?php echo esc_html( $wlf_secret_type ); ?>" name="wlf_wizard_archive_secret_key" value="<?php echo esc_attr( $settings->get_archive_secret_key() ); ?>" />
 </div>

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -36,7 +36,7 @@ $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 			</label>
 			<input type="checkbox" id="is_active" name="wlf_wizard_activate_link_fixer" value="1" <?php checked( Settings::is_link_processing_enabled() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'When enabled, all links withing your content will be indexed.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'When enabled, all links within your selected post types will be processed for potential archiving by the Link Fixer.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	</div>
 </div>
 
@@ -65,15 +65,15 @@ $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 			</label>
 			<input type="checkbox" id="wlf_is_active" name="wlf_wizard_scan_existing_content" id="wlf_wizard_scan_existing_content" value="1" <?php checked( Settings::should_scan_existing_posts() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'If enabled, all existing posts will be scanned and processed. Please note this process can take multiple days if you have a lot of content and links.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'If enabled, all existing posts of the selected types will be scanned and processed. Please note this process can take significant time (potentially hours or days) depending on the amount of content and number of links.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	</div>
 </div>
 
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
 	<label for="wlf_wizard_outcome">
-		<?php esc_html_e( 'Broken Link Outcome', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Action for Broken Links', 'wpcomsp_wayback_link_fixer' ); ?>
 	</label>
-	<p class="description"><?php esc_html_e( 'When a link is considered as broken, what should the outcome be?', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p class="description"><?php esc_html_e( 'What should the Link Fixer do when it identifies a broken link?', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	<select
 		id="wlf_wizard_outcome"
 		name="wlf_wizard_outcome"

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -25,18 +25,18 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 </div>
 
 <div class="wlf-wizard__content__intro">
-	<p><?php esc_html_e( 'Easily preserve your website’s content by enabling automatic archiving with the Internet Archive, setting up routine backups, and choosing which post types to include.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'Easily preserve your website’s content by enabling automatic archiving with the Internet Archive, setting up regular archiving, and choosing which post types to include.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 </div>
 
 <div class="wlf-wizard__content__field">
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_activate_auto_archiver">
-				<?php esc_html_e( 'Enable auto archiver', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Enable Auto Archiver', 'wpcomsp_wayback_link_fixer' ); ?>
 			</label>
 			<input type="checkbox" id="is_active" name="wlf_wizard_activate_auto_archiver" value="1" <?php checked( Settings::add_own_links() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'When "Auto Archiver" is enabled, your content is automatically updated on the Internet Archive each time you save changes.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'When the Auto Archiver is enabled, your content is automatically archived on the Internet Archive each time you publish or save changes to a post of the selected types.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	</div>
 </div>
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
@@ -60,11 +60,11 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_recurring_backup">
-				<?php esc_html_e( 'Routinely auto archive posts', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Enable Scheduled Archiving', 'wpcomsp_wayback_link_fixer' ); ?>
 			</label>
 			<input type="checkbox" name="wlf_wizard_recurring_backup" value="1" <?php checked( Settings::is_link_processing_enabled() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'If enabled, your posts will be routinely updated on the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'If enabled, your posts of selected types will be regularly archived on the Wayback Machine according to the interval set in the main plugin settings.', 'wpcomsp_wayback_link_fixer' ); ?></p>
 	</div>
 </div>
 


### PR DESCRIPTION
This commit applies a comprehensive set of updates to user-facing strings throughout the WordPress plugin. The changes aim to improve clarity, conciseness, grammatical correctness, and overall user-friendliness of the text displayed in the plugin's settings pages, admin reports, setup wizard, and help tabs.

Key improvements include:
- Clarification of technical terms (e.g., "S3 access key", "wildcards").
- Correction of minor grammatical errors and typos.
- Rephrasing of sentences for better readability and flow.
- Ensuring consistent terminology across different UI components.
- Making instructions and explanations more accessible to a typical WordPress user.

All primary user-facing text locations were reviewed, including:
- Plugin metadata
- Settings page (`src/Settings/Settings_Page.php`)
- Admin report pages (`templates/admin/reports/link-details.php`)
- Setup wizard steps (`templates/admin/wizard/*.php`)
- Help tabs (`templates/admin/links-table/*.php`)
- General PHP function messages (`functions.php`, `functions-bootstrap.php`)

JavaScript-generated text was also reviewed and found to be correctly localized via PHP.

A final review step confirmed that all intended changes were applied correctly, including a fix for an initially swapped pair of descriptions in the settings page.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
