### PR TITLE
Adds a new action to the plugin, to offer a short cut to settings page

### DIFF
--- a/src/Integrations.php
+++ b/src/Integrations.php
@@ -40,6 +40,7 @@ final class Integrations {
 	private $dashboard_notification;
 	private $setup_wizard;
 	private $dashboard_page;
+	private $plugin_management;
 
 	/**
 	 * Creates a new instance of the integrations component.
@@ -54,6 +55,7 @@ final class Integrations {
 		$this->dashboard_notification   = new Dashboard_Notifications();
 		$this->setup_wizard             = new Setup_Wizard();
 		$this->dashboard_page           = new Dashboard_Page();
+		$this->plugin_management        = new Util\Plugin_Management_Service();
 	}
 
 
@@ -79,6 +81,7 @@ final class Integrations {
 		$this->report_page->initialize();
 		$this->dashboard_notification->initialize();
 		$this->setup_wizard->initialize();
+		$this->plugin_management->initialize();
 	}
 
 	// endregion

--- a/src/Util/Plugin_Management_Service.php
+++ b/src/Util/Plugin_Management_Service.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Class used to handle any plugin management service tasks.
+ *
+ * @since 1.3.0
+ *
+ * @package WPCOMSpecialProjects\Wayback_Link_Fixer\Util
+ */
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\Wayback_Link_Fixer\Util;
+
+use WPCOMSpecialProjects\Wayback_Link_Fixer\Dashboard\Settings_Page;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Plugin_Management_Service
+ */
+class Plugin_Management_Service {
+
+	/**
+	 * Initialize the plugin management service.
+	 *
+	 * @return void
+	 */
+	public function initialize(): void {
+		add_action( 'plugin_action_links_' . WPCOMSP_WAYBACK_LINK_FIXER_BASENAME, array( $this, 'add_settings_link' ) );
+	}
+
+	/**
+	 * Add the settings link to the plugin action links.
+	 *
+	 * @param array $links The existing links.
+	 *
+	 * @return array The modified links.
+	 */
+	public function add_settings_link( array $links ): array {
+		$settings_link = '<a href="' . esc_url( Settings_Page::get_page_url() ) . '">' . esc_html__( 'Settings', 'internet-archive-wayback-machine-link-fixer' ) . '</a>';
+		$links[]       = $settings_link;
+		return $links;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds a new plugin management service to the application and integrates it into the main `Integrations` class. The most notable change is the introduction of the `Plugin_Management_Service`, which provides a settings link in the plugin action links for easier access to configuration. The changes are grouped below by theme.

**Feature Addition: Plugin Management**

* Added new class `Plugin_Management_Service` in `src/Util/Plugin_Management_Service.php`, which hooks into the plugin action links to add a "Settings" link for the plugin.

**Integration Updates**

* Updated the `Integrations` class to include a new private member `$plugin_management` for managing plugin-related tasks.
* Instantiated `Plugin_Management_Service` in the `Integrations` constructor to ensure it is available within the component.
* Called `initialize()` on the new `plugin_management` member in the `Integrations::initialize()` method to register the settings link hook during initialization.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #183 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient Settings link on the WordPress Plugins screen, allowing one-click access to the plugin’s settings page.
  * Ensures the Settings link is initialized reliably so it consistently appears where expected.
  * Streamlines plugin management from the admin area, making it faster to configure and adjust options without navigating through multiple menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->