### PR TITLE
Update the author tags

### DIFF
--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -4,7 +4,7 @@
  *
  * @since       1.0.0
  * @version     1.3.0
- * @author      WordPress.com Special Projects
+ * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
  * @noinspection ALL
@@ -16,8 +16,8 @@
  * Requires at least:       6.4
  * Tested up to:            6.5
  * Requires PHP:            7.4
- * Author:                  WordPress.com Special Projects
- * Author URI:              https://wpspecialprojects.wordpress.com
+ * Author:                  Internet Archive
+ * Author URI:              https://archive.org
  * License:                 GPL-3.0-or-later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:             internet-archive-wayback-machine-link-fixer

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Internet Archive Wayback Machine Link Fixer ===
-Contributors: wpcomspecialprojects
+Contributors: waybackmachineplugin and wpcomspecialprojects
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin's author information and contributor list to reflect the involvement of the Internet Archive and the official Wayback Machine plugin account.

Author and contributor updates:

* Updated the `@author` field and `Author` metadata in `internet-archive-wayback-machine-link-fixer.php` to reference Internet Archive instead of WordPress.com Special Projects. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL7-R7) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL19-R20)
* Changed the `Author URI` in `internet-archive-wayback-machine-link-fixer.php` to point to https://archive.org.
* Added `waybackmachineplugin` to the list of contributors in `readme.txt`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin author and homepage to Internet Archive branding, reflecting current ownership. No functional changes.

* **Documentation**
  * Revised contributors list to include the Wayback Machine plugin account alongside the existing contributor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->