### PR TITLE
Fix/pcp checks jul23  a

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -17,7 +17,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="wpcomsp_wayback_link_fixer"/>
+				<element value="wayback-link-fixer"/>
 			</property>
 		</properties>
 	</rule>

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
-# Team 51 Wayback Link Fixer Plugin
+# Internet Archive Wayback Machine Link Fixer
 
-**Contributors:** wpcomspecialprojects \
-**Tags:** \
-**Requires at least:** 6.4 \
-**Tested up to:** 6.5 \
-**Requires PHP:** 7.4 \
-**Stable tag:** 1.2.0   \
-**License:** GPLv3 or later \
-**License URI:** http://www.gnu.org/licenses/gpl-3.0.html
+**Contributors:** wpcomspecialprojects  
+**Tags:** wayback machine, internet archive, broken links, archive links  
+**Requires at least:** 6.4  
+**Tested up to:** 6.8  
+**Requires PHP:** 7.4  
+**Stable tag:** 1.3.0  
+**License:** GPL-3.0-or-later  
+**License URI:** https://www.gnu.org/licenses/gpl-3.0.html
 
 [![Unit Tests](https://github.com/a8cteam51/wayback-link-fixer/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/a8cteam51/wayback-link-fixer/actions/workflows/unit-tests.yml)
 
 
 ## Description
 
-Welcome to **Internet Archive Wayback Machine Link Fixer**, a WordPress plugin that helps protect your site from **LINKROT**—the slow death of links as web pages change or disappear over time. This plugin automatically scans your post content, both when saving and across existing posts, to find outbound links. For each one, it checks the Wayback Machine for an archived version and creates a new snapshot if none exists.
+**Internet Archive Wayback Machine Link Fixer** is a WordPress plugin designed to combat **link rot**—the gradual decay of web links as pages are moved, changed, or taken down. It automatically scans your post content—on save and across existing posts—to detect outbound links. For each one, it checks the Internet Archive’s Wayback Machine for an archived version and creates a snapshot if one isn’t available.
 
-As original content on the web vanishes, the plugin steps in to keep your links alive by redirecting users to reliable archived versions. It also proactively archives your own posts whenever they’re updated, ensuring your content has a consistent and preserved history.
+When a linked page disappears, the plugin helps preserve your user experience by redirecting visitors to a reliable archived version. It also works proactively by archiving your own posts every time they’re updated, creating a consistent backup of your content’s history.
 
-Maintain link integrity, preserve your content, and let the plugin handle it—automatically.
+Protect your links, preserve your content, and automate the archiving process—all with minimal effort.
+
+## Key Features
+
+- Automatically scans for outbound links in post content
+- Checks the Wayback Machine for existing archives
+- Creates new snapshots if no archive exists
+- Redirects broken or missing links to archived versions
+- Archives your own posts on updates
+- Works on both new and existing content
+- Helps maintain long-term content reliability and SEO
 
 ## Installation
 

--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -155,13 +155,13 @@ function wpcomsp_wayback_link_fixer_output_requirements_error( $error ) {
 		static function () use ( $error ) {
 			$requirements_error = wp_sprintf(
 				/* translators: 1: Plugin name, 2: Plugin version */
-				__( '<strong>%1$s (version %2$s)</strong> could not be initialized.', 'wpcomsp_wayback_link_fixer' ),
+				__( '<strong>%1$s (version %2$s)</strong> could not be initialized.', 'wayback-link-fixer' ),
 				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Name' ),
 				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Version' )
 			);
 
 			if ( $error->has_errors() ) {
-				$requirements_error .= ' ' . \__( 'Your environment does not meet all the system requirements listed below:', 'wpcomsp_wayback_link_fixer' );
+				$requirements_error .= ' ' . \__( 'Your environment does not meet all the system requirements listed below:', 'wayback-link-fixer' );
 				$requirements_error .= '<ul class="ul-disc">';
 
 				foreach ( $error->get_error_codes() as $error_code ) {
@@ -174,7 +174,7 @@ function wpcomsp_wayback_link_fixer_output_requirements_error( $error ) {
 						case 'plugin_wp_incompatible':
 							$error_message = wp_sprintf(
 								/* translators: 1: Current WP version, 2: Minimum WP version */
-								__( 'Current <em>WordPress version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
+								__( 'Current <em>WordPress version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wayback-link-fixer' ),
 								get_bloginfo( 'version' ),
 								$error_data['requires_wp']
 							);
@@ -182,13 +182,13 @@ function wpcomsp_wayback_link_fixer_output_requirements_error( $error ) {
 						case 'plugin_php_incompatible':
 							$error_message = wp_sprintf(
 								/* translators: 1: Current PHP version, 2: Minimum PHP version */
-								__( 'Current <em>PHP version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wpcomsp_wayback_link_fixer' ),
+								__( 'Current <em>PHP version (%1$s)</em> does not meet the minimum required version of %2$s.', 'wayback-link-fixer' ),
 								PHP_VERSION,
 								$error_data['requires_php']
 							);
 							break;
 						case 'missing_autoloader':
-							$error_message = __( 'The autoloader file is missing. Please run <code>composer install</code> to generate it.', 'wpcomsp_wayback_link_fixer' );
+							$error_message = __( 'The autoloader file is missing. Please run <code>composer install</code> to generate it.', 'wayback-link-fixer' );
 							break;
 						default:
 							$error_message = $error->get_error_message( $error_code );

--- a/functions.php
+++ b/functions.php
@@ -211,21 +211,6 @@ function wpcomsp_wayback_link_fixer_render_template( string $template, array $ar
 }
 
 
-
-/**
- * Enqueue select2 assets.
- *
- * @since 1.1.0
- *
- * @param array<string> $deps The dependencies.
- *
- * @return void
- */
-function wpcomsp_wayback_link_fixer_enqueue_select2_assets( array $deps = array() ): void {
-	wp_enqueue_style( 'select2-css', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', $deps, '4.1.0-rc.0' );
-	wp_enqueue_script( 'select2-js', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js', 'jquery', '4.1.0-rc.0', true );
-}
-
 /**
  * Render the CSS used for archived links in the header.
  *
@@ -234,17 +219,16 @@ function wpcomsp_wayback_link_fixer_enqueue_select2_assets( array $deps = array(
  * @return void
  */
 function wpcomsp_wayback_link_fixer_render_archived_link_css(): void {
-	$css = <<<CSS
-		.wlf-archived__redirect{
-			    color: var(--wp--preset--color--primary) !important;
-    			padding: 0 8px;
-    			font-size: 75%;
-		}
-		.wlf-archived__redirect:hover {
-			color: #005f7b;
-		}
+	$css = '
+.wlf-archived__redirect {
+    color: var(--wp--preset--color--primary) !important;
+    padding: 0 8px;
+    font-size: 75%;
 }
-CSS;
+.wlf-archived__redirect:hover {
+    color: #005f7b;
+}
+';
 
 	// Filter the css.
 	$css = apply_filters( 'wlf_archived_link_css', $css );

--- a/functions.php
+++ b/functions.php
@@ -183,7 +183,7 @@ function wpcomsp_wayback_link_fixer_render_template( string $template, array $ar
 			__FUNCTION__,
 			sprintf(
 				/* translators: %s: template path */
-				esc_html__( 'The template %s does not exist.', 'wpcomsp_wayback_link_fixer' ),
+				esc_html__( 'The template %s does not exist.', 'wayback-link-fixer' ),
 				'<code>' . esc_attr( $path ) . '</code>'
 			),
 			'1.0.0'
@@ -287,7 +287,7 @@ function wpcomsp_wayback_link_fixer_get_date_format(): string {
  * @return void
  */
 function wpcomsp_wayback_link_fixer_render_not_authenticated_notice(): void {
-	$in_unauthenticated_mode = __( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'wpcomsp_wayback_link_fixer' );
+	$in_unauthenticated_mode = __( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'wayback-link-fixer' );
 
 	// If the archive api is not configured.
 	if ( ! Settings::is_archive_api_configured() ) {
@@ -303,7 +303,7 @@ function wpcomsp_wayback_link_fixer_render_not_authenticated_notice(): void {
 
 	// If the creds are invalid.
 	if ( ! Settings::has_valid_archive_api_credentials() ) {
-		$message  = __( 'Your Archive.org API credentials are invalid. Please check your settings.', 'wpcomsp_wayback_link_fixer' );
+		$message  = __( 'Your Archive.org API credentials are invalid. Please check your settings.', 'wayback-link-fixer' );
 		$message .= ' ' . $in_unauthenticated_mode;
 		?>
 		<div class="notice notice-error">
@@ -312,7 +312,7 @@ function wpcomsp_wayback_link_fixer_render_not_authenticated_notice(): void {
 				print wp_kses_post(
 					sprintf(
 						// translators: %s is a link to the settings page.
-						__( 'Your Archive.org API credentials are invalid. <a href="%s">Please check your settings.</a>. As a result you are in in unauthenticated mode, which restricts you to 4000 new snapshots per day.', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Your Archive.org API credentials are invalid. <a href="%s">Please check your settings.</a>. As a result you are in in unauthenticated mode, which restricts you to 4000 new snapshots per day.', 'wayback-link-fixer' ),
 						esc_url( admin_url( 'options-general.php?page=' . Settings_Page::PAGE_SLUG ) )
 					)
 				);
@@ -339,7 +339,7 @@ function wpcomsp_wayback_link_fixer_render_wayback_offline_notice(): void {
 	?>
 	<div class="notice notice-error">
 		<p>
-			<?php esc_html_e( 'The Wayback Machine is currently offline. Please try again later.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'The Wayback Machine is currently offline. Please try again later.', 'wayback-link-fixer' ); ?>
 		</p>
 	</div>
 	<?php

--- a/languages/wayback-link-fixer.pot
+++ b/languages/wayback-link-fixer.pot
@@ -1,18 +1,18 @@
 # Copyright (C) 2025 WordPress.com Special Projects
-# This file is distributed under the GPL v3 or later.
+# This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Internet Archive Wayback Machine Link Fixer 1.3.0-RC5\n"
+"Project-Id-Version: Internet Archive Wayback Machine Link Fixer 1.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wayback-link-fixer\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-17T09:35:14+00:00\n"
+"POT-Creation-Date: 2025-07-23T10:09:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
-"X-Domain: wpcomsp_wayback_link_fixer\n"
+"X-Domain: wayback-link-fixer\n"
 
 #. Plugin Name of the plugin
 #: wayback-link-fixer.php
@@ -114,7 +114,7 @@ msgstr ""
 #: src/Report/Report_Page.php:96
 #: src/Report/Report_Page.php:97
 #: src/Report/Report_Page.php:278
-#: src/Settings/Settings_Page.php:416
+#: src/Settings/Settings_Page.php:413
 msgid "Link Fixer"
 msgstr ""
 
@@ -393,167 +393,167 @@ msgstr ""
 msgid "Link Fixer Settings"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:158
+#: src/Settings/Settings_Page.php:155
 msgid "Rerun The Setup Wizard"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:168
+#: src/Settings/Settings_Page.php:165
 #: templates/admin/wizard/complete.php:25
 msgid "Wayback Link Fixer Settings"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:177
+#: src/Settings/Settings_Page.php:174
 msgid "Save Changes"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:390
+#: src/Settings/Settings_Page.php:387
 msgid "Plugin Settings"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:401
+#: src/Settings/Settings_Page.php:398
 msgid "Archive.org API"
 msgstr ""
 
 #. Translators: %s is the link to the Internet account setup.
-#: src/Settings/Settings_Page.php:408
+#: src/Settings/Settings_Page.php:405
 #, php-format
 msgid "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new 'S3 access key' (this is a type of credential used by Archive.org)."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:418
-#: src/Settings/Settings_Page.php:607
+#: src/Settings/Settings_Page.php:415
+#: src/Settings/Settings_Page.php:604
 msgid "Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:429
+#: src/Settings/Settings_Page.php:426
 #: templates/admin/dashboard/widget.php:91
 msgid "Auto Archiver"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:431
+#: src/Settings/Settings_Page.php:428
 msgid "Keep your content securely archived with the Auto Archiver. Each time you update a post, a fresh copy is saved to the Wayback Machine. Ensure your work remains accessible and preserved over time."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:442
+#: src/Settings/Settings_Page.php:439
 #: templates/admin/wizard/step-2.php:35
 msgid "Enable Link Fixer"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:450
+#: src/Settings/Settings_Page.php:447
 #: templates/admin/wizard/step-2.php:45
 #: templates/admin/wizard/step-3.php:44
 msgid "Post Types"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:459
+#: src/Settings/Settings_Page.php:456
 msgid "Wipe Data on Uninstall"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:467
+#: src/Settings/Settings_Page.php:464
 msgid "Existing Posts"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:476
+#: src/Settings/Settings_Page.php:473
 msgid "Fixer Option"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:485
+#: src/Settings/Settings_Page.php:482
 msgid "Link Exclusions"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:494
-#: src/Settings/Settings_Page.php:862
+#: src/Settings/Settings_Page.php:491
+#: src/Settings/Settings_Page.php:859
 msgid "Archive.org Access Key"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:505
-#: src/Settings/Settings_Page.php:840
+#: src/Settings/Settings_Page.php:502
+#: src/Settings/Settings_Page.php:837
 msgid "Archive.org Secret Key"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:516
+#: src/Settings/Settings_Page.php:513
 msgid "Auto Archive Posts"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:524
+#: src/Settings/Settings_Page.php:521
 msgid "Routinely Archive"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:533
+#: src/Settings/Settings_Page.php:530
 msgid "Routine Interval"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:542
+#: src/Settings/Settings_Page.php:539
 msgid "Allowed Post Types"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:559
+#: src/Settings/Settings_Page.php:556
 msgid "The Archive.org API keys are invalid. Please check your settings."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:639
+#: src/Settings/Settings_Page.php:636
 msgid "Please choose which post types will have their content checked and links added to the Wayback Machine."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:669
+#: src/Settings/Settings_Page.php:666
 msgid "Please choose which post types will be automatically archived to the Wayback Machine when they are published."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:688
+#: src/Settings/Settings_Page.php:685
 msgid "If checked, this will remove all local data when the plugin is uninstalled. Leave unchecked if you plan to reinstall this plugin."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:711
+#: src/Settings/Settings_Page.php:708
 msgid "When enabled, all posts of the allowed types will be scanned, and their links will be archived in the Wayback Machine."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:714
+#: src/Settings/Settings_Page.php:711
 msgid "This runs in the background and may take hours or days, depending on post and link count."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:732
+#: src/Settings/Settings_Page.php:729
 msgid "Enter a list of URLs (or parts of URLs) to exclude from link processing. You can use an asterisk (<code>*</code>) as a wildcard. For example, <code>https://example.com/some-path/*</code> would exclude anything after '/some-path/', and <code>*twitter.com*</code> would exclude any URL containing 'twitter.com'."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:747
+#: src/Settings/Settings_Page.php:744
 msgid "Add a new exclusion (https://x.com*)"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:750
+#: src/Settings/Settings_Page.php:747
 msgid "Add"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:755
+#: src/Settings/Settings_Page.php:752
 msgid "No exclusions found."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:819
+#: src/Settings/Settings_Page.php:816
 msgid "Remove"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:882
+#: src/Settings/Settings_Page.php:879
 #: templates/admin/wizard/step-2.php:82
 msgid "Replace Link (No Notification)"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:885
+#: src/Settings/Settings_Page.php:882
 #: templates/admin/wizard/step-2.php:85
 msgid "Do Nothing"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:889
+#: src/Settings/Settings_Page.php:886
 msgid "Choose how to handle broken links."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:911
+#: src/Settings/Settings_Page.php:908
 msgid "When active, your own content will be automatically archived on the Wayback Machine each time you publish or update it."
 msgstr ""
 
-#: src/Settings/Settings_Page.php:934
+#: src/Settings/Settings_Page.php:931
 msgid "Regularly archive your posts on the Wayback Machine"
 msgstr ""
 
-#: src/Settings/Settings_Page.php:959
+#: src/Settings/Settings_Page.php:956
 msgid "Interval in days for regular archiving."
 msgstr ""
 

--- a/languages/wayback-link-fixer.pot
+++ b/languages/wayback-link-fixer.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-23T10:09:45+00:00\n"
+"POT-Creation-Date: 2025-07-23T11:10:02+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wayback-link-fixer\n"
@@ -103,17 +103,33 @@ msgstr ""
 msgid "Setup Wizard"
 msgstr ""
 
-#: src/Dashboard/Setup_Wizard.php:264
+#: src/Dashboard/Setup_Wizard.php:182
+msgid "Nonce verification failed"
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:191
+msgid "Current step is not set"
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:240
+msgid "Missing archive.org credentials"
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:246
+msgid "Next step is not set"
+msgstr ""
+
+#: src/Dashboard/Setup_Wizard.php:270
 msgid "Invalid Archive.org API credentials. Please verify your Access Key and Secret Key, or leave both fields blank to proceed without authentication."
 msgstr ""
 
-#: src/Dashboard/Setup_Wizard.php:342
+#: src/Dashboard/Setup_Wizard.php:348
 msgid "Link Fixer Setup Wizard"
 msgstr ""
 
 #: src/Report/Report_Page.php:96
 #: src/Report/Report_Page.php:97
-#: src/Report/Report_Page.php:278
+#: src/Report/Report_Page.php:281
 #: src/Settings/Settings_Page.php:413
 msgid "Link Fixer"
 msgstr ""
@@ -136,20 +152,20 @@ msgid "Table Columns"
 msgstr ""
 
 #. translators: %1$s is the post title, %2$s is the link to view all links.
-#: src/Report/Report_Page.php:294
+#: src/Report/Report_Page.php:297
 #, php-format
 msgid "Showing links for %1$s <a href=\"%2$s\">(Show all links)</a>"
 msgstr ""
 
-#: src/Report/Report_Page.php:311
+#: src/Report/Report_Page.php:314
 msgid "Search"
 msgstr ""
 
-#: src/Report/Report_Page.php:334
+#: src/Report/Report_Page.php:339
 msgid "The link does not exist."
 msgstr ""
 
-#: src/Report/Report_Page.php:346
+#: src/Report/Report_Page.php:351
 msgid "The link is not valid."
 msgstr ""
 

--- a/src/Action/Link_Latest_Snapshot_Action.php
+++ b/src/Action/Link_Latest_Snapshot_Action.php
@@ -62,7 +62,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => null,
 				'found'   => false,
 				'updated' => false,
-				'message' => __( 'Link not found.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link not found.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -72,7 +72,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => $link,
 				'found'   => false,
 				'updated' => false,
-				'message' => __( 'Service is offline.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Service is offline.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -82,7 +82,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => $link,
 				'found'   => true,
 				'updated' => false,
-				'message' => __( 'Link is already an archived link.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link is already an archived link.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -94,7 +94,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => $link,
 				'found'   => false,
 				'updated' => false,
-				'message' => __( 'No archive URL found.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'No archive URL found.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -104,7 +104,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => $link,
 				'found'   => true,
 				'updated' => false,
-				'message' => __( 'Archive URL is the same.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Archive URL is the same.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -118,7 +118,7 @@ class Link_Latest_Snapshot_Action {
 			'link'    => $link,
 			'found'   => true,
 			'updated' => true,
-			'message' => __( 'Link updated.', 'wpcomsp_wayback_link_fixer' ),
+			'message' => __( 'Link updated.', 'wayback-link-fixer' ),
 		);
 	}
 }

--- a/src/Action/Link_New_Snapshot_Action.php
+++ b/src/Action/Link_New_Snapshot_Action.php
@@ -80,7 +80,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => null,
 				'job_id'  => null,
-				'message' => __( 'Link not found', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link not found', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -92,7 +92,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => null,
 				'job_id'  => null,
-				'message' => __( 'Service is offline.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Service is offline.', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -101,7 +101,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link is an archive link already', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -114,7 +114,7 @@ class Link_New_Snapshot_Action {
 				return array(
 					'link'    => $link,
 					'job_id'  => null,
-					'message' => __( 'Exceeded snapshot limit', 'wpcomsp_wayback_link_fixer' ),
+					'message' => __( 'Exceeded snapshot limit', 'wayback-link-fixer' ),
 				);
 			} else {
 				return array(
@@ -131,7 +131,7 @@ class Link_New_Snapshot_Action {
 		return array(
 			'link'    => $link,
 			'job_id'  => $job_id,
-			'message' => __( 'Snapshot created, Link will be processed soon', 'wpcomsp_wayback_link_fixer' ),
+			'message' => __( 'Snapshot created, Link will be processed soon', 'wayback-link-fixer' ),
 		);
 	}
 }

--- a/src/Action/Validate_Link_Action.php
+++ b/src/Action/Validate_Link_Action.php
@@ -65,7 +65,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Service is offline', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Service is offline', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -73,7 +73,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => null,
 				'job_id'  => null,
-				'message' => __( 'Link not found', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link not found', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -82,7 +82,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Link is an archive link already', 'wayback-link-fixer' ),
 			);
 		}
 
@@ -95,7 +95,7 @@ class Validate_Link_Action {
 				return array(
 					'link'    => $link,
 					'job_id'  => null,
-					'message' => __( 'Exceeded snapshot limit', 'wpcomsp_wayback_link_fixer' ),
+					'message' => __( 'Exceeded snapshot limit', 'wayback-link-fixer' ),
 				);
 			} else {
 				return array(
@@ -112,7 +112,7 @@ class Validate_Link_Action {
 		return array(
 			'link'    => $link,
 			'job_id'  => $job_id,
-			'message' => __( 'Validation request created, link will be updated ASAP', 'wpcomsp_wayback_link_fixer' ),
+			'message' => __( 'Validation request created, link will be updated ASAP', 'wayback-link-fixer' ),
 		);
 	}
 }

--- a/src/Ajax/Link_Check_Ajax.php
+++ b/src/Ajax/Link_Check_Ajax.php
@@ -89,7 +89,7 @@ class Link_Check_Ajax {
 		}
 
 		// Find the link.
-		$link = $this->link_repository->find_by_url( sanitize_text_field( untrailingslashit( $_POST['link'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, Checked above.
+		$link = $this->link_repository->find_by_url( untrailingslashit( sanitize_text_field( wp_unslash( $_POST['link'] ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, Checked above.
 
 		// If the link does not exist, send an error.
 		if ( null === $link ) {
@@ -206,7 +206,7 @@ class Link_Check_Ajax {
 		}
 
 		// Verify the nonce.
-		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), self::ACTION ) ) {
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), self::ACTION ) ) {
 			throw new Exception( 'Invalid nonce.' );
 		}
 	}

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -62,7 +62,7 @@ class Dashboard_Notifications {
 	public function register_widgets(): void {
 		wp_add_dashboard_widget(
 			'wayback_link_fixer_dashboard_widget',
-			__( 'Wayback Link Fixer', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Wayback Link Fixer', 'wayback-link-fixer' ),
 			array( $this, 'render_widget' ),
 			null,
 			null,

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -179,7 +179,7 @@ class Setup_Wizard {
 
 		// verify nonce and referer
 		if ( ! check_admin_referer( 'wlf_wizard_nonce', 'wlf_wizard_nonce' ) ) {
-			$this->add_notice( 'Nonce verification failed' );
+			$this->add_notice( __( 'Nonce verification failed', 'wayback-link-fixer' ) );
 			return;
 		}
 
@@ -188,7 +188,7 @@ class Setup_Wizard {
 
 		// If current is not set, bail.
 		if ( empty( $current ) ) {
-			$this->add_notice( 'Current step is not set' );
+			$this->add_notice( __( 'Current step is not set', 'wayback-link-fixer' ) );
 			return;
 		}
 
@@ -237,7 +237,13 @@ class Setup_Wizard {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		// Check we have the 2 api creds.
 		if ( ! isset( $_POST['wlf_wizard_archive_access_key'], $_POST['wlf_wizard_archive_secret_key'] ) ) {
-			$this->add_notice( 'Missing archive.org credentials', 'error' );
+			$this->add_notice( __( 'Missing archive.org credentials', 'wayback-link-fixer' ), 'error' );
+			return;
+		}
+
+		// If next step is not set, bail.
+		if ( ! isset( $_POST['wlf-next-step'] ) ) {
+			$this->add_notice( __( 'Next step is not set', 'wayback-link-fixer' ), 'error' );
 			return;
 		}
 

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -81,7 +81,7 @@ class Setup_Wizard {
 
 		$message = sprintf(
 		// translators: %s is the URL to the setup wizard.
-			__( 'The Wayback Link Fixer plugin is almost ready. Please <a href="%s">run the setup wizard</a> to complete the installation.', 'wpcomsp_wayback_link_fixer' ),
+			__( 'The Wayback Link Fixer plugin is almost ready. Please <a href="%s">run the setup wizard</a> to complete the installation.', 'wayback-link-fixer' ),
 			esc_url( self::get_wizard_url() )
 		);
 
@@ -101,8 +101,8 @@ class Setup_Wizard {
 	public function register_setup_wizard(): void {
 		$this->page_hook = add_submenu_page(
 			Settings_Page::PAGE_SLUG,
-			__( 'Setup Wizard', 'wpcomsp_wayback_link_fixer' ),
-			__( 'Setup Wizard', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Setup Wizard', 'wayback-link-fixer' ),
+			__( 'Setup Wizard', 'wayback-link-fixer' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			function () {
@@ -261,7 +261,7 @@ class Setup_Wizard {
 
 		// Check the users api credentials.
 		if ( ! wpcomsp_wayback_link_fixer_get_system_client()->is_valid_user( $access_key, $secret_key ) ) {
-			$this->add_notice( __( 'Invalid Archive.org API credentials. Please verify your Access Key and Secret Key, or leave both fields blank to proceed without authentication.', 'wpcomsp_wayback_link_fixer' ), 'error' );
+			$this->add_notice( __( 'Invalid Archive.org API credentials. Please verify your Access Key and Secret Key, or leave both fields blank to proceed without authentication.', 'wayback-link-fixer' ), 'error' );
 			$_POST['wlf_wizard_invalid_keys'] = true; // Set a flag to indicate invalid keys.
 
 			// Hold the entered values in post.
@@ -339,7 +339,7 @@ class Setup_Wizard {
 
 		echo '<div class="wrap">';
 		echo '<h1>';
-		esc_html_e( 'Link Fixer Setup Wizard', 'wpcomsp_wayback_link_fixer' );
+		esc_html_e( 'Link Fixer Setup Wizard', 'wayback-link-fixer' );
 		echo '</h1>';
 
 		$step_data = $this->get_step_data();

--- a/src/Report/Report_Page.php
+++ b/src/Report/Report_Page.php
@@ -272,6 +272,9 @@ class Report_Page {
 		$table->render_notices();
 		wpcomsp_wayback_link_fixer_render_not_authenticated_notice();
 
+		// Get the current page.
+		$current_page = isset( $_REQUEST['page'] ) ? \sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : self::SLUG; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+
 		echo '<div class="wrap">';
 		printf(
 			'<h1 class="wp-heading-inline">%s</h1>',
@@ -282,7 +285,7 @@ class Report_Page {
 
 		// If we have a post id in params, show a message.
 		if ( array_key_exists( 'wlf_filtered_post_id', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
-			$post_id = sanitize_text_field( $_GET['wlf_filtered_post_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+			$post_id = sanitize_text_field( wp_unslash( $_GET['wlf_filtered_post_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
 
 			// Get the post title.
 			$post = get_post( $post_id );
@@ -307,7 +310,7 @@ class Report_Page {
 		// Render the table.
 		$table->prepare_items();
 		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="' . esc_attr( $_REQUEST['page'] ) . '">'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+		echo '<input type="hidden" name="page" value="' . esc_attr( $current_page ) . '">'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
 		$table->search_box( __( 'Search', 'wayback-link-fixer' ), 'wlf-link-search' );
 		$table->display();
 		echo '</form>';
@@ -325,7 +328,9 @@ class Report_Page {
 	private function render_single_page(): void {
 
 		// Get the link.
-		$link_id = absint( $_GET['wlf_link_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+		$link_id = isset( $_GET['wlf_link_id'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+			? absint( wp_unslash( $_GET['wlf_link_id'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible
+			: 0;
 
 		// If the link does not exist, show an error.
 		if ( 0 === $link_id ) {

--- a/src/Report/Report_Page.php
+++ b/src/Report/Report_Page.php
@@ -93,8 +93,8 @@ class Report_Page {
 	public function register_page(): void {
 		$hook = add_submenu_page(
 			self::PARENT_SLUG,
-			__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
-			__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Link Fixer', 'wayback-link-fixer' ),
+			__( 'Link Fixer', 'wayback-link-fixer' ),
 			'manage_options',
 			self::SLUG,
 			array( $this, 'render_page' )
@@ -159,7 +159,7 @@ class Report_Page {
 		// If the API is not online, make all options disabled.
 		if ( ! $is_online ) {
 			$actions = array(
-				'no-op' => __( 'API Offline, options disabled', 'wpcomsp_wayback_link_fixer' ),
+				'no-op' => __( 'API Offline, options disabled', 'wayback-link-fixer' ),
 			);
 			return $actions;
 		}
@@ -201,7 +201,7 @@ class Report_Page {
 		// Links per page option.
 		$option = 'per_page';
 		$args   = array(
-			'label'   => __( 'Links', 'wpcomsp_wayback_link_fixer' ),
+			'label'   => __( 'Links', 'wayback-link-fixer' ),
 			'default' => 20,
 			'option'  => 'links_per_page',
 		);
@@ -213,14 +213,14 @@ class Report_Page {
 		$screen->add_help_tab(
 			array(
 				'id'       => 'wlf_help_bulk_actions',
-				'title'    => __( 'Bulk Actions', 'wpcomsp_wayback_link_fixer' ),
+				'title'    => __( 'Bulk Actions', 'wayback-link-fixer' ),
 				'callback' => array( $this, 'render_help_bulk_actions' ),
 			)
 		);
 		$screen->add_help_tab(
 			array(
 				'id'       => 'wlf_help_table_columns',
-				'title'    => __( 'Table Columns', 'wpcomsp_wayback_link_fixer' ),
+				'title'    => __( 'Table Columns', 'wayback-link-fixer' ),
 				'callback' => array( $this, 'render_help_columns' ),
 			)
 		);
@@ -275,7 +275,7 @@ class Report_Page {
 		echo '<div class="wrap">';
 		printf(
 			'<h1 class="wp-heading-inline">%s</h1>',
-			esc_html__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
+			esc_html__( 'Link Fixer', 'wayback-link-fixer' ),
 		);
 
 		echo '<hr class="wp-header-end">';
@@ -291,7 +291,7 @@ class Report_Page {
 			if ( $post ) {
 				$body = sprintf(
 					// translators: %1$s is the post title, %2$s is the link to view all links.
-					__( 'Showing links for %1$s <a href="%2$s">(Show all links)</a>', 'wpcomsp_wayback_link_fixer' ),
+					__( 'Showing links for %1$s <a href="%2$s">(Show all links)</a>', 'wayback-link-fixer' ),
 					esc_html( $post->post_title ),
 					esc_url( self::get_page_url() ?? '' )
 				);
@@ -308,7 +308,7 @@ class Report_Page {
 		$table->prepare_items();
 		echo '<form method="get">';
 		echo '<input type="hidden" name="page" value="' . esc_attr( $_REQUEST['page'] ) . '">'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
-		$table->search_box( __( 'Search', 'wpcomsp_wayback_link_fixer' ), 'wlf-link-search' );
+		$table->search_box( __( 'Search', 'wayback-link-fixer' ), 'wlf-link-search' );
 		$table->display();
 		echo '</form>';
 
@@ -331,7 +331,7 @@ class Report_Page {
 		if ( 0 === $link_id ) {
 			printf(
 				'<div class="notice notice-error"><p>%s</p></div>',
-				esc_html__( 'The link does not exist.', 'wpcomsp_wayback_link_fixer' )
+				esc_html__( 'The link does not exist.', 'wayback-link-fixer' )
 			);
 			return;
 		}
@@ -343,7 +343,7 @@ class Report_Page {
 		if ( ! $link ) {
 			printf(
 				'<div class="notice notice-error"><p>%s</p></div>',
-				esc_html__( 'The link is not valid.', 'wpcomsp_wayback_link_fixer' )
+				esc_html__( 'The link is not valid.', 'wayback-link-fixer' )
 			);
 			return;
 		}

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -121,8 +121,8 @@ class Report_Table extends \WP_List_Table {
 			return;
 		}
 
-		$key    = sanitize_text_field( $_GET['wlf_notification'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-		$action = sanitize_text_field( $_GET['wlf_completed_action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+		$key    = sanitize_text_field( wp_unslash( $_GET['wlf_notification'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+		$action = sanitize_text_field( wp_unslash( $_GET['wlf_completed_action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 
 		// Get the cache and populate the notices.
 		$cache         = new List_Table_Action_Notification_Cache( $action );
@@ -178,7 +178,7 @@ class Report_Table extends \WP_List_Table {
 		}
 
 		// Verify the nonce and referrer.
-		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'bulk-' . $this->_args['plural'] ) && check_admin_referer( 'bulk-' . $this->_args['plural'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-' . $this->_args['plural'] ) && check_admin_referer( 'bulk-' . $this->_args['plural'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			// Add a notice.
 			$this->notices[] = array(
 				'message' => __( 'Something went wrong, please try again', 'wayback-link-fixer' ),
@@ -817,7 +817,7 @@ class Report_Table extends \WP_List_Table {
 		<?php endif; ?>
 
 		<?php if ( array_key_exists( 'wlf_filtered_post_id', $_GET ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>
-			<input type="hidden" name="wlf_filtered_post_id" value="<?php echo esc_attr( $_GET['wlf_filtered_post_id'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>" />
+			<input type="hidden" name="wlf_filtered_post_id" value="<?php echo absint( \sanitize_text_field( wp_unslash( $_GET['wlf_filtered_post_id'] ) ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>" />
 		<?php endif; ?>
 
 		<input type="submit" class="button" value="<?php esc_attr_e( 'Filter', 'wayback-link-fixer' ); ?>"  />
@@ -834,7 +834,7 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function get_status_from_url(): ?string {
 		return array_key_exists( 'wlf_status', $_GET ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? sanitize_text_field( $_GET['wlf_status'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+			? sanitize_text_field( wp_unslash( $_GET['wlf_status'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			: '';
 	}
 
@@ -845,7 +845,7 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function get_excluded_status_from_url(): ?string {
 		return array_key_exists( 'wlf_is_excluded', $_GET ) && '' !== $_GET['wlf_is_excluded'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? sanitize_text_field( $_GET['wlf_is_excluded'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+			? sanitize_text_field( wp_unslash( $_GET['wlf_is_excluded'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			: null;
 	}
 
@@ -856,7 +856,7 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function get_archived_status_from_url(): ?string {
 		return array_key_exists( 'wlf_has_archive', $_GET ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? sanitize_text_field( $_GET['wlf_has_archive'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+			? sanitize_text_field( wp_unslash( $_GET['wlf_has_archive'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			: '';
 	}
 
@@ -898,7 +898,7 @@ class Report_Table extends \WP_List_Table {
 			return Link_Repository::ORDER_ID_DESC;
 		}
 
-		$order_by = sanitize_text_field( $_GET['orderby'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+		$order_by = sanitize_text_field( wp_unslash( $_GET['orderby'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 
 		// If orderby is not a valid column, return default.
 		if ( ! in_array( $order_by, array( self::COLUMN_LINK_URL, self::COLUMN_LINK_CHECKS_LAST, self::COLUMN_LINK_ARCHIVE, self::COLUMN_LINK_CHECKS, self::COLUMN_LINK_EXCLUDE, self::COLUMN_LINK_HEALTH ), true ) ) {
@@ -907,7 +907,7 @@ class Report_Table extends \WP_List_Table {
 
 		// Get the direction.
 		$order = array_key_exists( 'order', $_GET ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? sanitize_text_field( $_GET['order'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+			? sanitize_text_field( wp_unslash( $_GET['order'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			: 'asc';
 
 		$asc_map = array(
@@ -1018,7 +1018,7 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function get_search_term(): string {
 		return array_key_exists( 's', $_GET ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
-			? sanitize_text_field( $_GET['s'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+			? sanitize_text_field( wp_unslash( $_GET['s'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			: '';
 	}
 

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -181,7 +181,7 @@ class Report_Table extends \WP_List_Table {
 		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'bulk-' . $this->_args['plural'] ) && check_admin_referer( 'bulk-' . $this->_args['plural'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			// Add a notice.
 			$this->notices[] = array(
-				'message' => __( 'Something went wrong, please try again', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'Something went wrong, please try again', 'wayback-link-fixer' ),
 				'type'    => 'error',
 			);
 
@@ -200,7 +200,7 @@ class Report_Table extends \WP_List_Table {
 
 		if ( empty( $links ) ) {
 			$this->notices[] = array(
-				'message' => __( 'No links selected.', 'wpcomsp_wayback_link_fixer' ),
+				'message' => __( 'No links selected.', 'wayback-link-fixer' ),
 				'type'    => 'error',
 			);
 			return;
@@ -229,7 +229,7 @@ class Report_Table extends \WP_List_Table {
 
 			case 'no-op':
 				$this->notices[] = array(
-					'message' => __( 'No action selected, are services offline?', 'wpcomsp_wayback_link_fixer' ),
+					'message' => __( 'No action selected, are services offline?', 'wayback-link-fixer' ),
 					'type'    => 'error',
 				);
 				$this->redirect_after_action();
@@ -238,7 +238,7 @@ class Report_Table extends \WP_List_Table {
 			default:
 				// Generate an error notification unknown action.
 				$this->notices[] = array(
-					'message' => __( 'Unknown action.', 'wpcomsp_wayback_link_fixer' ),
+					'message' => __( 'Unknown action.', 'wayback-link-fixer' ),
 					'type'    => 'error',
 				);
 				break;
@@ -312,7 +312,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %d is the link id.
-						__( 'Link not found with id:%d', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link not found with id:%d', 'wayback-link-fixer' ),
 						absint( $link_id )
 					),
 					'type'    => 'error',
@@ -325,7 +325,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'It was not possible to check %s', 'wpcomsp_wayback_link_fixer' ),
+						__( 'It was not possible to check %s', 'wayback-link-fixer' ),
 						esc_html( wpcomsp_wayback_link_fixer_trim_string( $results['link']->get_href(), 54 ) )
 					),
 					'type'    => 'error',
@@ -341,7 +341,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'Link %s has no checks.', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link %s has no checks.', 'wayback-link-fixer' ),
 						esc_html( wpcomsp_wayback_link_fixer_trim_string( $link_url, 54 ) )
 					),
 					'type'    => 'error',
@@ -353,7 +353,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %1$s is the link url, %2$s is the last check date, %3$s is the last check http code.
-					__( 'Link %1$s checked successfully on %2$s with %3$s status', 'wpcomsp_wayback_link_fixer' ),
+					__( 'Link %1$s checked successfully on %2$s with %3$s status', 'wayback-link-fixer' ),
 					esc_html( wpcomsp_wayback_link_fixer_trim_string( $link_url, 54 ) ),
 					DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )->format( get_option( 'date_format' ) ),
 					esc_html( $last_check['http_code'] )
@@ -382,7 +382,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %d is the link id.
-						__( 'Link not found with id:%d', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link not found with id:%d', 'wayback-link-fixer' ),
 						absint( $link_id )
 					),
 					'type'    => 'error',
@@ -395,7 +395,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'Link %s is already an archived link.', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link %s is already an archived link.', 'wayback-link-fixer' ),
 						esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
 					),
 					'type'    => 'notice',
@@ -408,7 +408,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'No archived link found for %s', 'wpcomsp_wayback_link_fixer' ),
+						__( 'No archived link found for %s', 'wayback-link-fixer' ),
 						esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
 					),
 					'type'    => 'error',
@@ -421,7 +421,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'It was not possible to update %s, the latest archive link is the same', 'wpcomsp_wayback_link_fixer' ),
+						__( 'It was not possible to update %s, the latest archive link is the same', 'wayback-link-fixer' ),
 						esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
 					),
 					'type'    => 'notice',
@@ -433,7 +433,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %s is the link url.
-					__( 'Link %s updated successfully', 'wpcomsp_wayback_link_fixer' ),
+					__( 'Link %s updated successfully', 'wayback-link-fixer' ),
 					esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
 				),
 				'type'    => 'success',
@@ -465,7 +465,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %d is the link id.
-						__( 'Link not found with id:%d', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link not found with id:%d', 'wayback-link-fixer' ),
 						absint( $link_id )
 					),
 					'type'    => 'error',
@@ -478,7 +478,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'Link %1$s could not have a new snapshot created: %2$s', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link %1$s could not have a new snapshot created: %2$s', 'wayback-link-fixer' ),
 						wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ),
 						esc_html( $result['message'] )
 					),
@@ -491,7 +491,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %s is the link url.
-					__( 'Link %s added to the queue and a new snapshot will be created and added as the archived url in the coming minutes..', 'wpcomsp_wayback_link_fixer' ),
+					__( 'Link %s added to the queue and a new snapshot will be created and added as the archived url in the coming minutes..', 'wayback-link-fixer' ),
 					wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 )
 				),
 				'type'    => 'success',
@@ -551,7 +551,7 @@ class Report_Table extends \WP_List_Table {
 		if ( ! empty( $link_not_found ) ) {
 			$notice .= sprintf(
 				// translators: %s is the icon for error, %d is the number of links that could not be found.
-				__( '%1$s - %2$d links could not be found.', 'wpcomsp_wayback_link_fixer' ),
+				__( '%1$s - %2$d links could not be found.', 'wayback-link-fixer' ),
 				$error_icon,
 				count( $link_not_found )
 			);
@@ -561,7 +561,7 @@ class Report_Table extends \WP_List_Table {
 		if ( ! empty( $archived_links ) ) {
 			$notice .= sprintf(
 				// translators: %s is the icon for error, %d is the number of links that are archived.
-				__( '%1$s - %2$d links that are already snapshots and will be skipped', 'wpcomsp_wayback_link_fixer' ),
+				__( '%1$s - %2$d links that are already snapshots and will be skipped', 'wayback-link-fixer' ),
 				$error_icon,
 				count( $archived_links )
 			);
@@ -581,7 +581,7 @@ class Report_Table extends \WP_List_Table {
 		if ( ! empty( $own_links ) ) {
 			$notice .= sprintf(
 				// translators: %s is the icon for error, , %d is the number of links that are own links.
-				__( '%1$s - %2$d links are from this site and will not be processed. Please enable the Auto Archiver to archive your own content.', 'wpcomsp_wayback_link_fixer' ),
+				__( '%1$s - %2$d links are from this site and will not be processed. Please enable the Auto Archiver to archive your own content.', 'wayback-link-fixer' ),
 				$error_icon,
 				count( $own_links )
 			);
@@ -597,7 +597,7 @@ class Report_Table extends \WP_List_Table {
 			$notice .= '</ul>';
 		}
 
-		$success_notice = __( '✅ - The following links were added to the queue for a new snapshot to be created:', 'wpcomsp_wayback_link_fixer' );
+		$success_notice = __( '✅ - The following links were added to the queue for a new snapshot to be created:', 'wayback-link-fixer' );
 		// If we have any where the link was added to the queue, add a notice.
 		if ( ! empty( $added_links ) ) {
 
@@ -610,7 +610,7 @@ class Report_Table extends \WP_List_Table {
 				);
 			}
 			$success_notice .= '</ul>';
-			$success_notice .= '<p>' . __( 'Snapshots are being queued for processing and will appear soon. Thanks for your patience!', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+			$success_notice .= '<p>' . __( 'Snapshots are being queued for processing and will appear soon. Thanks for your patience!', 'wayback-link-fixer' ) . '</p>';
 		}
 
 		// Add the notices.
@@ -647,7 +647,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %d is the link id.
-						__( 'Link not found with id:%d', 'wpcomsp_wayback_link_fixer' ),
+						__( 'Link not found with id:%d', 'wayback-link-fixer' ),
 						absint( $link_id )
 					),
 					'type'    => 'error',
@@ -659,7 +659,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %s is the link url.
-					__( 'Validating %s to ensure we can check its current status', 'wpcomsp_wayback_link_fixer' ),
+					__( 'Validating %s to ensure we can check its current status', 'wayback-link-fixer' ),
 					esc_html( wpcomsp_wayback_link_fixer_trim_string( $result['link']->get_href(), 54 ) )
 				),
 				'type'    => 'success',
@@ -714,16 +714,16 @@ class Report_Table extends \WP_List_Table {
 	public function get_columns() {
 		$columns = array(
 			self::COLUMN_CHECKBOX         => '<input type="checkbox" />',
-			self::COLUMN_LINK_URL         => __( 'URL', 'wpcomsp_wayback_link_fixer' ),
-			self::COLUMN_LINK_ARCHIVE     => __( 'Archive Status', 'wpcomsp_wayback_link_fixer' ),
-			self::COLUMN_LINK_HEALTH      => __( 'Link Health', 'wpcomsp_wayback_link_fixer' ),
-			self::COLUMN_LINK_CHECKS      => __( 'Times Checked', 'wpcomsp_wayback_link_fixer' ),
-			self::COLUMN_LINK_CHECKS_LAST => __( 'Last Check', 'wpcomsp_wayback_link_fixer' ),
+			self::COLUMN_LINK_URL         => __( 'URL', 'wayback-link-fixer' ),
+			self::COLUMN_LINK_ARCHIVE     => __( 'Archive Status', 'wayback-link-fixer' ),
+			self::COLUMN_LINK_HEALTH      => __( 'Link Health', 'wayback-link-fixer' ),
+			self::COLUMN_LINK_CHECKS      => __( 'Times Checked', 'wayback-link-fixer' ),
+			self::COLUMN_LINK_CHECKS_LAST => __( 'Last Check', 'wayback-link-fixer' ),
 		);
 
 		if ( Settings::show_link_table_debug_data() ) {
 			$exclude = array(
-				self::COLUMN_LINK_EXCLUDE => __( 'Link Excluded', 'wpcomsp_wayback_link_fixer' ),
+				self::COLUMN_LINK_EXCLUDE => __( 'Link Excluded', 'wayback-link-fixer' ),
 			);
 
 			// Add exclude after health.
@@ -757,13 +757,13 @@ class Report_Table extends \WP_List_Table {
 			return;
 		}
 		?>
-		<label for="wlf_status" class="screen-reader-text"><?php esc_html_e( 'Filter by status', 'wpcomsp_wayback_link_fixer' ); ?></label>
+		<label for="wlf_status" class="screen-reader-text"><?php esc_html_e( 'Filter by status', 'wayback-link-fixer' ); ?></label>
 		<select name="wlf_status" id="wlf_status">
-			<option value="all"><?php esc_html_e( 'Show valid and broken links', 'wpcomsp_wayback_link_fixer' ); ?></option>
+			<option value="all"><?php esc_html_e( 'Show valid and broken links', 'wayback-link-fixer' ); ?></option>
 			<?php
 			$statuses = array(
-				Link_Repository::LINK_STATUS_BROKEN => __( 'Show broken links', 'wpcomsp_wayback_link_fixer' ),
-				Link_Repository::LINK_STATUS_OK     => __( 'Show valid links', 'wpcomsp_wayback_link_fixer' ),
+				Link_Repository::LINK_STATUS_BROKEN => __( 'Show broken links', 'wayback-link-fixer' ),
+				Link_Repository::LINK_STATUS_OK     => __( 'Show valid links', 'wayback-link-fixer' ),
 			);
 			foreach ( $statuses as $status => $label ) {
 				printf(
@@ -776,13 +776,13 @@ class Report_Table extends \WP_List_Table {
 			?>
 		</select>
 
-		<label for="wlf_has_archive" class="screen-reader-text"><?php esc_html_e( 'Filter by archived link', 'wpcomsp_wayback_link_fixer' ); ?></label>
+		<label for="wlf_has_archive" class="screen-reader-text"><?php esc_html_e( 'Filter by archived link', 'wayback-link-fixer' ); ?></label>
 		<select name="wlf_has_archive" id="wlf_has_archive">
-			<option value=""><?php esc_html_e( 'Show with or without archived link', 'wpcomsp_wayback_link_fixer' ); ?></option>
+			<option value=""><?php esc_html_e( 'Show with or without archived link', 'wayback-link-fixer' ); ?></option>
 			<?php
 			$has_archive = array(
-				Link_Repository::LINK_HAS_ARCHIVE => __( 'Show links with archived link', 'wpcomsp_wayback_link_fixer' ),
-				Link_Repository::LINK_NO_ARCHIVE  => __( 'Show links without archived link', 'wpcomsp_wayback_link_fixer' ),
+				Link_Repository::LINK_HAS_ARCHIVE => __( 'Show links with archived link', 'wayback-link-fixer' ),
+				Link_Repository::LINK_NO_ARCHIVE  => __( 'Show links without archived link', 'wayback-link-fixer' ),
 			);
 			foreach ( $has_archive as $archive => $label ) {
 				printf(
@@ -796,13 +796,13 @@ class Report_Table extends \WP_List_Table {
 		</select>
 
 		<?php if ( Settings::show_link_table_debug_data() ) : ?>
-			<label for="wlf_is_excluded" class="screen-reader-text"><?php esc_html_e( 'Filter by excluded', 'wpcomsp_wayback_link_fixer' ); ?></label>
+			<label for="wlf_is_excluded" class="screen-reader-text"><?php esc_html_e( 'Filter by excluded', 'wayback-link-fixer' ); ?></label>
 			<select name="wlf_is_excluded" id="wlf_is_excluded">
-				<option value=""><?php esc_html_e( 'Show with or without excluded link', 'wpcomsp_wayback_link_fixer' ); ?></option>
+				<option value=""><?php esc_html_e( 'Show with or without excluded link', 'wayback-link-fixer' ); ?></option>
 				<?php
 				$has_archive = array(
-					Link_Repository::LINK_IS_EXCLUDED  => __( 'Show links that are excluded', 'wpcomsp_wayback_link_fixer' ),
-					Link_Repository::LINK_NOT_EXCLUDED => __( 'Show links that are not excluded', 'wpcomsp_wayback_link_fixer' ),
+					Link_Repository::LINK_IS_EXCLUDED  => __( 'Show links that are excluded', 'wayback-link-fixer' ),
+					Link_Repository::LINK_NOT_EXCLUDED => __( 'Show links that are not excluded', 'wayback-link-fixer' ),
 				);
 				foreach ( $has_archive as $archive => $label ) {
 					printf(
@@ -820,7 +820,7 @@ class Report_Table extends \WP_List_Table {
 			<input type="hidden" name="wlf_filtered_post_id" value="<?php echo esc_attr( $_GET['wlf_filtered_post_id'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible ?>" />
 		<?php endif; ?>
 
-		<input type="submit" class="button" value="<?php esc_attr_e( 'Filter', 'wpcomsp_wayback_link_fixer' ); ?>"  />
+		<input type="submit" class="button" value="<?php esc_attr_e( 'Filter', 'wayback-link-fixer' ); ?>"  />
 
 		<?php
 	}
@@ -948,10 +948,10 @@ class Report_Table extends \WP_List_Table {
 	 */
 	protected function get_bulk_actions(): array {
 		return array(
-			'updated_snapshot' => __( 'Update to latest snapshot', 'wpcomsp_wayback_link_fixer' ),
-			'new_snapshot'     => __( 'Create new snapshot', 'wpcomsp_wayback_link_fixer' ),
-			'check'            => __( 'Check link status', 'wpcomsp_wayback_link_fixer' ),
-			'validate'         => __( 'Verify link allows checking', 'wpcomsp_wayback_link_fixer' ),
+			'updated_snapshot' => __( 'Update to latest snapshot', 'wayback-link-fixer' ),
+			'new_snapshot'     => __( 'Create new snapshot', 'wayback-link-fixer' ),
+			'check'            => __( 'Check link status', 'wayback-link-fixer' ),
+			'validate'         => __( 'Verify link allows checking', 'wayback-link-fixer' ),
 		);
 	}
 
@@ -1127,7 +1127,7 @@ class Report_Table extends \WP_List_Table {
 
 		// If we have no checks, return N/a.
 		if ( ! $last_check ) {
-			return __( 'N/a', 'wpcomsp_wayback_link_fixer' );
+			return __( 'N/a', 'wayback-link-fixer' );
 		}
 
 		$last_check_status = $last_check['http_code'] ?? null;
@@ -1139,17 +1139,17 @@ class Report_Table extends \WP_List_Table {
 
 		$last_status_display = $last_check_status
 			? "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/{$last_check_status}\" target=\"_blank\">{$last_check_status}  status</a>"
-			: __( 'No HTTP Code', 'wpcomsp_wayback_link_fixer' );
+			: __( 'No HTTP Code', 'wayback-link-fixer' );
 
 		return sprintf(
 			// translators: %1$s is the last check date, %2$s is the last check http code.
-			__( '%1$s with %2$s', 'wpcomsp_wayback_link_fixer' ),
+			__( '%1$s with %2$s', 'wayback-link-fixer' ),
 			$last_check['date']
 				? DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )->format( get_option( 'date_format' ) )
-				: __( 'Missing date', 'wpcomsp_wayback_link_fixer' ),
+				: __( 'Missing date', 'wayback-link-fixer' ),
 			$last_check
 				? $last_status_display
-				: __( 'No HTTP Code', 'wpcomsp_wayback_link_fixer' )
+				: __( 'No HTTP Code', 'wayback-link-fixer' )
 		);
 	}
 
@@ -1161,6 +1161,6 @@ class Report_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function no_items() {
-		echo esc_html__( 'No links have been created yet.', 'wpcomsp_wayback_link_fixer' );
+		echo esc_html__( 'No links have been created yet.', 'wayback-link-fixer' );
 	}
 }

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -109,9 +109,6 @@ class Settings_Page {
 			return;
 		}
 
-		// Register select2
-		wpcomsp_wayback_link_fixer_enqueue_select2_assets( array( self::PAGE_SLUG ) );
-
 		wp_register_script(
 			self::PAGE_SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/js/build/admin_settings.js',

--- a/src/Settings/Settings_Page.php
+++ b/src/Settings/Settings_Page.php
@@ -86,8 +86,8 @@ class Settings_Page {
 	public function register_page(): void {
 		$this->menu_hook = add_submenu_page(
 			'options-general.php',
-			__( 'Wayback Link Fixer', 'wpcomsp_wayback_link_fixer' ),
-			__( 'Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Wayback Link Fixer', 'wayback-link-fixer' ),
+			__( 'Link Fixer Settings', 'wayback-link-fixer' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_page' )
@@ -152,7 +152,7 @@ class Settings_Page {
 			$wizard_link = \sprintf(
 				'<a href="%s" class="button button-primary">%s</a>',
 				esc_url( Setup_Wizard::get_wizard_url() . '&rerun-wizard=1' ),
-				esc_html__( 'Rerun The Setup Wizard', 'wpcomsp_wayback_link_fixer' )
+				esc_html__( 'Rerun The Setup Wizard', 'wayback-link-fixer' )
 			);
 		}
 
@@ -162,7 +162,7 @@ class Settings_Page {
 			<h1 class="wp-heading-inline wlf-settings__header">%s</h1>
 			%s
 			</div>',
-			esc_html__( 'Wayback Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ),
+			esc_html__( 'Wayback Link Fixer Settings', 'wayback-link-fixer' ),
 			$wizard_link // phpcs:ignore
 		);
 
@@ -171,7 +171,7 @@ class Settings_Page {
 		do_settings_sections( self::PAGE_SLUG );
 		settings_fields( self::PAGE_SLUG );
 
-		submit_button( __( 'Save Changes', 'wpcomsp_wayback_link_fixer' ) );
+		submit_button( __( 'Save Changes', 'wayback-link-fixer' ) );
 
 		echo '</form></div>';
 	}
@@ -384,7 +384,7 @@ class Settings_Page {
 	private function add_settings_fields(): void {
 		add_settings_section(
 			self::GROUP_PLUGIN_SETTINGS,
-			__( 'Plugin Settings', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Plugin Settings', 'wayback-link-fixer' ),
 			'__return_empty_string',
 			self::PAGE_SLUG,
 			array(
@@ -395,14 +395,14 @@ class Settings_Page {
 
 		add_settings_section(
 			self::GROUP_IA_SETTINGS,
-			__( 'Archive.org API', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Archive.org API', 'wayback-link-fixer' ),
 			'__return_empty_string',
 			self::PAGE_SLUG,
 			array(
 				'before_section' => '<div id="wlf_settings_ia_section" class="wlf_settings_postbox">',
 				'after_section'  => $this->render_invalid_api_keys_message() . '<p class="description">' . sprintf(
 						// Translators: %s is the link to the Internet account setup.
-					__( "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new 'S3 access key' (this is a type of credential used by Archive.org).", 'wpcomsp_wayback_link_fixer' ),
+					__( "To get your API key and secret, please visit the <a href='%s' target='_blank'>Internet Archive</a> and create a new 'S3 access key' (this is a type of credential used by Archive.org).", 'wayback-link-fixer' ),
 					esc_url( 'https://archive.org/account/s3.php' )
 				) . '</p></div>',
 			)
@@ -410,9 +410,9 @@ class Settings_Page {
 
 		add_settings_section(
 			self::GROUP_LINK_FIXER,
-			__( 'Link Fixer', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Link Fixer', 'wayback-link-fixer' ),
 			function () {
-				echo '<p class="description">' . esc_html__( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wayback-link-fixer' ) . '</p>';
 			},
 			self::PAGE_SLUG,
 			array(
@@ -423,9 +423,9 @@ class Settings_Page {
 
 		add_settings_section(
 			self::GROUP_AUTO_ARCHIVER,
-			__( 'Auto Archiver', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Auto Archiver', 'wayback-link-fixer' ),
 			function () {
-				echo '<p class="description">' . esc_html__( 'Keep your content securely archived with the Auto Archiver. Each time you update a post, a fresh copy is saved to the Wayback Machine. Ensure your work remains accessible and preserved over time.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Keep your content securely archived with the Auto Archiver. Each time you update a post, a fresh copy is saved to the Wayback Machine. Ensure your work remains accessible and preserved over time.', 'wayback-link-fixer' ) . '</p>';
 			},
 			self::PAGE_SLUG,
 			array(
@@ -436,7 +436,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::PROCESS_LINKS,
-			__( 'Enable Link Fixer', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Enable Link Fixer', 'wayback-link-fixer' ),
 			array( $this, 'render_process_links_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER
@@ -444,7 +444,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ALLOWED_POST_TYPES,
-			__( 'Post Types', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Post Types', 'wayback-link-fixer' ),
 			array( $this, 'render_fixer_post_types_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER,
@@ -453,7 +453,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::DROP_TABLES_ON_UNINSTALL_KEY,
-			__( 'Wipe Data on Uninstall', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Wipe Data on Uninstall', 'wayback-link-fixer' ),
 			array( $this, 'render_drop_tables_on_uninstall_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_PLUGIN_SETTINGS
@@ -461,7 +461,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::SCAN_EXISTING_POSTS,
-			__( 'Existing Posts', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Existing Posts', 'wayback-link-fixer' ),
 			array( $this, 'render_check_existing_posts' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER,
@@ -470,7 +470,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::FIXER_OPTION,
-			__( 'Fixer Option', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Fixer Option', 'wayback-link-fixer' ),
 			array( $this, 'render_fixer_option' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER,
@@ -479,7 +479,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::LINK_EXCLUSIONS,
-			__( 'Link Exclusions', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Link Exclusions', 'wayback-link-fixer' ),
 			array( $this, 'render_link_exclusions_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER,
@@ -488,7 +488,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ARCHIVE_ORG_ACCESS_KEY,
-			__( 'Archive.org Access Key', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Archive.org Access Key', 'wayback-link-fixer' ),
 			array( $this, 'render_archive_api_access_key' ),
 			self::PAGE_SLUG,
 			self::GROUP_IA_SETTINGS,
@@ -499,7 +499,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ARCHIVE_ORG_SECRET_KEY,
-			__( 'Archive.org Secret Key', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Archive.org Secret Key', 'wayback-link-fixer' ),
 			array( $this, 'render_archive_api_secret_key' ),
 			self::PAGE_SLUG,
 			self::GROUP_IA_SETTINGS,
@@ -510,7 +510,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ALLOW_OWN_CONTENT_SUBMISSIONS,
-			__( 'Auto Archive Posts', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Auto Archive Posts', 'wayback-link-fixer' ),
 			array( $this, 'render_allow_own_posts' ),
 			self::PAGE_SLUG,
 			self::GROUP_AUTO_ARCHIVER
@@ -518,7 +518,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE,
-			__( 'Routinely Archive', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Routinely Archive', 'wayback-link-fixer' ),
 			array( $this, 'render_own_link_routinely_update' ),
 			self::PAGE_SLUG,
 			self::GROUP_AUTO_ARCHIVER,
@@ -527,7 +527,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL,
-			__( 'Routine Interval', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Routine Interval', 'wayback-link-fixer' ),
 			array( $this, 'render_own_link_routinely_update_interval' ),
 			self::PAGE_SLUG,
 			self::GROUP_AUTO_ARCHIVER,
@@ -536,7 +536,7 @@ class Settings_Page {
 
 		add_settings_field(
 			Settings::ALLOWED_OWN_CONTENT_POST_TYPES,
-			__( 'Allowed Post Types', 'wpcomsp_wayback_link_fixer' ),
+			__( 'Allowed Post Types', 'wayback-link-fixer' ),
 			array( $this, 'render_archiver_post_types_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_AUTO_ARCHIVER,
@@ -553,7 +553,7 @@ class Settings_Page {
 	 */
 	public function render_invalid_api_keys_message(): string {
 		if ( ! Settings::has_valid_archive_api_credentials() ) {
-			return '<div id="invalid_api_creds"><p class="description">' . esc_html__( 'The Archive.org API keys are invalid. Please check your settings.', 'wpcomsp_wayback_link_fixer' ) . '</p></div>';
+			return '<div id="invalid_api_creds"><p class="description">' . esc_html__( 'The Archive.org API keys are invalid. Please check your settings.', 'wayback-link-fixer' ) . '</p></div>';
 		}
 
 		return '';
@@ -601,7 +601,7 @@ class Settings_Page {
 				value="1"
 				<?php checked( Settings::is_link_processing_enabled() ); ?>
 			/>
-			<?php esc_html_e( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break.', 'wayback-link-fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -633,7 +633,7 @@ class Settings_Page {
 			</label>
 			<?php
 		}
-		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will have their content checked and links added to the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will have their content checked and links added to the Wayback Machine.', 'wayback-link-fixer' ) . '</p>';
 	}
 
 	/**
@@ -663,7 +663,7 @@ class Settings_Page {
 			</label>
 			<?php
 		}
-		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will be automatically archived to the Wayback Machine when they are published.', 'wpcomsp_wayback_link_fixer' ) . '</p>';
+		echo '</div><p class="description">' . esc_html__( 'Please choose which post types will be automatically archived to the Wayback Machine when they are published.', 'wayback-link-fixer' ) . '</p>';
 	}
 
 	/**
@@ -682,7 +682,7 @@ class Settings_Page {
 				name="<?php echo esc_attr( Settings::DROP_TABLES_ON_UNINSTALL_KEY ); ?>"
 				value="1"
 				<?php checked( Settings::drop_tables_on_uninstall() ); ?>
-			/><?php esc_html_e( 'If checked, this will remove all local data when the plugin is uninstalled. Leave unchecked if you plan to reinstall this plugin.', 'wpcomsp_wayback_link_fixer' ); ?>
+			/><?php esc_html_e( 'If checked, this will remove all local data when the plugin is uninstalled. Leave unchecked if you plan to reinstall this plugin.', 'wayback-link-fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -705,10 +705,10 @@ class Settings_Page {
 				data-group="link_fixer"
 				<?php checked( Settings::should_scan_existing_posts() ); ?>
 			/>
-			<?php esc_html_e( 'When enabled, all posts of the allowed types will be scanned, and their links will be archived in the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'When enabled, all posts of the allowed types will be scanned, and their links will be archived in the Wayback Machine.', 'wayback-link-fixer' ); ?>
 		</label>
 		<p class="description">
-			<?php esc_html_e( 'This runs in the background and may take hours or days, depending on post and link count.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'This runs in the background and may take hours or days, depending on post and link count.', 'wayback-link-fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -726,7 +726,7 @@ class Settings_Page {
 		echo wp_kses(
 			sprintf(
 				'<div><p>%s</p></div>',
-				__( "Enter a list of URLs (or parts of URLs) to exclude from link processing. You can use an asterisk (<code>*</code>) as a wildcard. For example, <code>https://example.com/some-path/*</code> would exclude anything after '/some-path/', and <code>*twitter.com*</code> would exclude any URL containing 'twitter.com'.", 'wpcomsp_wayback_link_fixer' )
+				__( "Enter a list of URLs (or parts of URLs) to exclude from link processing. You can use an asterisk (<code>*</code>) as a wildcard. For example, <code>https://example.com/some-path/*</code> would exclude anything after '/some-path/', and <code>*twitter.com*</code> would exclude any URL containing 'twitter.com'.", 'wayback-link-fixer' )
 			),
 			array(
 				'code' => array(),
@@ -741,15 +741,15 @@ class Settings_Page {
 				<input
 					type="text"
 					id="wlf_excluded_links_new"
-					placeholder="<?php esc_html_e( 'Add a new exclusion (https://x.com*)', 'wpcomsp_wayback_link_fixer' ); ?>"
+					placeholder="<?php esc_html_e( 'Add a new exclusion (https://x.com*)', 'wayback-link-fixer' ); ?>"
 					data-group="link_fixer"
 				/>
-				<button id="wlf_excluded_links_new_action" data-group="link_fixer" type="button" class="button button-secondary add-exclusion"><?php esc_html_e( 'Add', 'wpcomsp_wayback_link_fixer' ); ?></button>
+				<button id="wlf_excluded_links_new_action" data-group="link_fixer" type="button" class="button button-secondary add-exclusion"><?php esc_html_e( 'Add', 'wayback-link-fixer' ); ?></button>
 			</div>
 
 			<div id="wlf_excluded_empty" style="display: <?php echo empty( $urls ) ? 'block' : 'none'; ?>;">
 				<p>
-					<?php esc_html_e( 'No exclusions found.', 'wpcomsp_wayback_link_fixer' ); ?>
+					<?php esc_html_e( 'No exclusions found.', 'wayback-link-fixer' ); ?>
 				</p>
 			</div>
 				<?php
@@ -813,7 +813,7 @@ class Settings_Page {
 			esc_attr( $url ),
 			esc_attr( $url ),
 			esc_attr( $index ),
-			esc_html__( 'Remove', 'wpcomsp_wayback_link_fixer' )
+			esc_html__( 'Remove', 'wayback-link-fixer' )
 		);
 	}
 
@@ -834,7 +834,7 @@ class Settings_Page {
 			style="width:80%;"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Archive.org Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Archive.org Secret Key', 'wayback-link-fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -856,7 +856,7 @@ class Settings_Page {
 			style="width:80%;"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Archive.org Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Archive.org Access Key', 'wayback-link-fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -876,14 +876,14 @@ class Settings_Page {
 			data-group="link_fixer"
 		>
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
-				<?php esc_html_e( 'Replace Link (No Notification)', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Replace Link (No Notification)', 'wayback-link-fixer' ); ?>
 			</option>
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
-				<?php esc_html_e( 'Do Nothing', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Do Nothing', 'wayback-link-fixer' ); ?>
 			</option>
 		</select>
 		<p class="description">
-			<?php esc_html_e( 'Choose how to handle broken links.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Choose how to handle broken links.', 'wayback-link-fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -905,7 +905,7 @@ class Settings_Page {
 				value="1"
 				<?php checked( Settings::add_own_links() ); ?>
 			/>
-			<?php esc_html_e( 'When active, your own content will be automatically archived on the Wayback Machine each time you publish or update it.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'When active, your own content will be automatically archived on the Wayback Machine each time you publish or update it.', 'wayback-link-fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -928,7 +928,7 @@ class Settings_Page {
 				data-group="auto_archiver"
 				<?php checked( Settings::own_link_routinely_update() ); ?>
 			/>
-			<?php esc_html_e( 'Regularly archive your posts on the Wayback Machine', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Regularly archive your posts on the Wayback Machine', 'wayback-link-fixer' ); ?>
 		</label>
 		<?php
 	}
@@ -953,7 +953,7 @@ class Settings_Page {
 			data-group="auto_archiver"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Interval in days for regular archiving.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Interval in days for regular archiving.', 'wayback-link-fixer' ); ?>
 		</p>
 		<?php
 	}

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -111,7 +111,7 @@ class WP_Post_Table_Controller {
 		}
 
 		// Add the column.
-		$columns[ self::LINK_COLUMN_KEY ] = __( 'Links', 'wpcomsp_wayback_link_fixer' );
+		$columns[ self::LINK_COLUMN_KEY ] = __( 'Links', 'wayback-link-fixer' );
 
 		return $columns;
 	}
@@ -148,14 +148,14 @@ class WP_Post_Table_Controller {
 
 		// If we have no links, show a message.
 		if ( empty( $stats['total'] ) ) {
-			echo esc_html__( 'No links found', 'wpcomsp_wayback_link_fixer' );
+			echo esc_html__( 'No links found', 'wayback-link-fixer' );
 			return;
 		}
 
 		print wp_kses(
 			sprintf(
 			// translators: %2$s is the url to view the links in a report, %2$s is the number of broken links, %3$s is the total number of links.
-				__( '<a href="%1$s"><strong>%2$s</strong> broken out of <strong>%3$s</strong></a>', 'wpcomsp_wayback_link_fixer' ),
+				__( '<a href="%1$s"><strong>%2$s</strong> broken out of <strong>%3$s</strong></a>', 'wayback-link-fixer' ),
 				$this->generate_report_page_url( $links, $post_id ),
 				absint( $stats['broken'] ),
 				absint( $stats['total'] )

--- a/src/Wayback_Machine/Exception/Exceeded_Snapshot_Limit_Exception.php
+++ b/src/Wayback_Machine/Exception/Exceeded_Snapshot_Limit_Exception.php
@@ -27,6 +27,6 @@ class Exceeded_Snapshot_Limit_Exception extends Exception {
 	 * @return Exceeded_Snapshot_Limit_Exception
 	 */
 	public static function create(): Exceeded_Snapshot_Limit_Exception {
-		return new Exceeded_Snapshot_Limit_Exception( esc_html( __( 'Snapshot creation limit exceeded', 'wpcomsp_wayback_link_fixer' ) ) );
+		return new Exceeded_Snapshot_Limit_Exception( esc_html( __( 'Snapshot creation limit exceeded', 'wayback-link-fixer' ) ) );
 	}
 }

--- a/src/Wayback_Machine/Exception/Invalid_Response_Exception.php
+++ b/src/Wayback_Machine/Exception/Invalid_Response_Exception.php
@@ -28,6 +28,6 @@ class Invalid_Response_Exception extends Exception {
 	 * @return Invalid_Response_Exception
 	 */
 	public static function create( string $message = ' ' ): Invalid_Response_Exception {
-		return new Invalid_Response_Exception( esc_html( __( 'The response is invalid.', 'wpcomsp_wayback_link_fixer' ) . $message ) );
+		return new Invalid_Response_Exception( esc_html( __( 'The response is invalid.', 'wayback-link-fixer' ) . $message ) );
 	}
 }

--- a/src/Wayback_Machine/Exception/Service_Offline_Exception.php
+++ b/src/Wayback_Machine/Exception/Service_Offline_Exception.php
@@ -30,7 +30,7 @@ class Service_Offline_Exception extends Exception {
 		return new Service_Offline_Exception(
 			sprintf(
 				// translators: %s is the message.
-				__( 'The service is offline.%s', 'wpcomsp_wayback_link_fixer' ),
+				__( 'The service is offline.%s', 'wayback-link-fixer' ),
 				'' !== $message ? esc_html( ' ' . $message ) : ''
 			)
 		);

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -23,13 +23,13 @@ defined( 'ABSPATH' ) || exit;
 <div class="wlf_dashboard-wrapper">
 	<?php if ( ! $wlf_api_configured ) : ?>
 		<div class="wlf_dashboard-warning">
-			<?php esc_html_e( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'wayback-link-fixer' ); ?>
 		</div>
 	<?php endif; ?>
 
 	<?php if ( $wlf_api_configured && ! \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings::has_valid_archive_api_credentials() ) : ?>
 		<div class="wlf_dashboard-warning">
-			<?php esc_html_e( 'Your Archive.org API credentials are invalid. Please check your settings.', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Your Archive.org API credentials are invalid. Please check your settings.', 'wayback-link-fixer' ); ?>
 		</div>
 	<?php endif; ?>
 
@@ -38,8 +38,8 @@ defined( 'ABSPATH' ) || exit;
 		<strong>
 			<?php
 			echo $wlf_is_online
-				? esc_html__( 'Archive.org API services are online.', 'wpcomsp_wayback_link_fixer' )
-				: esc_html__( 'Archive.org API is offline. Processes will be delayed, until service is resumed.', 'wpcomsp_wayback_link_fixer' );
+				? esc_html__( 'Archive.org API services are online.', 'wayback-link-fixer' )
+				: esc_html__( 'Archive.org API is offline. Processes will be delayed, until service is resumed.', 'wayback-link-fixer' );
 			?>
 		</strong>
 	</div>
@@ -58,13 +58,13 @@ defined( 'ABSPATH' ) || exit;
 						?>
 					</div>
 					<div class="wlf_dashboard-stats-label">
-						<?php esc_html_e( "Today's Snapshots", 'wpcomsp_wayback_link_fixer' ); ?>
+						<?php esc_html_e( "Today's Snapshots", 'wayback-link-fixer' ); ?>
 					</div>
 				</div>
 				<div class="wlf_dashboard-stats-box">
 					<div class="wlf_dashboard-stats-number"><?php echo esc_html( absint( $wlf_details['processing'] ) ); ?></div>
 					<div class="wlf_dashboard-stats-label">
-						<?php esc_html_e( 'Pending Snapshots', 'wpcomsp_wayback_link_fixer' ); ?>
+						<?php esc_html_e( 'Pending Snapshots', 'wayback-link-fixer' ); ?>
 					</div>
 				</div>
 			</div>
@@ -72,15 +72,15 @@ defined( 'ABSPATH' ) || exit;
 	<?php endif; ?>
 
 	<div class="wlf_dashboard-status-section">
-		<h3 class="wlf_dashboard-section-title"><?php esc_html_e( 'Active Features', 'wpcomsp_wayback_link_fixer' ); ?></h3>
+		<h3 class="wlf_dashboard-section-title"><?php esc_html_e( 'Active Features', 'wayback-link-fixer' ); ?></h3>
 		<div class="wlf_dashboard-features">
 			<div class="wlf_dashboard-features-item">
 				<span class="wlf_dashboard-features-status <?php echo esc_attr( $wlf_link_processing_enabled ? 'enabled' : 'disabled' ); ?>">
 					<span class="dashicons <?php echo esc_attr( $wlf_link_processing_enabled ? 'dashicons-yes-alt' : 'dashicons-no-alt' ); ?>"></span>
 				</span>
 				<div class="wlf_dashboard-features-content">
-					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Link Processing', 'wpcomsp_wayback_link_fixer' ); ?></span>
-					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Create snapshots of external links when posts are created or updated', 'wpcomsp_wayback_link_fixer' ); ?></div>
+					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Link Processing', 'wayback-link-fixer' ); ?></span>
+					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Create snapshots of external links when posts are created or updated', 'wayback-link-fixer' ); ?></div>
 				</div>
 			</div>
 			<div class="wlf_dashboard-features-item">
@@ -88,8 +88,8 @@ defined( 'ABSPATH' ) || exit;
 					<span class="dashicons <?php echo esc_attr( $wlf_auto_archiver_enabled ? 'dashicons-yes-alt' : 'dashicons-no-alt' ); ?>"></span>
 				</span>
 				<div class="wlf_dashboard-features-content">
-					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Auto Archiver', 'wpcomsp_wayback_link_fixer' ); ?></span>
-					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Create snapshots of your own content', 'wpcomsp_wayback_link_fixer' ); ?></div>
+					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Auto Archiver', 'wayback-link-fixer' ); ?></span>
+					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Create snapshots of your own content', 'wayback-link-fixer' ); ?></div>
 				</div>
 			</div>
 			<div class="wlf_dashboard-features-item">
@@ -97,8 +97,8 @@ defined( 'ABSPATH' ) || exit;
 					<span class="dashicons <?php echo esc_attr( $wlf_scan_existing_enabled ? 'dashicons-yes-alt' : 'dashicons-no-alt' ); ?>"></span>
 				</span>
 				<div class="wlf_dashboard-features-content">
-					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Scan Existing Posts', 'wpcomsp_wayback_link_fixer' ); ?></span>
-					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Process links in previously published content', 'wpcomsp_wayback_link_fixer' ); ?></div>
+					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Scan Existing Posts', 'wayback-link-fixer' ); ?></span>
+					<div class="wlf_dashboard-features-description"><?php esc_html_e( 'Process links in previously published content', 'wayback-link-fixer' ); ?></div>
 				</div>
 			</div>
 			<div class="wlf_dashboard-features-item">
@@ -106,13 +106,13 @@ defined( 'ABSPATH' ) || exit;
 					<span class="dashicons dashicons-clock"></span>
 				</span>
 				<div class="wlf_dashboard-features-content">
-					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Link Checking', 'wpcomsp_wayback_link_fixer' ); ?></span>
+					<span class="wlf_dashboard-features-label"><?php esc_html_e( 'Link Checking', 'wayback-link-fixer' ); ?></span>
 					<div class="wlf_dashboard-features-description">
 						<?php if ( $wlf_link_processing_enabled ) : ?>
 							<?php
 							printf(
 								/* translators: 1: number of days between checks, 2: number of failed checks before marking as broken */
-								esc_html__( 'Links are checked every %1$d days and marked as broken after %2$d consecutive failures', 'wpcomsp_wayback_link_fixer' ),
+								esc_html__( 'Links are checked every %1$d days and marked as broken after %2$d consecutive failures', 'wayback-link-fixer' ),
 								absint( $wlf_link_check_duration ),
 								absint( $wlf_failed_check_count )
 							);
@@ -121,7 +121,7 @@ defined( 'ABSPATH' ) || exit;
 							<?php
 							printf(
 								/* translators: 1: opening link tag, 2: closing link tag */
-								esc_html__( 'Links are not being checked. %1$sEnable Link Processing%2$s to turn this back on.', 'wpcomsp_wayback_link_fixer' ),
+								esc_html__( 'Links are not being checked. %1$sEnable Link Processing%2$s to turn this back on.', 'wayback-link-fixer' ),
 								'<a href="' . esc_url( $wlf_link_to_settings ) . '">',
 								'</a>'
 							);
@@ -136,14 +136,14 @@ defined( 'ABSPATH' ) || exit;
 	<div class="wlf_dashboard-navigation">
 		<a href="<?php echo esc_url( $wlf_link_to_settings ); ?>" class="button">
 			<span class="dashicons dashicons-admin-settings" style="margin-top: 3px;"></span>
-			<?php esc_html_e( 'Settings', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Settings', 'wayback-link-fixer' ); ?>
 		</a>
 		<a href="<?php echo esc_url( $wlf_link_table ); ?>" class="button">
 			<span class="dashicons dashicons-list-view" style="margin-top: 3px;"></span>
 			<?php
 			printf(
 				/* translators: %d: number of links */
-				esc_html__( 'View Links (%d)', 'wpcomsp_wayback_link_fixer' ),
+				esc_html__( 'View Links (%d)', 'wayback-link-fixer' ),
 				count( $wlf_total_links )
 			);
 			?>

--- a/templates/admin/links-table/help-tab-bulk-actions.php
+++ b/templates/admin/links-table/help-tab-bulk-actions.php
@@ -7,15 +7,15 @@
 
 ?>
 <div id="wlf_help_tab_bulk_actions" class="wlf_help_tab">
-	<h3><?php esc_html_e( 'Update to latest snapshot', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'When this option is selected, the link will have its archive updated to the latest snapshot available from the Internet Archive.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Update to latest snapshot', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'When this option is selected, the link will have its archive updated to the latest snapshot available from the Internet Archive.', 'wayback-link-fixer' ); ?></p>
 
-	<h3><?php esc_html_e( 'Create new snapshot', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'When this option is selected, a request to create a new snapshot of the link on the Internet Archive will be made. This process can take some time, depending on the Archive.org systems. The link\'s archived version in your records will be updated once the snapshot is complete and available.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Create new snapshot', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'When this option is selected, a request to create a new snapshot of the link on the Internet Archive will be made. This process can take some time, depending on the Archive.org systems. The link\'s archived version in your records will be updated once the snapshot is complete and available.', 'wayback-link-fixer' ); ?></p>
 
-	<h3><?php esc_html_e( 'Check link status', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'This option checks the current status and availability of the live link.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Check link status', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'This option checks the current status and availability of the live link.', 'wayback-link-fixer' ); ?></p>
 
-	<h3><?php esc_html_e( 'Verify Link Can Be Checked', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'This action checks if the link\'s host (e.g., via robots.txt or meta tags) or your plugin settings prevent the link from being archived or checked. It helps determine if a link should be excluded.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Verify Link Can Be Checked', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'This action checks if the link\'s host (e.g., via robots.txt or meta tags) or your plugin settings prevent the link from being archived or checked. It helps determine if a link should be excluded.', 'wayback-link-fixer' ); ?></p>
 </div>

--- a/templates/admin/links-table/help-tab-columns.php
+++ b/templates/admin/links-table/help-tab-columns.php
@@ -10,46 +10,46 @@ $wlf_check_frequency = \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Setting
 ?>
 
 <div id="wlf_help_tab_columns" class="wlf_help_tab">
-	<h3><?php esc_html_e( 'Archive Status', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'Indicates whether the link has a valid snapshot from the Internet Archive associated with it.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Archive Status', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'Indicates whether the link has a valid snapshot from the Internet Archive associated with it.', 'wayback-link-fixer' ); ?></p>
 	<p>
-		<span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e( 'Has a valid archive snapshot', 'wpcomsp_wayback_link_fixer' ); ?><br>
-		<span class="dashicons dashicons-plus-alt"></span> <?php esc_html_e( 'New link, not yet processed', 'wpcomsp_wayback_link_fixer' ); ?><br>
-		<span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Processing in progress', 'wpcomsp_wayback_link_fixer' ); ?><br>
-		<span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No archive available', 'wpcomsp_wayback_link_fixer' ); ?>
+		<span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e( 'Has a valid archive snapshot', 'wayback-link-fixer' ); ?><br>
+		<span class="dashicons dashicons-plus-alt"></span> <?php esc_html_e( 'New link, not yet processed', 'wayback-link-fixer' ); ?><br>
+		<span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Processing in progress', 'wayback-link-fixer' ); ?><br>
+		<span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No archive available', 'wayback-link-fixer' ); ?>
 	</p>
 
-	<h3><?php esc_html_e( 'Link Health', 'wpcomsp_wayback_link_fixer' ); ?></h3>
+	<h3><?php esc_html_e( 'Link Health', 'wayback-link-fixer' ); ?></h3>
 	<p>
 		<?php
 		echo esc_html(
 			sprintf(
 				// translators: %d is the number of consecutive failed checks required to mark a link as broken.
-				__( 'Indicates whether the live link is active or broken. A link is marked as broken after %d consecutive failed checks.', 'wpcomsp_wayback_link_fixer' ),
+				__( 'Indicates whether the live link is active or broken. A link is marked as broken after %d consecutive failed checks.', 'wayback-link-fixer' ),
 				$wlf_failed_count
 			)
 		);
 		?>
 	</p>
 	<p>
-		<span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e( 'Link is active', 'wpcomsp_wayback_link_fixer' ); ?><br>
-		<span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Link status pending verification', 'wpcomsp_wayback_link_fixer' ); ?><br>
-		<span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'Link is broken', 'wpcomsp_wayback_link_fixer' ); ?>
+		<span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e( 'Link is active', 'wayback-link-fixer' ); ?><br>
+		<span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Link status pending verification', 'wayback-link-fixer' ); ?><br>
+		<span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'Link is broken', 'wayback-link-fixer' ); ?>
 	</p>
 
-	<h3><?php esc_html_e( 'Times Checked', 'wpcomsp_wayback_link_fixer' ); ?></h3>
+	<h3><?php esc_html_e( 'Times Checked', 'wayback-link-fixer' ); ?></h3>
 	<p>
 		<?php
 		echo esc_html(
 			sprintf(
 				// translators: %d is the number of days between checks.
-				__( 'Shows how many times the link has been checked. Links are automatically checked every %d days.', 'wpcomsp_wayback_link_fixer' ),
+				__( 'Shows how many times the link has been checked. Links are automatically checked every %d days.', 'wayback-link-fixer' ),
 				$wlf_check_frequency
 			)
 		);
 		?>
 	</p>
 
-	<h3><?php esc_html_e( 'Last Check', 'wpcomsp_wayback_link_fixer' ); ?></h3>
-	<p><?php esc_html_e( 'Displays the date and result (e.g., HTTP status code) of the most recent check on the live link, if available.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<h3><?php esc_html_e( 'Last Check', 'wayback-link-fixer' ); ?></h3>
+	<p><?php esc_html_e( 'Displays the date and result (e.g., HTTP status code) of the most recent check on the live link, if available.', 'wayback-link-fixer' ); ?></p>
 </div>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -23,7 +23,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 ?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( $wlf_link_title ); ?></h1>
-	<a class="page-title-action" href="<?php echo esc_url( $wlf_back_url ); ?>"><?php esc_html_e( 'Back to All Links', 'wpcomsp_wayback_link_fixer' ); ?></a>
+	<a class="page-title-action" href="<?php echo esc_url( $wlf_back_url ); ?>"><?php esc_html_e( 'Back to All Links', 'wayback-link-fixer' ); ?></a>
 	<hr class="wp-header-end">
 
 
@@ -33,51 +33,51 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 				<div id="normal-sortables" class="meta-box-sortables ui-sortable">
 					<div id="wlf_link_details" class="postbox ">
 						<div class="postbox-header">
-							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Link Details', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Link Details', 'wayback-link-fixer' ); ?></h2>
 						</div>
 						<div class="inside">
-							<p class="wlf_link_url"><strong><?php esc_html_e( 'URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <a href="<?php echo esc_url( $wlf_link->get_href() ); ?>" target="_blank"><?php echo esc_html( $wlf_link->get_href() ); ?></a></p>
+							<p class="wlf_link_url"><strong><?php esc_html_e( 'URL', 'wayback-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $wlf_link->get_href() ); ?>" target="_blank"><?php echo esc_html( $wlf_link->get_href() ); ?></a></p>
 
 							<?php if ( $wlf_link->is_excluded() ) : ?>
-								<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archive Status', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'EXCLUDED', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archive Status', 'wayback-link-fixer' ); ?></strong>: <?php esc_html_e( 'EXCLUDED', 'wayback-link-fixer' ); ?></p>
 							<?php else : ?>
 								<p class="wlf_link_archived_url">
-									<strong><?php esc_html_e( 'Archive Status', 'wpcomsp_wayback_link_fixer' ); ?></strong>:
+									<strong><?php esc_html_e( 'Archive Status', 'wayback-link-fixer' ); ?></strong>:
 									<?php
 									if ( ! $wlf_link->is_processed() ) {
 										$wlf_archive_process = $wlf_link->get_archive_process();
 										if ( Link::PROCESS_NEW === $wlf_archive_process ) {
-											esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible', 'wpcomsp_wayback_link_fixer' );
+											esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible', 'wayback-link-fixer' );
 										} else {
-											esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'wpcomsp_wayback_link_fixer' );
+											esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'wayback-link-fixer' );
 										}
 									} elseif ( '' !== $wlf_link->get_archived_href() ) {
 										printf(
 											/* translators: %s: The archived URL */
-											esc_html__( 'HAS ARCHIVE - A snapshot of this link is available on the Internet Archive: %s', 'wpcomsp_wayback_link_fixer' ),
-											'<a href="' . esc_url( $wlf_link->get_archived_href() ) . '" target="_blank">' . esc_html__( 'View Snapshot', 'wpcomsp_wayback_link_fixer' ) . '</a>'
+											esc_html__( 'HAS ARCHIVE - A snapshot of this link is available on the Internet Archive: %s', 'wayback-link-fixer' ),
+											'<a href="' . esc_url( $wlf_link->get_archived_href() ) . '" target="_blank">' . esc_html__( 'View Snapshot', 'wayback-link-fixer' ) . '</a>'
 										);
 									} else {
-										esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible', 'wpcomsp_wayback_link_fixer' );
+										esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible', 'wayback-link-fixer' );
 									}
 									?>
 								</p>
 
 								<?php if ( '' !== $wlf_link->get_archived_href() ) : ?>
-									<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <a href="<?php echo esc_url( $wlf_link->get_archived_href() ); ?>" target="_blank"><?php echo esc_html( $wlf_link->get_archived_href() ); ?></a></p>
+									<p class="wlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'wayback-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $wlf_link->get_archived_href() ); ?>" target="_blank"><?php echo esc_html( $wlf_link->get_archived_href() ); ?></a></p>
 								<?php endif; ?>
 							<?php endif; ?>
 
 							<?php if ( '' !== $wlf_link->get_redirect_href() ) : ?>
-								<p class="wlf_link_redirected_url"><strong><?php esc_html_e( 'Redirects To', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_redirect_href() ); ?></p>
+								<p class="wlf_link_redirected_url"><strong><?php esc_html_e( 'Redirects To', 'wayback-link-fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_redirect_href() ); ?></p>
 							<?php endif; ?>
 
 							<?php if ( '' !== $wlf_link->get_message() ) : ?>
-								<p class="wlf_link_message"><strong><?php esc_html_e( 'Message', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_message() ); ?></p>
+								<p class="wlf_link_message"><strong><?php esc_html_e( 'Message', 'wayback-link-fixer' ); ?></strong>: <?php echo esc_html( $wlf_link->get_message() ); ?></p>
 							<?php endif; ?>
 
 							<?php if ( $wlf_link->is_excluded() ) : ?>
-								<p class="wlf_link_excluded"><strong><?php esc_html_e( 'Excluded', 'wpcomsp_wayback_link_fixer' ); ?></strong>: <?php esc_html_e( 'This link is excluded from processing (e.g., by robots.txt or your exclusion settings).', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p class="wlf_link_excluded"><strong><?php esc_html_e( 'Excluded', 'wayback-link-fixer' ); ?></strong>: <?php esc_html_e( 'This link is excluded from processing (e.g., by robots.txt or your exclusion settings).', 'wayback-link-fixer' ); ?></p>
 							<?php endif; ?>
 						</div>
 					</div>
@@ -85,22 +85,22 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 
 					<div id="wlf_link_checks" class="postbox ">
 						<div class="postbox-header">
-							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Link Checks', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Link Checks', 'wayback-link-fixer' ); ?></h2>
 						</div>
 						<div class="inside">
 							<p class="wlf_link_broken">
 								<?php
 								$wlf_normal_state_string = ( 0 === count( $wlf_link->get_checks() ) )
-									? esc_html__( 'Not yet checked', 'wpcomsp_wayback_link_fixer' )
+									? esc_html__( 'Not yet checked', 'wayback-link-fixer' )
 									: sprintf(
 										// translators: %d is the number of consecutive failures required to mark a link as 'Broken'.
-										esc_html__( 'Monitoring: Link will be marked as \'Broken\' after %d consecutive failures.', 'wpcomsp_wayback_link_fixer' ),
+										esc_html__( 'Monitoring: Link will be marked as \'Broken\' after %d consecutive failures.', 'wayback-link-fixer' ),
 										Settings::get_failed_count()
 									);
 								printf(
 									'<strong>%s</strong>: %s',
-									esc_html__( 'Current Status', 'wpcomsp_wayback_link_fixer' ),
-									$wlf_link->is_broken() ? esc_html__( 'Broken', 'wpcomsp_wayback_link_fixer' ) : esc_html( $wlf_normal_state_string )
+									esc_html__( 'Current Status', 'wayback-link-fixer' ),
+									$wlf_link->is_broken() ? esc_html__( 'Broken', 'wayback-link-fixer' ) : esc_html( $wlf_normal_state_string )
 								);
 								?>
 							</p>
@@ -108,14 +108,14 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 							<table class="wp-list-table widefat fixed striped">
 								<thead>
 									<tr>
-										<th><?php esc_html_e( 'Date', 'wpcomsp_wayback_link_fixer' ); ?></th>
-										<th><?php esc_html_e( 'Status', 'wpcomsp_wayback_link_fixer' ); ?></th>
+										<th><?php esc_html_e( 'Date', 'wayback-link-fixer' ); ?></th>
+										<th><?php esc_html_e( 'Status', 'wayback-link-fixer' ); ?></th>
 									</tr>
 								</thead>
 								<tbody>
 									<?php if ( 0 === count( $wlf_link->get_checks() ) ) : ?>
 										<tr>
-											<td colspan="2"><?php esc_html_e( 'No check history for this link yet.', 'wpcomsp_wayback_link_fixer' ); ?></td>
+											<td colspan="2"><?php esc_html_e( 'No check history for this link yet.', 'wayback-link-fixer' ); ?></td>
 										</tr>
 									<?php endif; ?>
 
@@ -123,7 +123,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 										<tr id="wlf_reveal_hidden_checks">
 											<td colspan="2">
 												<button class="button" id="wlf_show_hidden_checks">
-													<?php esc_html_e( 'Show Older Checks', 'wpcomsp_wayback_link_fixer' ); ?>
+													<?php esc_html_e( 'Show Older Checks', 'wayback-link-fixer' ); ?>
 												</button>
 											</td>
 										</tr>
@@ -140,7 +140,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 												<?php if ( is_numeric( $wlf_check['http_code'] ) ) : ?>
 													<td class="wlf-archived__http-code"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/<?php echo esc_attr( $wlf_check['http_code'] ); ?>" target="_blank"><?php echo esc_html( $wlf_check['http_code'] ); ?></a></td>
 												<?php else : ?>
-													<td class="wlf-archived__error"><?php esc_html_e( 'Error', 'wpcomsp_wayback_link_fixer' ); ?></td>
+													<td class="wlf-archived__error"><?php esc_html_e( 'Error', 'wayback-link-fixer' ); ?></td>
 												<?php endif; ?>
 											</tr>
 									<?php endforeach; ?>
@@ -151,19 +151,19 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 
 					<div id="wlf_link_posts" class="postbox ">
 						<div class="postbox-header">
-							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Found In', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Found In', 'wayback-link-fixer' ); ?></h2>
 						</div>
 						<div class="inside">
 							<?php if ( empty( $wlf_posts ) ) : ?>
-								<p><?php esc_html_e( 'This link has not been found in any posts yet.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+								<p><?php esc_html_e( 'This link has not been found in any posts yet.', 'wayback-link-fixer' ); ?></p>
 							<?php else : ?>
 								<table class="wp-list-table widefat fixed striped">
 									<thead>
 										<tr>
-											<th><?php esc_html_e( 'Post', 'wpcomsp_wayback_link_fixer' ); ?></th>
-											<th><?php esc_html_e( 'Post Type', 'wpcomsp_wayback_link_fixer' ); ?></th>
-											<th><?php esc_html_e( 'Status', 'wpcomsp_wayback_link_fixer' ); ?></th>
-											<th><?php esc_html_e( 'Actions', 'wpcomsp_wayback_link_fixer' ); ?></th>
+											<th><?php esc_html_e( 'Post', 'wayback-link-fixer' ); ?></th>
+											<th><?php esc_html_e( 'Post Type', 'wayback-link-fixer' ); ?></th>
+											<th><?php esc_html_e( 'Status', 'wayback-link-fixer' ); ?></th>
+											<th><?php esc_html_e( 'Actions', 'wayback-link-fixer' ); ?></th>
 										</tr>
 									</thead>
 									<tbody>
@@ -175,7 +175,7 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 															<?php
 															printf(
 																// Translators: %1$s is the post ID, %2$s is the post type label (e.g., "Post", "Page").
-																esc_html__( 'Untitled %2$s (ID: %1$d)', 'wpcomsp_wayback_link_fixer' ),
+																esc_html__( 'Untitled %2$s (ID: %1$d)', 'wayback-link-fixer' ),
 																absint( $wlf_post->ID ),
 																esc_html( get_post_type_object( $wlf_post->post_type )->labels->singular_name )
 															);
@@ -192,24 +192,24 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 													$wlf_post_status = get_post_status( $wlf_post->ID );
 													?>
 													<?php if ( 'publish' === $wlf_post_status ) : ?>
-														<span class="wlf-archived__redirect"><?php esc_html_e( 'Published', 'wpcomsp_wayback_link_fixer' ); ?></span>
+														<span class="wlf-archived__redirect"><?php esc_html_e( 'Published', 'wayback-link-fixer' ); ?></span>
 													<?php elseif ( 'draft' === $wlf_post_status ) : ?>
-														<span class="wlf-archived__redirect"><?php esc_html_e( 'Draft', 'wpcomsp_wayback_link_fixer' ); ?></span>
+														<span class="wlf-archived__redirect"><?php esc_html_e( 'Draft', 'wayback-link-fixer' ); ?></span>
 													<?php elseif ( 'pending' === $wlf_post_status ) : ?>
-														<span class="wlf-archived__redirect"><?php esc_html_e( 'Pending', 'wpcomsp_wayback_link_fixer' ); ?></span>
+														<span class="wlf-archived__redirect"><?php esc_html_e( 'Pending', 'wayback-link-fixer' ); ?></span>
 													<?php elseif ( 'future' === $wlf_post_status ) : ?>
-														<span class="wlf-archived__redirect"><?php esc_html_e( 'Scheduled', 'wpcomsp_wayback_link_fixer' ); ?></span>
+														<span class="wlf-archived__redirect"><?php esc_html_e( 'Scheduled', 'wayback-link-fixer' ); ?></span>
 													<?php else : ?>
 														<span class="wlf-archived__redirect"><?php echo esc_html( $wlf_post_status ); ?></span>
 													<?php endif; ?>
 												</td>
 												<td>
 													<a href="<?php echo esc_url( get_edit_post_link( $wlf_post->ID ) ); ?>">
-														<?php esc_html_e( 'Edit', 'wpcomsp_wayback_link_fixer' ); ?>
+														<?php esc_html_e( 'Edit', 'wayback-link-fixer' ); ?>
 													</a>
 													|
 													<a href="<?php echo esc_url( get_permalink( $wlf_post->ID ) ); ?>">
-														<?php esc_html_e( 'View', 'wpcomsp_wayback_link_fixer' ); ?>
+														<?php esc_html_e( 'View', 'wayback-link-fixer' ); ?>
 													</a>
 												</td>
 											</tr>

--- a/templates/admin/wizard/complete.php
+++ b/templates/admin/wizard/complete.php
@@ -13,7 +13,7 @@
 <?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 <div class="wlf-wizard__content__header">
-	<h2><?php esc_html_e( 'Setup complete.', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+	<h2><?php esc_html_e( 'Setup complete.', 'wayback-link-fixer' ); ?></h2>
 </div>
 
 <div class="wlf-wizard__content__intro">
@@ -21,8 +21,8 @@
 	<?php
 	printf(
 		// translators: %s is a link to the plugin settings page.
-		esc_html__( 'Setup is now complete! You can edit these settings at any time from the %s page.', 'wpcomsp_wayback_link_fixer' ),
-		'<a href="' . esc_url( menu_page_url( 'wpcomsp_wayback_link_fixer_settings', false ) ) . '">' . esc_html__( 'Wayback Link Fixer Settings', 'wpcomsp_wayback_link_fixer' ) . '</a>'
+		esc_html__( 'Setup is now complete! You can edit these settings at any time from the %s page.', 'wayback-link-fixer' ),
+		'<a href="' . esc_url( menu_page_url( 'wpcomsp_wayback_link_fixer_settings', false ) ) . '">' . esc_html__( 'Wayback Link Fixer Settings', 'wayback-link-fixer' ) . '</a>'
 	);
 	?>
 	</p>

--- a/templates/admin/wizard/footer.php
+++ b/templates/admin/wizard/footer.php
@@ -11,12 +11,12 @@
 $wlf_previous_state = 'step-1' === $step_data['step'] ? 'DISABLED' : '';
 $wlf_next_state     = 'complete' === $step_data['step'] ? 'DISABLED' : '';
 $wlf_next_label     = 'complete' === $step_data['next']
-	? esc_html__( 'Finish', 'wpcomsp_wayback_link_fixer' )
-	: esc_html__( 'Next Step', 'wpcomsp_wayback_link_fixer' );
+	? esc_html__( 'Finish', 'wayback-link-fixer' )
+	: esc_html__( 'Next Step', 'wayback-link-fixer' );
 
 $wlf_progress_string = sprintf(
 	/* translators: 1: current step, 2: total steps */
-	esc_html__( 'Step %1$d of %2$d', 'wpcomsp_wayback_link_fixer' ),
+	esc_html__( 'Step %1$d of %2$d', 'wayback-link-fixer' ),
 	$step_data['progress']['current'],
 	$step_data['progress']['total']
 );
@@ -27,7 +27,7 @@ $wlf_progress_pc = ( $step_data['progress']['current'] / $step_data['progress'][
 	<div id="wlf-wizard__footer">
 		<div class="wlf-wizard__footer__previous">
 			<?php if ( 'complete' !== $step_data['step'] || (isset($_GET['rerun-wizard']) && '1' === sanitize_text_field($_GET['rerun-wizard']) ) ) : // phpcs:ignore ?>
-				<button class="button button-primary" type="submit" name="wlf-previous-step" <?php echo esc_attr( $wlf_previous_state ); ?>><?php esc_html_e( 'Previous Step', 'wpcomsp_wayback_link_fixer' ); ?></button>
+				<button class="button button-primary" type="submit" name="wlf-previous-step" <?php echo esc_attr( $wlf_previous_state ); ?>><?php esc_html_e( 'Previous Step', 'wayback-link-fixer' ); ?></button>
 			<?php endif; ?>
 		</div>
 		<div class="wlf-wizard__footer__progress">

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -29,23 +29,23 @@ $wlf_existing_secret_key = isset( $_POST['wlf_wizard_archive_secret_key_temp'] )
 <?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 <div class="wlf-wizard__content__header">
-	<h2><?php esc_html_e( 'Step 1: Configure the Wayback Machine API', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+	<h2><?php esc_html_e( 'Step 1: Configure the Wayback Machine API', 'wayback-link-fixer' ); ?></h2>
 </div>
 
 <div class="wlf-wizard__content__intro">
-	<p><?php esc_html_e( 'To archive more than 4000 links from your site to the Wayback Machine per day, you\'ll need a free archive.org account. Once you have your account, enter the API Access Key and Secret Key below.', 'wpcomsp_wayback_link_fixer' ); ?>
-		<br /><a href="https://archive.org/account/s3.php" target="_blank"><?php esc_html_e( 'Get your API keys here.', 'wpcomsp_wayback_link_fixer' ); ?></a></p>
+	<p><?php esc_html_e( 'To archive more than 4000 links from your site to the Wayback Machine per day, you\'ll need a free archive.org account. Once you have your account, enter the API Access Key and Secret Key below.', 'wayback-link-fixer' ); ?>
+		<br /><a href="https://archive.org/account/s3.php" target="_blank"><?php esc_html_e( 'Get your API keys here.', 'wayback-link-fixer' ); ?></a></p>
 </div>
 
 <div class="wlf-wizard__content__field">
 	<label for="wlf_wizard_archive_access_key">
-		<?php esc_html_e( 'Archive.org API Access Key', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Archive.org API Access Key', 'wayback-link-fixer' ); ?>
 	</label>
 	<input type="<?php echo esc_html( $wlf_access_type ); ?>" name="wlf_wizard_archive_access_key" value="<?php echo esc_attr( $wlf_existing_access_key ); ?>"<?php echo $wlf_invalid_keys ? ' class="invalid"' : ''; ?>/>
 </div>
 <div class="wlf-wizard__content__field">
 	<label for="wlf_wizard_archive_secret_key">
-		<?php esc_html_e( 'Archive.org API Secret Key', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Archive.org API Secret Key', 'wayback-link-fixer' ); ?>
 	</label>
 	<input type="<?php echo esc_html( $wlf_secret_type ); ?>" name="wlf_wizard_archive_secret_key" value="<?php echo esc_attr( $wlf_existing_secret_key ); ?>"<?php echo $wlf_invalid_keys ? ' class="invalid"' : ''; ?>/>
 </div>

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -21,30 +21,30 @@ $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 <?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 <div class="wlf-wizard__content__header">
-	<h2><?php esc_html_e( 'Step 2: Configure the Link Fixer', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+	<h2><?php esc_html_e( 'Step 2: Configure the Link Fixer', 'wayback-link-fixer' ); ?></h2>
 </div>
 
 <div class="wlf-wizard__content__intro">
-	<p><?php esc_html_e( 'You can set the Link Fixer to work only with specific post types and apply it to existing posts.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'You can set the Link Fixer to work only with specific post types and apply it to existing posts.', 'wayback-link-fixer' ); ?></p>
 </div>
 
 <div class="wlf-wizard__content__field">
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_activate_link_fixer">
-				<?php esc_html_e( 'Enable Link Fixer', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Enable Link Fixer', 'wayback-link-fixer' ); ?>
 			</label>
 			<input type="checkbox" id="is_active" name="wlf_wizard_activate_link_fixer" value="1" <?php checked( Settings::is_link_processing_enabled() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'When enabled, all links within your selected post types will be processed for potential archiving by the Link Fixer.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'When enabled, all links within your selected post types will be processed for potential archiving by the Link Fixer.', 'wayback-link-fixer' ); ?></p>
 	</div>
 </div>
 
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
 	<label for="wlf_wizard_post_types">
-		<?php esc_html_e( 'Post Types', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Post Types', 'wayback-link-fixer' ); ?>
 	</label>
-	<p class="description"><?php esc_html_e( 'Select the post types you want to enable the link fixer for.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p class="description"><?php esc_html_e( 'Select the post types you want to enable the link fixer for.', 'wayback-link-fixer' ); ?></p>
 	<div class="wlf-wizard__content__inner-field checkboxes">
 		<?php foreach ( $post_types as $wlf_pt_slug => $wlf_pt_name ) : ?>
 			<div class="inner-spaced-between__list">
@@ -61,28 +61,28 @@ $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_scan_existing_content">
-				<?php esc_html_e( 'Scan Existing Content', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Scan Existing Content', 'wayback-link-fixer' ); ?>
 			</label>
 			<input type="checkbox" id="wlf_is_active" name="wlf_wizard_scan_existing_content" id="wlf_wizard_scan_existing_content" value="1" <?php checked( Settings::should_scan_existing_posts() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'If enabled, all existing posts of the selected types will be scanned and processed. Please note this process can take significant time (potentially hours or days) depending on the amount of content and number of links.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'If enabled, all existing posts of the selected types will be scanned and processed. Please note this process can take significant time (potentially hours or days) depending on the amount of content and number of links.', 'wayback-link-fixer' ); ?></p>
 	</div>
 </div>
 
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
 	<label for="wlf_wizard_outcome">
-		<?php esc_html_e( 'Action for Broken Links', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Action for Broken Links', 'wayback-link-fixer' ); ?>
 	</label>
-	<p class="description"><?php esc_html_e( 'What should the Link Fixer do when it identifies a broken link?', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p class="description"><?php esc_html_e( 'What should the Link Fixer do when it identifies a broken link?', 'wayback-link-fixer' ); ?></p>
 	<select
 		id="wlf_wizard_outcome"
 		name="wlf_wizard_outcome"
 	>
 		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
-			<?php esc_html_e( 'Replace Link (No Notification)', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Replace Link (No Notification)', 'wayback-link-fixer' ); ?>
 		</option>
 		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
-			<?php esc_html_e( 'Do Nothing', 'wpcomsp_wayback_link_fixer' ); ?>
+			<?php esc_html_e( 'Do Nothing', 'wayback-link-fixer' ); ?>
 		</option>
 	</select>
 </div>

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -21,29 +21,29 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 <?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 <div class="wlf-wizard__content__header">
-	<h2><?php esc_html_e( 'Step 3: Configure the Auto Archiver', 'wpcomsp_wayback_link_fixer' ); ?></h2>
+	<h2><?php esc_html_e( 'Step 3: Configure the Auto Archiver', 'wayback-link-fixer' ); ?></h2>
 </div>
 
 <div class="wlf-wizard__content__intro">
-	<p><?php esc_html_e( 'Easily preserve your website’s content by enabling automatic archiving with the Internet Archive, setting up regular archiving, and choosing which post types to include.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p><?php esc_html_e( 'Easily preserve your website’s content by enabling automatic archiving with the Internet Archive, setting up regular archiving, and choosing which post types to include.', 'wayback-link-fixer' ); ?></p>
 </div>
 
 <div class="wlf-wizard__content__field">
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_activate_auto_archiver">
-				<?php esc_html_e( 'Enable Auto Archiver', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Enable Auto Archiver', 'wayback-link-fixer' ); ?>
 			</label>
 			<input type="checkbox" id="is_active" name="wlf_wizard_activate_auto_archiver" value="1" <?php checked( Settings::add_own_links() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'When the Auto Archiver is enabled, your content is automatically archived on the Internet Archive each time you publish or save changes to a post of the selected types.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'When the Auto Archiver is enabled, your content is automatically archived on the Internet Archive each time you publish or save changes to a post of the selected types.', 'wayback-link-fixer' ); ?></p>
 	</div>
 </div>
 <div class="wlf-wizard__content__field is_optional <?php echo esc_attr( $wlf_hide_class ); ?>" >
 	<label for="wlf_wizard_post_types">
-		<?php esc_html_e( 'Post Types', 'wpcomsp_wayback_link_fixer' ); ?>
+		<?php esc_html_e( 'Post Types', 'wayback-link-fixer' ); ?>
 	</label>
-	<p class="description"><?php esc_html_e( 'Select which post types should be archived on the Wayback Machine.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+	<p class="description"><?php esc_html_e( 'Select which post types should be archived on the Wayback Machine.', 'wayback-link-fixer' ); ?></p>
 	<div class="wlf-wizard__content__inner-field checkboxes">
 		<?php foreach ( $post_types as $wlf_pt_slug => $wlf_pt_name ) : ?>
 			<div class="inner-spaced-between__list">
@@ -60,11 +60,11 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 	<div class="wlf-wizard__content__inner-field checkbox">
 		<div class="inner-spaced-between">
 			<label for="wlf_wizard_recurring_backup">
-				<?php esc_html_e( 'Enable Scheduled Archiving', 'wpcomsp_wayback_link_fixer' ); ?>
+				<?php esc_html_e( 'Enable Scheduled Archiving', 'wayback-link-fixer' ); ?>
 			</label>
 			<input type="checkbox" name="wlf_wizard_recurring_backup" value="1" <?php checked( Settings::is_link_processing_enabled() ); ?> />
 		</div>
-		<p class="description"><?php esc_html_e( 'If enabled, your posts of selected types will be regularly archived on the Wayback Machine according to the interval set in the main plugin settings.', 'wpcomsp_wayback_link_fixer' ); ?></p>
+		<p class="description"><?php esc_html_e( 'If enabled, your posts of selected types will be regularly archived on the Wayback Machine according to the interval set in the main plugin settings.', 'wayback-link-fixer' ); ?></p>
 	</div>
 </div>
 

--- a/wayback-link-fixer.php
+++ b/wayback-link-fixer.php
@@ -21,7 +21,7 @@
  * Author URI:              https://wpspecialprojects.wordpress.com
  * License:                 GPL-3.0-or-later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
- * Text Domain:             wpcomsp_wayback_link_fixer
+ * Text Domain:             wayback-link-fixer
  * Domain Path:             /languages
  */
 

--- a/wayback-link-fixer.php
+++ b/wayback-link-fixer.php
@@ -3,27 +3,27 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.0-RC5
+ * @version     1.3.0
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
- * @noinspection    ALL
+ * @noinspection ALL
  *
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Plugin URI:              https://wpspecialprojects.wordpress.com
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.0-RC5
- * Requires at least:       6.2
- * Tested up to:            6.7
+ * Version:                 1.3.0
+ * Requires at least:       6.4
+ * Tested up to:            6.5
  * Requires PHP:            7.4
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
- * License:                 GPL v3 or later
+ * License:                 GPL-3.0-or-later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:             wpcomsp_wayback_link_fixer
  * Domain Path:             /languages
- **/
+ */
 
 defined( 'ABSPATH' ) || exit;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request focuses on rebranding the plugin from "Team 51 Wayback Link Fixer" to "Internet Archive Wayback Machine Link Fixer" and updating the associated text domain and metadata. Additionally, it removes unused code and refines the plugin's language files. Below are the most important changes grouped by theme:

### Rebranding and Text Domain Updates:
* Updated text domain from `wpcomsp_wayback_link_fixer` to `wayback-link-fixer` across all files, including `.phpcs.xml`, `functions-bootstrap.php`, `functions.php`, and `src/Action/Link_Latest_Snapshot_Action.php`. [[1]](diffhunk://#diff-e62fd5e0887483aa43041a31ce6deb93282f826f0cf3be6a422dbd3c7d4ed120L20-R20) [[2]](diffhunk://#diff-d11f127292045d32f37db7655122b304e188c33ac7a67be65048d8432ec57c70L158-R164) [[3]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L186-R186) [[4]](diffhunk://#diff-b0448840866b45d877b31c50fd2caef90a26ae71d7d4ab6b4a1f1cd938c6fe35L65-R65) [[5]](diffhunk://#diff-b0448840866b45d877b31c50fd2caef90a26ae71d7d4ab6b4a1f1cd938c6fe35L121-R121)
* Revised plugin name and metadata in `README.md` to reflect the new branding, including updated tags, version numbers, and descriptions.
* Updated language domain and metadata in `languages/wayback-link-fixer.pot`.

### Code Cleanup:
* Removed unused `wpcomsp_wayback_link_fixer_enqueue_select2_assets` function from `functions.php`.
* Simplified CSS rendering logic in `wpcomsp_wayback_link_fixer_render_archived_link_css` by switching from heredoc syntax to single quotes. [[1]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L237-R222) [[2]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L246-R231)

### Language File Refinements:
* Adjusted references and line mappings in `languages/wayback-link-fixer.pot` to align with updated source files and ensure accurate translations. [[1]](diffhunk://#diff-6a85c33c6b072d45adb7529ca684c96d454bf4a2686760a216b98d1d12560d6cL117-R117) [[2]](diffhunk://#diff-6a85c33c6b072d45adb7529ca684c96d454bf4a2686760a216b98d1d12560d6cL396-R556)

These changes collectively enhance the plugin's branding, simplify its codebase, and ensure consistency across its files.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin name and metadata in documentation for clarity and accuracy.
  * Revised descriptions, tags, license, and tested WordPress versions.
  * Added a "Key Features" section to highlight main functionalities.

* **Style**
  * Standardized and updated the text domain used for translations throughout the plugin for improved localization consistency.

* **Bug Fixes**
  * Improved input handling and sanitization in several admin and report interfaces to enhance data integrity and security.

* **Refactor**
  * Removed unused asset loading related to Select2.
  * Minor formatting and consistency improvements in code and templates.

* **New Features**
  * Enhanced setup wizard with new error handling for missing credentials and step validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->