### PR TITLE
Feature/chunk new snapshots from link table

### DIFF
--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -19,6 +19,7 @@ use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_Check_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Validate_Link_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_New_Snapshot_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_Latest_Snapshot_Action;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Create_New_Snapshot_Event;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Util\List_Table_Action_Notification_Cache;
 
 /**
@@ -52,7 +53,7 @@ class Report_Table extends \WP_List_Table {
 	 *
 	 * @var array{message:string, type:string}[]
 	 */
-	private array $notices = array();
+	protected array $notices = array();
 
 	/**
 	 * Create instance of Report_List_Table.
@@ -449,6 +450,12 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function process_new_snapshot( array $links ): void {
 		$action = new Link_New_Snapshot_Action();
+		// If we have more than 5 links, we will process them in a batch.
+		if ( count( $links ) > 5 ) {
+			$this->delay_new_snapshot_processing( $links );
+			return;
+		}
+
 		// Iterate over the links and update them.
 		foreach ( $links as $link_id ) {
 			$result = $action->create_new_snapshot( absint( $link_id ) );
@@ -491,6 +498,136 @@ class Report_Table extends \WP_List_Table {
 			);
 		}
 	}
+
+	/**
+	 * Batch process new snapshot requests.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param integer[] $links The links to process.
+	 *
+	 * @return void
+	 */
+	private function delay_new_snapshot_processing( array $links ): void {
+		$link_not_found = array();
+		$own_links      = array();
+		$archived_links = array();
+		$added_links    = array();
+
+		//Iterate over the links and update them.
+		foreach ( $links as $link_id ) {
+			// Check the link exists.
+			$link = $this->links->find_by_id( $link_id );
+
+			if ( ! $link ) {
+				// Add a notice.
+				$link_not_found[] = absint( $link_id );
+				continue;
+			}
+
+			if ( wpcomsp_wayback_link_fixer_is_archive_link( $link->get_href() ) ) {
+				// Add a notice.
+				$archived_links[] = $link;
+				continue;
+			}
+
+			if ( wpcomsp_wayback_link_fixer_is_current_site_link( $link->get_href() ) ) {
+				// Add a notice.
+				$own_links[] = $link;
+				continue;
+			}
+
+			// Add the task to the queue.
+			Create_New_Snapshot_Event::add_to_queue( $link_id );
+			$added_links[] = $link;
+		}
+
+		// Create the report to show.
+		$notice = '';
+
+		$error_icon = '<span style="color: red;">❌</span>';
+
+		// If we have any where the link could not be found, add a notice.
+		if ( ! empty( $link_not_found ) ) {
+			$notice .= sprintf(
+				// translators: %s is the icon for error, %d is the number of links that could not be found.
+				__( '%1$s - %2$d links could not be found.', 'wpcomsp_wayback_link_fixer' ),
+				$error_icon,
+				count( $link_not_found )
+			);
+		}
+
+		// If we have any where the link is an archived link, add a notice.
+		if ( ! empty( $archived_links ) ) {
+			$notice .= sprintf(
+				// translators: %s is the icon for error, %d is the number of links that are archived.
+				__( '%1$s - %2$d links that are already snapshots and will be skipped', 'wpcomsp_wayback_link_fixer' ),
+				$error_icon,
+				count( $archived_links )
+			);
+
+			// List the urls.
+			$notice .= '<ul>';
+			foreach ( $archived_links as $link ) {
+				$notice .= sprintf(
+					'<li>%s</li>',
+					wpcomsp_wayback_link_fixer_trim_string( $link->get_href(), 54 )
+				);
+			}
+			$notice .= '</ul>';
+		}
+
+		// If we have any where the link is an own link, add a notice.
+		if ( ! empty( $own_links ) ) {
+			$notice .= sprintf(
+				// translators: %s is the icon for error, , %d is the number of links that are own links.
+				__( '%1$s - %2$d links are from this site and will not be processed. Please enable the Auto Archiver to archive your own content.', 'wpcomsp_wayback_link_fixer' ),
+				$error_icon,
+				count( $own_links )
+			);
+
+			// List the urls.
+			$notice .= '<ul>';
+			foreach ( $own_links as $link ) {
+				$notice .= sprintf(
+					'<li>%s</li>',
+					wpcomsp_wayback_link_fixer_trim_string( $link->get_href(), 54 )
+				);
+			}
+			$notice .= '</ul>';
+		}
+
+		$success_notice = __( '✅ - The following links were added to the queue for a new snapshot to be created:', 'wpcomsp_wayback_link_fixer' );
+		// If we have any where the link was added to the queue, add a notice.
+		if ( ! empty( $added_links ) ) {
+
+			// List the urls.
+			$success_notice .= '<ul>';
+			foreach ( $added_links as $link ) {
+				$success_notice .= sprintf(
+					'<li>%s</li>',
+					wpcomsp_wayback_link_fixer_trim_string( $link->get_href(), 54 )
+				);
+			}
+			$success_notice .= '</ul>';
+			$success_notice .= '<p>' . __( 'Snapshots are being queued for processing and will appear soon. Thanks for your patience!', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+		}
+
+		// Add the notices.
+		if ( '' !== $notice ) {
+			$this->notices[] = array(
+				'message' => $notice,
+				'type'    => 'error',
+			);
+		}
+		// Add the success notice.
+		$this->notices[] = array(
+			'message' => $success_notice,
+			'type'    => 'success',
+		);
+	}
+
+
 
 	/**
 	 * Process the Link Exclusion action.
@@ -561,7 +698,7 @@ class Report_Table extends \WP_List_Table {
 		foreach ( $this->notices as $notice ) {
 			?>
 			<div class="notice notice-<?php echo esc_attr( $notice['type'] ); ?> is-dismissible">
-				<p><?php echo esc_html( $notice['message'] ); ?></p>
+				<p><?php echo \wp_kses_post( $notice['message'] ); ?></p>
 			</div>
 			<?php
 		}

--- a/tests/Action/Test_Link_New_Snapshot_Action.php
+++ b/tests/Action/Test_Link_New_Snapshot_Action.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * Tests for Check Snapshot Status Event
+ *
+ * @since 1.3.0
+ *
+ * @coversDefaultClass \WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Check_Snapshot_Status_Event
+ */
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Tests\Event;
+
+use Gin0115\WPUnit_Helpers\Objects;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Report_Table;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_New_Snapshot_Action;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Check_Snapshot_Status_Event;
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Link_Checker_Client;
+
+/**
+ * Test_Link_New_Snapshot_Action
+ *
+ * @group Action
+ * @group Link_New_Snapshot_Action
+ */
+class Test_Link_New_Snapshot_Action extends \WP_UnitTestCase {
+
+	private $wpdb;
+	private $link_repository;
+
+	/**
+	 * Setup
+	 */
+	public function set_up(): void {
+		$this->wpdb            = $GLOBALS['wpdb'];
+		$this->link_repository = new Link_Repository();
+
+		// Clear the actionscheduler_actions table.
+		$this->wpdb->query( "TRUNCATE TABLE {$this->wpdb->prefix}actionscheduler_actions" );
+
+		// Clear any wlf_snapshot_client filter.
+		remove_all_filters( 'wlf_snapshot_client' );
+
+		// Clear the link table.
+		$this->wpdb->query( 'TRUNCATE TABLE ' . Settings::get_link_table_name() );
+
+		parent::set_up();
+	}
+
+	/**
+	 * Set the snapshot client to return a mocked response.
+	 *
+	 * @param array $response The response to return.
+	 *
+	 * @return void
+	 */
+	private function set_snapshot_client_response( array $response ): void {
+		$service = $this->createMock( Snapshot_Client::class );
+		$service->method( 'get_snapshot_status' )->willReturn( $response );
+
+		add_filter( 'wlf_snapshot_client', fn() => $service );
+	}
+
+	/**
+	 * Get a mocked up Table instance.
+	 *
+	 * @return Report_Table
+	 */
+	private function get_mocked_table(): Report_Table {
+		return new class($this->link_repository) extends Report_Table {
+
+			public function test_links( array $links ): void {
+				Objects::invoke_method( $this, 'process_new_snapshot', array( $links ) );
+			}
+
+			public function get_notices(): ?array {
+				return $this->notices;
+			}
+		};
+	}
+
+
+	/**
+	 * @testdox When creating a new snapshot for less than 10 links, just process and start the process of creating a new snapshot.
+	 *
+	 * @return void
+	 */
+	public function test_create_new_snapshot_for_less_than_10_links(): void {
+		// Create 4 links.
+		$all = array(
+			new Link( 'https://glynnquelch.co.uk/link' ),
+			new Link( 'https://glynnquelch.co.uk/link2' ),
+			new Link( 'https://glynnquelch.co.uk/link3' ),
+			new Link( 'https://glynnquelch.co.uk/link4' ),
+		);
+
+		$calls = 0;
+
+		// Use a mock IA insstance
+		$client = $this->createMock( \WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
+		$client->method( 'create_snapshot' )
+			->willReturnCallback(function($link) use( &$calls) {
+				$calls++;
+				return 'some-id';
+			});
+
+		// Set the mock client
+		add_filter(
+			'wlf_snapshot_client',
+			function () use ( $client ) {
+				return $client;
+			}
+		);
+
+		// Iterate through the links and save them.
+		foreach ( $all as $link ) {
+			$this->link_repository->upsert( $link );
+		}
+
+		// Create the action
+		$table = $this->get_mocked_table();
+
+		$links    = $this->link_repository->query_links( 9999 );
+		$link_ids = array_map( fn( Link $link ) => $link->get_id(), $links );
+		$table->test_links( $link_ids );
+		$notices = $table->get_notices();
+
+		$this->assertCount(4, $notices );
+		$this->assertCount(4, array_filter(
+			$notices,
+			fn( $notice ) => $notice['type'] === 'success'
+		) );
+		$this->assertCount(0, array_filter(
+			$notices,
+			fn( $notice ) => $notice['type'] === 'error'
+		) );
+		$this->assertEquals(4, $calls);
+
+		// Remove the filter.
+		remove_all_filters( 'wlf_snapshot_client' );
+
+
+	}
+
+	/**
+	 * @testdox When trying to create snapshots for more than 10 links, it should create a new action to process the links in batches.
+	 *
+	 * @return void
+	 */
+	public function test_create_new_snapshot_for_more_than_10_links(): void {
+		// Create 12 links.
+		$all = array(
+			new Link( 'https://glynnquelch.co.uk/link' ),
+			new Link( 'https://glynnquelch.co.uk/link2' ),
+			new Link( 'https://glynnquelch.co.uk/link3' ),
+			new Link( 'https://glynnquelch.co.uk/link4' ),
+			new Link( 'https://glynnquelch.co.uk/link5' ),
+			new Link( 'https://glynnquelch.co.uk/link6' ),
+			new Link( 'https://glynnquelch.co.uk/link7' ),
+			new Link( 'https://glynnquelch.co.uk/link8' ),
+			new Link( 'https://glynnquelch.co.uk/link9' ),
+			new Link( 'https://glynnquelch.co.uk/link10' ),
+			new Link( 'https://glynnquelch.co.uk/link11' ),
+			new Link( 'https://glynnquelch.co.uk/link12' ),
+		);
+
+		// Use a mock IA insstance
+		$client = $this->createMock( \WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
+		$client->method( 'create_snapshot' )
+			->willReturn('some-id');
+
+		// Set the mock client
+		add_filter(
+			'wlf_snapshot_client',
+			function () use ( $client ) {
+				return $client;
+			}
+		);
+
+		foreach ( $all as $link ) {
+			$this->link_repository->upsert( $link );
+		}
+
+		// Create the action
+		$table = $this->get_mocked_table();
+
+		$links    = $this->link_repository->query_links( 9999 );
+		$link_ids = array_map( fn( Link $link ) => $link->get_id(), $links );
+
+		$table->test_links( $link_ids );
+		$notices = $table->get_notices();
+
+		// Remove the filter.
+		remove_all_filters( 'wlf_snapshot_client' );
+
+		// We should have only 1 notice.
+		$this->assertCount( 1, $notices );
+		$this->assertEquals( 'success', $notices[0]['type'] );
+
+		// The message should contain all the links hrefs.
+		foreach( $all as $link ) {
+			$this->assertStringContainsString( $link->get_href(), $notices[0]['message'] );
+		}
+
+		// Check how many actions are scheduled.
+		$actions = $this->wpdb->get_results( "SELECT args FROM {$this->wpdb->prefix}actionscheduler_actions where hook='wlf_create_new_snapshot'" );
+		$this->assertCount( 12, $actions );
+
+		// Iterate over the actions and check the id in args is id in array.
+		foreach ( $actions as $action ) {
+			$args = json_decode( $action->args, true );
+			$this->assertContains( $args['link_id'], $link_ids );
+		}
+	}
+
+	/**
+	 * @testdox when we send a chunk of urls to have new snapshots created, own site and IA archive links should be omitted and reported back.
+	 *
+	 * @return void
+	 */
+	public function test_create_new_snapshot_omits_own_and_ia_links(): void {
+		// Create 12
+		$valid = array(
+			new Link( 'https://glynnquelch.co.uk/link' ),
+			new Link( 'https://glynnquelch.co.uk/link2' ),
+			new Link( 'https://glynnquelch.co.uk/link3' ),
+			new Link( 'https://glynnquelch.co.uk/link4' ),
+		);
+
+		$invalid = [
+			// Own site links.
+			new Link( 'https://example.org/link' ),
+			new Link( 'https://example.org/link2' ),
+			new Link( 'https://example.org/link3' ),
+			new Link( 'https://example.org/link4' ),
+			// IA links.
+			new Link( 'https://web.archive.org/web/link' ),
+			new Link( 'https://web.archive.org/web/link2' ),
+			new Link( 'https://web.archive.org/web/link3' ),
+			new Link( 'https://web.archive.org/web/link4' ),
+		];
+
+
+		foreach ( array_merge($valid, $invalid) as $link ) {
+			$this->link_repository->upsert( $link );
+		}
+
+		// Create the action
+		$table = $this->get_mocked_table();
+
+		$links    = $this->link_repository->query_links( 9999 );
+		$link_ids = array_map( fn( Link $link ) => $link->get_id(), $links );
+
+		$table->test_links( $link_ids );
+		$notices = $table->get_notices();
+
+		// We should have both success and error notices.
+		$this->assertCount( 2, $notices );
+
+		$success_notices = array_filter(
+			$notices,
+			fn( $notice ) => $notice['type'] === 'success'
+		);
+		$error_notices = array_filter(
+			$notices,
+			fn( $notice ) => $notice['type'] === 'error'
+		);
+
+		// Iterating over the valid urls, they should be in the success notice.
+		foreach ( $valid as $link ) {
+			$this->assertStringContainsString( $link->get_href(), \array_values($success_notices)[0]['message'] );
+		}
+		// Iterating over the invalid urls, they should be in the error notice.
+		foreach ( $invalid as $link ) {
+			$this->assertStringContainsString( $link->get_href(),\array_values( $error_notices)[0]['message'] );
+		}
+
+		// Check how many actions are scheduled.
+		$actions = $this->wpdb->get_results( "SELECT args FROM {$this->wpdb->prefix}actionscheduler_actions where hook='wlf_create_new_snapshot'" );
+		$this->assertCount( 4, $actions );
+	}
+}

--- a/tests/Report/Test_Report_Table_Actions.php
+++ b/tests/Report/Test_Report_Table_Actions.php
@@ -1,34 +1,31 @@
 <?php
 
 /**
- * Tests for Check Snapshot Status Event
+ * Tests for the bulk action on the report table
  *
  * @since 1.3.0
  *
- * @coversDefaultClass \WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Check_Snapshot_Status_Event
+ * @coversDefaultClass WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Report_Table
  */
 
 declare(strict_types=1);
 
-namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Tests\Event;
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Tests\Report;
 
 use Gin0115\WPUnit_Helpers\Objects;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Report\Report_Table;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link_Repository;
-use WPCOMSpecialProjects\Wayback_Link_Fixer\Action\Link_New_Snapshot_Action;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Snapshot_Client;
-use WPCOMSpecialProjects\Wayback_Link_Fixer\Event\Check_Snapshot_Status_Event;
-use WPCOMSpecialProjects\Wayback_Link_Fixer\Wayback_Machine\Link_Checker_Client;
 
 /**
- * Test_Link_New_Snapshot_Action
+ * Test_Report_Table_Actions
  *
  * @group Action
- * @group Link_New_Snapshot_Action
+ * @group Test_Report_Table_Actions
  */
-class Test_Link_New_Snapshot_Action extends \WP_UnitTestCase {
+class Test_Report_Table_Actions extends \WP_UnitTestCase {
 
 	private $wpdb;
 	private $link_repository;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a user selects links to have new snapshots created, this will now treat more than 5 links at a time to be processed via the action sheduler.
* Adds matching tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #169 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced batch processing for creating snapshots when selecting more than five links, with detailed notices for each processing outcome.
  * Notices now support safe HTML formatting for improved readability.

* **Bug Fixes**
  * Improved handling of links that are not found, belong to the same site, or are already archived, with clear feedback provided to users.

* **Tests**
  * Added comprehensive tests to ensure correct behavior for snapshot creation, batch processing, and notice generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->