### PR TITLE
Enable link fixer, enable scanning existing content and scanning own …

### DIFF
--- a/src/Event/Process_Local_Post_Event.php
+++ b/src/Event/Process_Local_Post_Event.php
@@ -73,7 +73,9 @@ class Process_Local_Post_Event {
 			self::HANDLE,
 			array(
 				'post_id' => $post_id,
-			)
+			),
+			'wlf_process_local_post', // The group name.
+			true
 		);
 	}
 

--- a/src/Event/Process_Local_Post_Event.php
+++ b/src/Event/Process_Local_Post_Event.php
@@ -73,9 +73,7 @@ class Process_Local_Post_Event {
 			self::HANDLE,
 			array(
 				'post_id' => $post_id,
-			),
-			'wlf_process_local_post', // The group name.
-			true
+			)
 		);
 	}
 

--- a/src/Event/Scan_Own_Posts_Event.php
+++ b/src/Event/Scan_Own_Posts_Event.php
@@ -131,7 +131,6 @@ class Scan_Own_Posts_Event {
 		if ( ! $posts->have_posts() ) {
 			return;
 		}
-
 		// Loop through the posts and add them to the queue.
 		foreach ( $posts->posts as $post ) {
 			$this->post_controller->add_own_post_to_wayback_machine( $post->ID );

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -79,7 +79,7 @@ class Settings {
 	 * @return boolean
 	 */
 	public static function is_link_processing_enabled(): bool {
-		return (bool) get_option( self::PROCESS_LINKS, false );
+		return (bool) get_option( self::PROCESS_LINKS, true );
 	}
 
 	/**
@@ -299,7 +299,7 @@ class Settings {
 	public static function add_own_links(): bool {
 		return (bool) apply_filters(
 			'wlf_add_own_content_to_wayback_machine',
-			(bool) get_option( self::ALLOW_OWN_CONTENT_SUBMISSIONS, false )
+			(bool) get_option( self::ALLOW_OWN_CONTENT_SUBMISSIONS, true )
 		);
 	}
 

--- a/tests/Event/Test_Scan_Own_Posts_Event.php
+++ b/tests/Event/Test_Scan_Own_Posts_Event.php
@@ -103,6 +103,7 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 		// Allow with the filters.
 		\add_filter( 'wlf_own_content_allow_post', '__return_true' );
 		\add_filter( 'wlf_routinely_update_wayback_machine', '__return_true' );
+		\add_filter( 'wlf_scan_existing_posts', '__return_false' );
 
 		// Only allow post type 'post'.
 		\add_filter(
@@ -121,7 +122,7 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 		$event();
 
 		// Get all action shceduler actions.
-		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions" );
+		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE status = 'pending'" );
 
 		// Should be 1 added action.
 		$this->assertCount( 1, $actions );
@@ -136,8 +137,10 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_only_get_posts_that_have_not_been_checked_in_last_24_hours(): void {
-		\add_filter( 'wlf_own_content_allow_post', '__return_true' );
 		\add_filter( 'wlf_routinely_update_wayback_machine', '__return_true' );
+		\add_filter( 'wlf_own_content_allow_post', '__return_false' );
+		$backup_settings = get_option( Settings::PROCESS_LINKS );
+		update_option( Settings::PROCESS_LINKS, false );
 
 		// Set the interval to 24 hours.
 		\add_filter( 'wlf_routinely_update_wayback_machine_interval', fn() => 1 );
@@ -145,20 +148,23 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 		// Create 2 posts.
 		$post_id_1 = $this->factory->post->create( array( 'post_type' => 'post' ) );
 		$post_id_2 = $this->factory->post->create( array( 'post_type' => 'post' ) );
-		// Set the meta, post 1 should be last checked 2 days ago and post 2 should be 1hour ago.
-		$time_1 = time() - 2 * DAY_IN_SECONDS;
-		$time_2 = time() - 1 * HOUR_IN_SECONDS;
 
+		// Set the meta, post 1 should be last checked 2 days ago and post 2 should be 1hour ago.
+		$time_1 = time() - 6 * DAY_IN_SECONDS;
+		$time_2 = time() - 1 * HOUR_IN_SECONDS;
 		update_post_meta( $post_id_1, Settings::OWN_LINK_LAST_PROCESSED, $time_1 );
 		update_post_meta( $post_id_2, Settings::OWN_LINK_LAST_PROCESSED, $time_2 );
+
+		// Reset the filters and allow adding own posts.
+		\add_filter( 'wlf_own_content_allow_post', '__return_true' );
+		update_option( Settings::PROCESS_LINKS, $backup_settings );
 
 		// Run the event.
 		$event = new Scan_Own_Posts_Event();
 		$event();
 
 		// Get all action shceduler actions.
-		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions" );
-
+		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions where status='pending'" );
 		// Should be 1 added action.
 		$this->assertCount( 1, $actions );
 

--- a/tests/Event/Test_Scan_Own_Posts_Event.php
+++ b/tests/Event/Test_Scan_Own_Posts_Event.php
@@ -164,7 +164,7 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 		$event();
 
 		// Get all action shceduler actions.
-		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions where status='pending'" );
+		$actions = $GLOBALS['wpdb']->get_results( "SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE status='pending'" );
 		// Should be 1 added action.
 		$this->assertCount( 1, $actions );
 


### PR DESCRIPTION
…content is enabled by default

#### Changes proposed in this Pull Request

This pull request updates default option values in the `Settings.php` file to enable certain features by default. The changes ensure that link processing and own content submissions are now active unless explicitly disabled.

Default value changes:

* Changed the default for link processing to enabled by setting the fallback value in `get_option` to `true` in the `is_link_processing_enabled` method (`src/Settings/Settings.php`).
* Changed the default for allowing own content submissions to enabled by setting the fallback value in `get_option` to `true` in the `add_own_links` method (`src/Settings/Settings.php`).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Link processing is now enabled by default for new installs.
  - Submitting your own site’s links to the Wayback Machine is enabled by default.
  - Automatic scanning/archiving of your own posts begins without manual setup.

- Tests
  - Improved test coverage and stricter scheduling queries to validate behavior under different filter configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->