### PR TITLE
Removed unused meta data functions and switched to passing version an…

### DIFF
--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -10,79 +10,6 @@ declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Returns the plugin's metadata.
- *
- * @template PluginMetaKey of key-of<PluginMetaData>
- *
- * @param   PluginMetaKey|null $property Optional. The property to return. Default all.
- *
- * @return  ($property is null ? PluginMetaData : ($property is PluginMetaKey ? PluginMetaData[PluginMetaKey] : null))
- */
-function wpcomsp_wayback_link_fixer_get_plugin_metadata( $property = null ) {
-	static $plugin_data = null;
-
-	$can_translate = 0 < did_action( 'init' );
-	$translate_key = 0 < did_action( 'plugins_loaded' ) ? 'full' : ( $can_translate ? 'translated' : 'raw' );
-
-	if ( ! isset( $plugin_data[ $translate_key ] ) ) {
-		if ( ! function_exists( 'get_plugin_data' ) ) {
-			/* @phpstan-ignore requireOnce.fileNotFound */
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$plugin_file                   = trailingslashit( WP_PLUGIN_DIR ) . constant( 'WPCOMSP_WAYBACK_LINK_FIXER_BASENAME' );
-		$plugin_data[ $translate_key ] = get_plugin_data( $plugin_file, false, $can_translate );
-	}
-
-	$metadata = $plugin_data[ $translate_key ];
-	if ( null === $property ) {
-		return $metadata;
-	}
-
-	if ( is_string( $property ) && isset( $metadata[ $property ] ) ) {
-		return $metadata[ $property ];
-	}
-
-	return null;
-}
-
-/**
- * Returns the plugin's slug.
- *
- * @since   1.0.0
- * @version 1.0.0
- *
- * @return  string
- */
-function wpcomsp_wayback_link_fixer_get_plugin_slug(): string {
-	$text_domain = wpcomsp_wayback_link_fixer_get_plugin_metadata( 'TextDomain' );
-	return sanitize_key( $text_domain );
-}
-
-/**
- * Returns the plugin's name.
- *
- * @since   1.0.0
- * @version 1.0.0
- *
- * @return  string
- */
-function wpcomsp_wayback_link_fixer_get_plugin_name(): string {
-	return wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Name' );
-}
-
-/**
- * Returns the plugin's version.
- *
- * @since   1.0.0
- * @version 1.0.0
- *
- * @return  string
- */
-function wpcomsp_wayback_link_fixer_get_plugin_version(): string {
-	return wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Version' );
-}
 
 /**
  * Checks compatibility with the current WordPress version.
@@ -120,23 +47,16 @@ function wpcomsp_wayback_link_fixer_is_php_version_compatible( $min_php_version 
  * @return  true|\WP_Error
  */
 function wpcomsp_wayback_link_fixer_validate_requirements() {
-	$plugin_metadata = wpcomsp_wayback_link_fixer_get_plugin_metadata();
-	if ( ! isset( $plugin_metadata['RequiresPHP'] ) || '' === $plugin_metadata['RequiresPHP'] ) {
-		$plugin_metadata['RequiresPHP'] = '7.4';
-	}
-	if ( ! isset( $plugin_metadata['RequiresWP'] ) || '' === $plugin_metadata['RequiresWP'] ) {
-		$plugin_metadata['RequiresWP'] = '6.7';
-	}
 
-	$is_php_compatible = wpcomsp_wayback_link_fixer_is_php_version_compatible( $plugin_metadata['RequiresPHP'] );
-	$is_wp_compatible  = wpcomsp_wayback_link_fixer_is_wp_version_compatible( $plugin_metadata['RequiresWP'] );
+	$is_php_compatible = wpcomsp_wayback_link_fixer_is_php_version_compatible( WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['php'] );
+	$is_wp_compatible  = wpcomsp_wayback_link_fixer_is_wp_version_compatible( WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['wp'] );
 
 	$wp_error = new \WP_Error();
 	if ( ! $is_wp_compatible ) {
-		$wp_error->add( 'plugin_wp_incompatible', '', array( 'requires_wp' => $plugin_metadata['RequiresWP'] ) );
+		$wp_error->add( 'plugin_wp_incompatible', '', array( 'requires_wp' => WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['wp'] ) );
 	}
 	if ( ! $is_php_compatible ) {
-		$wp_error->add( 'plugin_php_incompatible', '', array( 'requires_php' => $plugin_metadata['RequiresPHP'] ) );
+		$wp_error->add( 'plugin_php_incompatible', '', array( 'requires_php' => WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['php'] ) );
 	}
 
 	return $wp_error->has_errors() ? $wp_error : true;
@@ -156,8 +76,8 @@ function wpcomsp_wayback_link_fixer_output_requirements_error( $error ) {
 			$requirements_error = wp_sprintf(
 				/* translators: 1: Plugin name, 2: Plugin version */
 				__( '<strong>%1$s (version %2$s)</strong> could not be initialized.', 'internet-archive-wayback-machine-link-fixer' ),
-				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Name' ),
-				wpcomsp_wayback_link_fixer_get_plugin_metadata( 'Version' )
+				__( 'Internet Archive Wayback Machine Link Fixer', 'internet-archive-wayback-machine-link-fixer' ),
+				WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 			);
 
 			if ( $error->has_errors() ) {

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -14,7 +14,7 @@
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
  * Version:                 1.3.0
  * Requires at least:       6.4
- * Tested up to:            6.5
+ * Tested up to:            6.8
  * Requires PHP:            7.4
  * Author:                  Internet Archive
  * Author URI:              https://archive.org
@@ -27,12 +27,17 @@
 defined( 'ABSPATH' ) || exit;
 
 // Define plugin constants.
-function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
-define( 'WPCOMSP_WAYBACK_LINK_FIXER_METADATA', get_plugin_data( __FILE__, false, false ) );
-
 define( 'WPCOMSP_WAYBACK_LINK_FIXER_BASENAME', plugin_basename( __FILE__ ) );
 define( 'WPCOMSP_WAYBACK_LINK_FIXER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPCOMSP_WAYBACK_LINK_FIXER_URL', plugin_dir_url( __FILE__ ) );
+define( 'WPCOMSP_WAYBACK_LINK_FIXER_VERSION', '1.3.0' );
+define(
+	'WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS',
+	array(
+		'wp'  => '6.4',
+		'php' => '7.4',
+	)
+);
 
 // Load the rest of the bootstrap functions.
 require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . '/functions-bootstrap.php';

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -54,7 +54,7 @@ class Dashboard_Notifications {
 				self::PAGE_SLUG,
 				WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/css/build/style-style.scss.css',
 				array(),
-				WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version']
+				WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 			);
 		}
 	}

--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -89,7 +89,7 @@ class Dashboard_Page {
 				self::DASHBOARD_SLUG,
 				WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/css/build/style-style.scss.css',
 				array(),
-				WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version']
+				WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 			);
 		}
 
@@ -99,7 +99,7 @@ class Dashboard_Page {
 				self::DASHBOARD_SLUG . '_dashboard',
 				WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/js/build/dashboard.js',
 				array(),
-				WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+				WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 				true
 			);
 		}

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -134,7 +134,7 @@ class Report_Page {
 			self::SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/css/build/style-style.scss.css',
 			array(),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version']
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 		);
 
 		// Enqueue the admin scripts.
