### PR TITLE
now all src dirs shoudl be skipped in zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
             "phpunit.xml.dist" \
             "postcss.config.js" \
             "tests/*" \
-            ".vscode/*"
+            ".vscode/*" \
+            "assets/css/src/*" \
+            "assets/js/src/*"
 
       - name:  Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request makes a small update to the release workflow configuration. The change expands the list of files and directories that are included in the release process.

* Added `assets/css/src/*` and `assets/js/src/*` to the list of paths in the `release.yml` workflow to ensure these source files are included during the release.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined release packaging by excluding development-only source asset folders from release archives.
  - Produces smaller, cleaner download artifacts with only the files needed to run the application.
  - Improves download times and reduces storage footprint for end-users without affecting functionality or compatibility.
  - No changes to public interfaces or behavior; existing workflows and features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->