### PR TITLE
Fix/gh202 ensure all template vars are escaped

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -211,30 +211,6 @@ function wpcomsp_wayback_link_fixer_render_template( string $template, array $ar
 }
 
 
-/**
- * Render the CSS used for archived links in the header.
- *
- * @since 1.1.0
- *
- * @return void
- */
-function wpcomsp_wayback_link_fixer_render_archived_link_css(): void {
-	$css = '
-.wlf-archived__redirect {
-    color: var(--wp--preset--color--primary) !important;
-    padding: 0 8px;
-    font-size: 75%;
-}
-.wlf-archived__redirect:hover {
-    color: #005f7b;
-}
-';
-
-	// Filter the css.
-	$css = apply_filters( 'wlf_archived_link_css', $css );
-
-	echo '<style>' . $css . '</style>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-}
 
 /**
  * Get image asset URL from filename.

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -73,9 +73,6 @@ if ( is_wp_error( WPCOMSP_WAYBACK_LINK_FIXER_REQUIREMENTS ) ) {
 		\WPCOMSpecialProjects\Wayback_Link_Fixer_Migration\Migration_3::class,
 	);
 
-	add_action( 'wp_head', 'wpcomsp_wayback_link_fixer_render_archived_link_css', 999 );
-
-
 	require_once WPCOMSP_WAYBACK_LINK_FIXER_PATH . 'functions.php';
 	add_action( 'plugins_loaded', array( wpcomsp_wayback_link_fixer_get_plugin_instance(), 'maybe_initialize' ) );
 

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -87,7 +87,7 @@ class Setup_Wizard {
 		add_action(
 			'admin_notices',
 			function () use ( $message ) {
-				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', wp_kses( $message, array( 'a' => array( 'href' => array() ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', wp_kses( $message, array( 'a' => array( 'href' => array() ) ) ) );
 			}
 		);
 	}

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -87,7 +87,7 @@ class Setup_Wizard {
 		add_action(
 			'admin_notices',
 			function () use ( $message ) {
-				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', $message ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', wp_kses( $message, array( 'a' => array( 'href' => array() ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		);
 	}

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -99,7 +99,33 @@ class Report_Table extends \WP_List_Table {
 			'$0' . $help_icon,
 			$bulk_actions
 		);
-		echo $bulk_actions; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$allowed_html = array(
+			'label'  => array(
+				'for'   => array(),
+				'class' => array(),
+			),
+			'select' => array(
+				'name'  => array(),
+				'id'    => array(),
+				'class' => array(),
+			),
+			'option' => array(
+				'value' => array(),
+			),
+			'input'  => array(
+				'type'  => array(),
+				'name'  => array(),
+				'id'    => array(),
+				'class' => array(),
+				'value' => array(),
+			),
+			'span'   => array(
+				'id'    => array(),
+				'class' => array(),
+			),
+		);
+
+		echo wp_kses( $bulk_actions, $allowed_html );
 	}
 
 	/**
@@ -277,7 +303,7 @@ class Report_Table extends \WP_List_Table {
 		$url = home_url() . $redirect;
 
 		// Redirect to the page using JS as page already loaded headers.
-		echo "<script>window.location = '$url';</script>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this is just a redirect.
+		printf( '<script>window.location = "%s";</script>', esc_url( $url ) );
 		exit;
 	}
 

--- a/templates/admin/dashboard/link-list.php
+++ b/templates/admin/dashboard/link-list.php
@@ -12,7 +12,10 @@
  * @param string $wlf_no_links_message Message to display when no links are available.
  */
 
-defined( 'ABSPATH' ) || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 <div class="wlf_dashboard-accordion-content wlf_dashboard-accordion-content<?php echo esc_attr( $wlf_is_active ? '--active' : '' ); ?>" id="<?php echo esc_attr( $wlf_section_id ); ?>">
 	<div class="wlf_dashboard-link-checks">

--- a/templates/admin/dashboard/page.php
+++ b/templates/admin/dashboard/page.php
@@ -25,7 +25,10 @@
  * @param array  $wlf_latest_links     Array of latest links with associated posts.
  */
 
-defined( 'ABSPATH' ) || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 
 // Extract link statistics
 $wlf_total_links_count     = $wlf_link_stats['total_links'] ?? 0;

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -17,7 +17,10 @@
  * @param int    $wlf_failed_check_count      Number of failed checks before marking as broken.
  */
 
-defined( 'ABSPATH' ) || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 <div class="wlf_dashboard-wrapper">

--- a/templates/admin/links-table/help-tab-bulk-actions.php
+++ b/templates/admin/links-table/help-tab-bulk-actions.php
@@ -5,6 +5,10 @@
  * @since 1.3.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 <div id="wlf_help_tab_bulk_actions" class="wlf_help_tab">
 	<h3><?php esc_html_e( 'Update to latest snapshot', 'internet-archive-wayback-machine-link-fixer' ); ?></h3>

--- a/templates/admin/links-table/help-tab-columns.php
+++ b/templates/admin/links-table/help-tab-columns.php
@@ -5,6 +5,11 @@
  * @since 1.3.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
 $wlf_failed_count    = \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings::get_failed_count();
 $wlf_check_frequency = \WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings::get_link_check_duration();
 ?>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -9,10 +9,12 @@
  * @var string $wlf_back_url The URL to return to the report.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Link\Link;
-
-defined( 'ABSPATH' ) || exit;
 
 // Check if we have any previous links to show.
 $wlf_check_count      = count( $wlf_link->get_checks() );

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -185,7 +185,19 @@ $wlf_link_title = wpcomsp_wayback_link_fixer_trim_string( str_replace( array( 'h
 														<?php endif; ?>
 													</a>
 												</td>
-												<td><?php echo wpcomsp_wayback_link_fixer_get_admin_post_type_link( $wlf_post->post_type );  //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, escaped in function ?></td>
+												<td>
+												<?php
+												echo wp_kses(
+													wpcomsp_wayback_link_fixer_get_admin_post_type_link( $wlf_post->post_type ),
+													array(
+														'a' => array(
+															'href' => array(),
+															'target' => array(),
+														),
+													)
+												);
+												?>
+													</td>
 												<td>
 													<?php
 													// Get the post status.

--- a/templates/admin/wizard/complete.php
+++ b/templates/admin/wizard/complete.php
@@ -8,6 +8,10 @@
  * @param string $header The header template.
  * @param string $footer The footer template.
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <?php echo wp_kses_post( $header ); ?>

--- a/templates/admin/wizard/complete.php
+++ b/templates/admin/wizard/complete.php
@@ -10,7 +10,7 @@
  */
 ?>
 
-<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $header ); ?>
 
 <div class="wlf-wizard__content__header">
 	<h2><?php esc_html_e( 'Setup complete.', 'internet-archive-wayback-machine-link-fixer' ); ?></h2>
@@ -29,4 +29,4 @@
 </div>
 
 
-<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $footer ); ?>

--- a/templates/admin/wizard/footer.php
+++ b/templates/admin/wizard/footer.php
@@ -20,13 +20,14 @@ $wlf_progress_string = sprintf(
 	$step_data['progress']['current'],
 	$step_data['progress']['total']
 );
-$wlf_progress_pc = ( $step_data['progress']['current'] / $step_data['progress']['total'] ) * 100;
+$wlf_progress_pc  = ( $step_data['progress']['current'] / $step_data['progress']['total'] ) * 100;
+$wlf_rerun_wizard = isset( $_GET['rerun-wizard'] ) && '1' === sanitize_text_field( $_GET['rerun-wizard'] ); // phpcs:ignore
 ?>
 	</div> <!-- END Wizard content -->
 
 	<div id="wlf-wizard__footer">
 		<div class="wlf-wizard__footer__previous">
-			<?php if ( 'complete' !== $step_data['step'] || (isset($_GET['rerun-wizard']) && '1' === sanitize_text_field($_GET['rerun-wizard']) ) ) : // phpcs:ignore ?>
+			<?php if ( 'complete' !== $step_data['step'] || $wlf_rerun_wizard ) : ?>
 				<button class="button button-primary" type="submit" name="wlf-previous-step" <?php echo esc_attr( $wlf_previous_state ); ?>><?php esc_html_e( 'Previous Step', 'internet-archive-wayback-machine-link-fixer' ); ?></button>
 			<?php endif; ?>
 		</div>

--- a/templates/admin/wizard/footer.php
+++ b/templates/admin/wizard/footer.php
@@ -8,6 +8,10 @@
  * @param array $step_data The step data.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $wlf_previous_state = 'step-1' === $step_data['step'] ? 'DISABLED' : '';
 $wlf_next_state     = 'complete' === $step_data['step'] ? 'DISABLED' : '';
 $wlf_next_label     = 'complete' === $step_data['next']

--- a/templates/admin/wizard/header.php
+++ b/templates/admin/wizard/header.php
@@ -7,6 +7,10 @@
  *
  * @param array  $step_data The step data.
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div id="wlf_wizard" class="wlf_settings_card"> <!-- Wizard container -->

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -12,6 +12,10 @@
  * @param string $footer The footer template.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Sets the type for api keys based on the current environment.
 $wlf_invalid_keys = isset( $_POST['wlf_wizard_invalid_keys'] ); // phpcs:ignore
 $wlf_access_type  = '' === $settings->get_archive_access_key() || $wlf_invalid_keys
@@ -26,7 +30,7 @@ $wlf_existing_access_key = isset( $_POST['wlf_wizard_archive_access_key_temp'] )
 $wlf_existing_secret_key = isset( $_POST['wlf_wizard_archive_secret_key_temp'] ) ? sanitize_text_field( wp_unslash( $_POST['wlf_wizard_archive_secret_key_temp'] ) ) : $settings->get_archive_secret_key(); // phpcs:ignore
 ?>
 
-<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $header ); ?>
 
 <div class="wlf-wizard__content__header">
 	<h2><?php esc_html_e( 'Step 1: Configure the Wayback Machine API', 'internet-archive-wayback-machine-link-fixer' ); ?></h2>
@@ -51,4 +55,4 @@ $wlf_existing_secret_key = isset( $_POST['wlf_wizard_archive_secret_key_temp'] )
 </div>
 
 
-<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $footer ); ?>

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -12,6 +12,10 @@
  * @param string $footer The footer template.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 
 // Holds the class to hide all inputs if not enabled.

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -18,7 +18,7 @@ use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 ?>
 