@@ -142,7 +142,7 @@ class Report_Page {
 			self::SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/js/build/link-table.js',
 			array( 'jquery' ),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 			true
 		);
 	}

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -114,7 +114,7 @@ class Settings_Page {
 			self::PAGE_SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/js/build/admin_settings.js',
 			array( 'jquery' ),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 			true
 		);
 
@@ -133,7 +133,7 @@ class Settings_Page {
 			self::PAGE_SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/css/build/style-style.scss.css',
 			array(),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version']
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 		);
 	}
 

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -152,7 +152,7 @@ class Setup_Wizard {
 			self::PAGE_SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/js/build/wizard.js',
 			array(),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 			true
 		);
 
@@ -161,7 +161,7 @@ class Setup_Wizard {
 			self::PAGE_SLUG,
 			WPCOMSP_WAYBACK_LINK_FIXER_URL . 'assets/css/build/style-style.scss.css',
 			array(),
-			WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version']
+			WPCOMSP_WAYBACK_LINK_FIXER_VERSION
 		);
 	}
 

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
@@ -80,7 +80,7 @@ class HTTP_Link_Checker_Client implements Link_Checker_Client {
 		);
 
 		$headers = array(
-			'WP-Wayback-Link-Fixer' => WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+			'WP-Wayback-Link-Fixer' => WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 		);
 
 		// Get the response.

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
@@ -64,7 +64,7 @@ class HTTP_Snapshot_Client implements Snapshot_Client {
 	 */
 	private function get_headers(): array {
 		$headers = array(
-			'WP-Wayback-Link-Fixer' => WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'],
+			'WP-Wayback-Link-Fixer' => WPCOMSP_WAYBACK_LINK_FIXER_VERSION,
 		);
 
 		// Add the auth header if set.

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -24,19 +24,19 @@ class Test_Functions extends \WP_UnitTestCase {
 	 */
 	public static function normalize_url_provider(): array {
 		return array(
-			'HTTPs simple' => array( 'https://example.com', 'https%3A%2F%2Fexample.com' ),
-			'HTTP simple' => array( 'http://example.com', 'http%3A%2F%2Fexample.com' ),
-			'HTTP with trailing slash' => array( 'http://example.com/', 'http%3A%2F%2Fexample.com' ),
-			'URL with special characters in path' => array( 'http://example.com/wiki/Help:Executive+Bios', 'http%3A%2F%2Fexample.com%2Fwiki%2FHelp%253AExecutive%252BBios' ),
-			'HTTP URL with basic path' => array( 'http://example.com/path/to/resource', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource' ),
+			'HTTPs simple'                          => array( 'https://example.com', 'https%3A%2F%2Fexample.com' ),
+			'HTTP simple'                           => array( 'http://example.com', 'http%3A%2F%2Fexample.com' ),
+			'HTTP with trailing slash'              => array( 'http://example.com/', 'http%3A%2F%2Fexample.com' ),
+			'URL with special characters in path'   => array( 'http://example.com/wiki/Help:Executive+Bios', 'http%3A%2F%2Fexample.com%2Fwiki%2FHelp%253AExecutive%252BBios' ),
+			'HTTP URL with basic path'              => array( 'http://example.com/path/to/resource', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource' ),
 			'HTTP URL with path and trailing slash' => array( 'http://example.com/path/to/resource/', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource' ),
-			'HTTP URL with spaces in path' => array( 'http://example.com/path with space/to/resource', 'http%3A%2F%2Fexample.com%2Fpath%2520with%2520space%2Fto%2Fresource' ),
-			'HTTP URL with query parameters' => array( 'http://example.com/path/to/resource?foo=bar', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource?foo%3Dbar' ),
-			'HTTP URL with fragment' => array( 'http://example.com/path/to/resource#section1', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource#section1' ),
-			'HTTP URL with port' => array( 'http://example.com:8080/path/to/resource', 'http%3A%2F%2Fexample.com:8080%2Fpath%2Fto%2Fresource' ),
+			'HTTP URL with spaces in path'          => array( 'http://example.com/path with space/to/resource', 'http%3A%2F%2Fexample.com%2Fpath%2520with%2520space%2Fto%2Fresource' ),
+			'HTTP URL with query parameters'        => array( 'http://example.com/path/to/resource?foo=bar', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource?foo%3Dbar' ),
+			'HTTP URL with fragment'                => array( 'http://example.com/path/to/resource#section1', 'http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource#section1' ),
+			'HTTP URL with port'                    => array( 'http://example.com:8080/path/to/resource', 'http%3A%2F%2Fexample.com:8080%2Fpath%2Fto%2Fresource' ),
 			'HTTP URL with query containing spaces' => array( 'http://example.com/?query with spaces', 'http%3A%2F%2Fexample.com%2F?query%20with%20spaces' ),
-			'HTTPs URL with special characters' => array( 'https://example.com/path/to/special&chars', 'https%3A%2F%2Fexample.com%2Fpath%2Fto%2Fspecial%2526chars' ),
-			'HTTP URL with hashbang fragment' => array( 'http://example.com/#!special_characters', 'http%3A%2F%2Fexample.com%2F#!special_characters' ),
+			'HTTPs URL with special characters'     => array( 'https://example.com/path/to/special&chars', 'https%3A%2F%2Fexample.com%2Fpath%2Fto%2Fspecial%2526chars' ),
+			'HTTP URL with hashbang fragment'       => array( 'http://example.com/#!special_characters', 'http%3A%2F%2Fexample.com%2F#!special_characters' ),
 		);
 	}
 
@@ -54,4 +54,16 @@ class Test_Functions extends \WP_UnitTestCase {
 		$this->assertSame( $expected, \wpcomsp_wayback_link_fixer_normalize_url( $url ) );
 	}
 
+	/**
+	 * @testdox The constants should be defined and match the plugin metadata.
+	 *
+	 * @return void
+	 */
+	public function test_constants_should_be_defined_and_match_plugin_metadata(): void {
+		// Get the plugin metadata.
+		$plugin_metadata = get_plugin_data( WP_PLUGIN_DIR . '/internet-archive-wayback-machine-link-fixer/internet-archive-wayback-machine-link-fixer.php' );
+		$this->assertSame( WPCOMSP_WAYBACK_LINK_FIXER_VERSION, $plugin_metadata['Version'], 'Version should match the plugin metadata.' );
+		$this->assertSame( WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['wp'], $plugin_metadata['RequiresWP'], 'RequiresWP should match the plugin metadata.' );
+		$this->assertSame( WPCOMSP_WAYBACK_LINK_FIXER_MINIMUM_VERSIONS['php'], $plugin_metadata['RequiresPHP'], 'RequiresPHP should match the plugin metadata.' );
+	}
 }

--- a/tests/Wayback_Machine/Test_HTTP_Snapshot_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Snapshot_Client.php
@@ -445,7 +445,7 @@ class Test_HTTP_Snapshot_Client extends \WP_UnitTestCase {
 			function ( $response, $args, $url ) {
 				$this->assertArrayHasKey( 'headers', $args );
 				$this->assertArrayHasKey( 'WP-Wayback-Link-Fixer', $args['headers'] );
-				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'], $args['headers']['WP-Wayback-Link-Fixer'] );
+				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_VERSION, $args['headers']['WP-Wayback-Link-Fixer'] );
 				return new \WP_Error( 'http_request_failed', 'Error' );
 			},
 			10,
@@ -481,7 +481,7 @@ class Test_HTTP_Snapshot_Client extends \WP_UnitTestCase {
 			function ( $response, $args, $url ) {
 				$this->assertArrayHasKey( 'headers', $args );
 				$this->assertArrayHasKey( 'WP-Wayback-Link-Fixer', $args['headers'] );
-				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'], $args['headers']['WP-Wayback-Link-Fixer'] );
+				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_VERSION, $args['headers']['WP-Wayback-Link-Fixer'] );
 				$this->assertArrayHasKey( 'Authorization', $args['headers'] );
 				$this->assertEquals( 'LOW test_access_key:test_secret_key', $args['headers']['Authorization'] );
 				return new \WP_Error( 'http_request_failed', 'Error' );
@@ -518,7 +518,7 @@ class Test_HTTP_Snapshot_Client extends \WP_UnitTestCase {
 			function ( $response, $args, $url ) {
 				$this->assertArrayHasKey( 'headers', $args );
 				$this->assertArrayHasKey( 'WP-Wayback-Link-Fixer', $args['headers'] );
-				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_METADATA['Version'], $args['headers']['WP-Wayback-Link-Fixer'] );
+				$this->assertEquals( WPCOMSP_WAYBACK_LINK_FIXER_VERSION, $args['headers']['WP-Wayback-Link-Fixer'] );
 				return array(
 					'body'     => json_encode( array( 'status' => 'success', 'job_id' => '12345' ) ),
 					'response' => array( 'code' => 200 ),


### PR DESCRIPTION
…d min versions as constants, so they can used elsewhere. Means we need to manually update them, but does mean we can have tests to check this

#### Changes proposed in this Pull Request

* No longer uses the core function to get versions and other data from the plugin header block. These are now held as constants, but did remove some of the functions which we dont use

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #199 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Bumped plugin to 1.3.0.
  - Set minimum requirements: WordPress 6.4 and PHP 7.4.
  - Updated requirement error messages to reference fixed minimum-version constants.

- Refactor
  - Replaced dynamic metadata lookups with stable constants for plugin version and minimums.
  - Removed public metadata helper functions.
  - Standardized asset and HTTP header versioning to use the new version constant.

- Tests
  - Added test asserting constants match plugin header and updated header/version assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->