### PR TITLE
Remove _scaffold from auto created function names

### DIFF
--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @return  ($property is null ? PluginMetaData : ($property is PluginMetaKey ? PluginMetaData[PluginMetaKey] : null))
  */
-function wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( $property = null ) {
+function wpcomsp_wayback_link_fixer_get_plugin_metadata( $property = null ) {
 	static $plugin_data = null;
 
 	$can_translate = 0 < did_action( 'init' );
@@ -55,8 +55,8 @@ function wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( $property = nu
  *
  * @return  string
  */
-function wpcomsp_wayback_link_fixer_scaffold_get_plugin_slug(): string {
-	$text_domain = wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'TextDomain' );
+function wpcomsp_wayback_link_fixer_get_plugin_slug(): string {
+	$text_domain = wpcomsp_wayback_link_fixer_get_plugin_metadata( 'TextDomain' );
 	return sanitize_key( $text_domain );
 }
 
@@ -68,8 +68,8 @@ function wpcomsp_wayback_link_fixer_scaffold_get_plugin_slug(): string {
  *
  * @return  string
  */
-function wpcomsp_wayback_link_fixer_scaffold_get_plugin_name(): string {
-	return wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'Name' );
+function wpcomsp_wayback_link_fixer_get_plugin_name(): string {
+	return wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Name' );
 }
 
 /**
@@ -80,8 +80,8 @@ function wpcomsp_wayback_link_fixer_scaffold_get_plugin_name(): string {
  *
  * @return  string
  */
-function wpcomsp_wayback_link_fixer_scaffold_get_plugin_version(): string {
-	return wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'Version' );
+function wpcomsp_wayback_link_fixer_get_plugin_version(): string {
+	return wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Version' );
 }
 
 /**
@@ -91,7 +91,7 @@ function wpcomsp_wayback_link_fixer_scaffold_get_plugin_version(): string {
  *
  * @return  boolean
  */
-function wpcomsp_wayback_link_fixer_scaffold_is_wp_version_compatible( $min_wp_version ) {
+function wpcomsp_wayback_link_fixer_is_wp_version_compatible( $min_wp_version ) {
 	if ( ! function_exists( 'is_wp_version_compatible' ) ) {
 		return false;
 	}
@@ -106,7 +106,7 @@ function wpcomsp_wayback_link_fixer_scaffold_is_wp_version_compatible( $min_wp_v
  *
  * @return  boolean
  */
-function wpcomsp_wayback_link_fixer_scaffold_is_php_version_compatible( $min_php_version ) {
+function wpcomsp_wayback_link_fixer_is_php_version_compatible( $min_php_version ) {
 	if ( ! function_exists( 'is_php_version_compatible' ) ) {
 		return false;
 	}
@@ -119,17 +119,17 @@ function wpcomsp_wayback_link_fixer_scaffold_is_php_version_compatible( $min_php
  *
  * @return  true|\WP_Error
  */
-function wpcomsp_wayback_link_fixer_scaffold_validate_requirements() {
-	$plugin_metadata = wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata();
+function wpcomsp_wayback_link_fixer_validate_requirements() {
+	$plugin_metadata = wpcomsp_wayback_link_fixer_get_plugin_metadata();
 	if ( ! isset( $plugin_metadata['RequiresPHP'] ) || '' === $plugin_metadata['RequiresPHP'] ) {
-		$plugin_metadata['RequiresPHP'] = '8.3';
+		$plugin_metadata['RequiresPHP'] = '7.4';
 	}
 	if ( ! isset( $plugin_metadata['RequiresWP'] ) || '' === $plugin_metadata['RequiresWP'] ) {
 		$plugin_metadata['RequiresWP'] = '6.7';
 	}
 
-	$is_php_compatible = wpcomsp_wayback_link_fixer_scaffold_is_php_version_compatible( $plugin_metadata['RequiresPHP'] );
-	$is_wp_compatible  = wpcomsp_wayback_link_fixer_scaffold_is_wp_version_compatible( $plugin_metadata['RequiresWP'] );
+	$is_php_compatible = wpcomsp_wayback_link_fixer_is_php_version_compatible( $plugin_metadata['RequiresPHP'] );
+	$is_wp_compatible  = wpcomsp_wayback_link_fixer_is_wp_version_compatible( $plugin_metadata['RequiresWP'] );
 
 	$wp_error = new \WP_Error();
 	if ( ! $is_wp_compatible ) {
@@ -149,15 +149,15 @@ function wpcomsp_wayback_link_fixer_scaffold_validate_requirements() {
  *
  * @return  void
  */
-function wpcomsp_wayback_link_fixer_scaffold_output_requirements_error( $error ) {
+function wpcomsp_wayback_link_fixer_output_requirements_error( $error ) {
 	add_action(
 		'admin_notices',
 		static function () use ( $error ) {
 			$requirements_error = wp_sprintf(
 				/* translators: 1: Plugin name, 2: Plugin version */
 				__( '<strong>%1$s (version %2$s)</strong> could not be initialized.', 'wpcomsp_wayback_link_fixer' ),
-				wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'Name' ),
-				wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'Version' )
+				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Name' ),
+				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Version' )
 			);
 
 			if ( $error->has_errors() ) {

--- a/functions.php
+++ b/functions.php
@@ -59,18 +59,6 @@ function wpcomsp_wayback_link_fixer_deactivate(): void {
 
 
 /**
- * Returns the plugin's slug.
- *
- * @since   1.0.0
- * @version 1.0.0
- *
- * @return  string
- */
-function wpcomsp_wayback_link_fixer_get_plugin_slug(): string {
-	return sanitize_key( WPCOMSP_WAYBACK_LINK_FIXER_METADATA['TextDomain'] );
-}
-
-/**
  * Escape a HTTP status code.
  *
  * @since 1.0.0

--- a/wayback-link-fixer.php
+++ b/wayback-link-fixer.php
@@ -43,9 +43,9 @@ add_action(
 	'init',
 	static function () {
 		load_plugin_textdomain(
-			wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'TextDomain' ),
+			wpcomsp_wayback_link_fixer_get_plugin_metadata( 'TextDomain' ),
 			false,
-			dirname( WPCOMSP_WAYBACK_LINK_FIXER_BASENAME ) . wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata( 'DomainPath' )
+			dirname( WPCOMSP_WAYBACK_LINK_FIXER_BASENAME ) . wpcomsp_wayback_link_fixer_get_plugin_metadata( 'DomainPath' )
 		);
 	}
 );
@@ -62,16 +62,16 @@ add_action(
 
 // Load the autoloader.
 if ( ! is_file( WPCOMSP_WAYBACK_LINK_FIXER_PATH . '/vendor/autoload.php' ) ) {
-	wpcomsp_wayback_link_fixer_scaffold_output_requirements_error( new WP_Error( 'missing_autoloader' ) );
+	wpcomsp_wayback_link_fixer_output_requirements_error( new WP_Error( 'missing_autoloader' ) );
 	return;
 }
 require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . '/vendor/autoload.php';
 
-define( 'WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS', wpcomsp_wayback_link_fixer_scaffold_validate_requirements() );
+define( 'WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS', wpcomsp_wayback_link_fixer_validate_requirements() );
 
 
 if ( is_wp_error( WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS ) ) {
-	wpcomsp_wayback_link_fixer_scaffold_output_requirements_error( WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS );
+	wpcomsp_wayback_link_fixer_output_requirements_error( WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS );
 } else {
 	// Include the action scheduler integration.
 	require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . 'lib/action-scheduler/action-scheduler.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request refactors the `wpcomsp_wayback_link_fixer` plugin by removing the "scaffold" prefix from function names and updating the plugin's minimum PHP version requirement. The changes aim to simplify function naming conventions and adjust compatibility requirements for better alignment with current standards.

### Refactoring Function Names:
* Removed "scaffold" prefix from all function names in `functions-bootstrap.php`, such as `wpcomsp_wayback_link_fixer_scaffold_get_plugin_metadata` renamed to `wpcomsp_wayback_link_fixer_get_plugin_metadata`. This applies to metadata retrieval, slug generation, name retrieval, version retrieval, compatibility checks, and requirements validation. [[1]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L22-R22) [[2]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L58-R59) [[3]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L71-R72) [[4]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L83-R84) [[5]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L94-R94) [[6]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L109-R109) [[7]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L122-R132) [[8]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L152-R160)

* Updated function calls in `wayback-link-fixer.php` to reflect the new function names, ensuring consistency across the codebase. [[1]](diffhunk://#diff-2708a44dcd20b3b5ca73a179f5fbe887a3844e039e7264c093b9062caf531887L46-R48) [[2]](diffhunk://#diff-2708a44dcd20b3b5ca73a179f5fbe887a3844e039e7264c093b9062caf531887L65-R74)

### Compatibility Adjustments:
* Changed the default minimum PHP version requirement from `8.3` to `7.4` in the `wpcomsp_wayback_link_fixer_validate_requirements` function to accommodate broader usage.

### Code Cleanup:
* Removed a redundant implementation of the `wpcomsp_wayback_link_fixer_get_plugin_slug` function from `functions.php`, as it is now consolidated in `functions-bootstrap.php`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized function names for improved consistency by removing the `_scaffold` segment.
  * Updated all references to use the new function names.
  * Removed an unused function related to plugin slug retrieval.

* **New Features**
  * Lowered the minimum required PHP version from 8.3 to 7.4, increasing compatibility with more environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->