-<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $header ); ?>
 
 <div class="wlf-wizard__content__header">
 	<h2><?php esc_html_e( 'Step 2: Configure the Link Fixer', 'internet-archive-wayback-machine-link-fixer' ); ?></h2>
@@ -87,4 +87,4 @@ $wlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 	</select>
 </div>
 
-<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $footer ); ?>

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -12,6 +12,10 @@
  * @param string $footer The footer template.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 
 // Holds the class to hide all inputs if not enabled.

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -18,7 +18,7 @@ use WPCOMSpecialProjects\Wayback_Link_Fixer\Settings\Settings;
 $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 ?>
 
-<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $header ); ?>
 
 <div class="wlf-wizard__content__header">
 	<h2><?php esc_html_e( 'Step 3: Configure the Auto Archiver', 'internet-archive-wayback-machine-link-fixer' ); ?></h2>
@@ -68,4 +68,4 @@ $wlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
 	</div>
 </div>
 
-<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo wp_kses_post( $footer ); ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure all template parts are escaped, even if they are escaped in the partials.
* Ensure all files have the no direct access checks

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #202 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Changes
  - Removed automatic archived-link styling from site header; archived links no longer receive special CSS by default.

- Bug Fixes
  - Hardened admin UI output: sanitized notices, bulk actions, report links, and wizard header/footer; escaped redirect URLs.
  - Added access guards to admin templates to prevent direct access.
  - Adjusted wizard navigation so the "Previous Step" button respects the rerun-wizard parameter.

- Refactor
  - Replaced terse access guards with explicit conditionals and minor template cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->