### PR TITLE
Fix/minor tweaks

### DIFF
--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -289,11 +289,18 @@ class Setup_Wizard {
 	 * @return void
 	 */
 	private function handle_step_2(): void {
+
+		// If next step is not set, bail.
+		if ( ! isset( $_POST['iawmlf-next-step'] ) ) {
+			$this->add_notice( __( 'Next step is not set', 'internet-archive-wayback-machine-link-fixer' ), 'error' );
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		// Get values from the form.
 		$is_active          = isset( $_POST['iawmlf_wizard_activate_link_fixer'] );
 		$allowed_post_types = isset( $_POST['iawmlf_wizard_post_types'] ) && is_array( $_POST['iawmlf_wizard_post_types'] )
-			? array_map( fn( $type ) => sanitize_text_field( wp_unslash( $type ) ), $_POST['iawmlf_wizard_post_types'] )
+			? array_map( fn( $type ) => sanitize_text_field( wp_unslash( $type ) ),  $_POST['iawmlf_wizard_post_types'] )
 			: array();
 		$scan_existing      = isset( $_POST['iawmlf_wizard_scan_existing_content'] );
 		$outcome            = isset( $_POST['iawmlf_wizard_outcome'] ) ? sanitize_text_field( wp_unslash( $_POST['iawmlf_wizard_outcome'] ) ) : 'do_nothing';
@@ -316,6 +323,13 @@ class Setup_Wizard {
 	 * @return void
 	 */
 	private function handle_step_3(): void {
+
+		// If next step is not set, bail.
+		if ( ! isset( $_POST['iawmlf-next-step'] ) ) {
+			$this->add_notice( __( 'Next step is not set', 'internet-archive-wayback-machine-link-fixer' ), 'error' );
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		// Get values from the form.
 		$is_active             = isset( $_POST['iawmlf_wizard_activate_auto_archiver'] );

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -289,9 +289,8 @@ class Setup_Wizard {
 	 * @return void
 	 */
 	private function handle_step_2(): void {
-
 		// If next step is not set, bail.
-		if ( ! isset( $_POST['iawmlf-next-step'] ) ) {
+		if ( ! isset( $_POST['iawmlf-next-step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$this->add_notice( __( 'Next step is not set', 'internet-archive-wayback-machine-link-fixer' ), 'error' );
 			return;
 		}
@@ -300,7 +299,7 @@ class Setup_Wizard {
 		// Get values from the form.
 		$is_active          = isset( $_POST['iawmlf_wizard_activate_link_fixer'] );
 		$allowed_post_types = isset( $_POST['iawmlf_wizard_post_types'] ) && is_array( $_POST['iawmlf_wizard_post_types'] )
-			? array_map( fn( $type ) => sanitize_text_field( wp_unslash( $type ) ),  $_POST['iawmlf_wizard_post_types'] )
+			? array_map( fn( $type ) => sanitize_text_field( wp_unslash( $type ) ), $_POST['iawmlf_wizard_post_types'] )
 			: array();
 		$scan_existing      = isset( $_POST['iawmlf_wizard_scan_existing_content'] );
 		$outcome            = isset( $_POST['iawmlf_wizard_outcome'] ) ? sanitize_text_field( wp_unslash( $_POST['iawmlf_wizard_outcome'] ) ) : 'do_nothing';
@@ -323,9 +322,8 @@ class Setup_Wizard {
 	 * @return void
 	 */
 	private function handle_step_3(): void {
-
 		// If next step is not set, bail.
-		if ( ! isset( $_POST['iawmlf-next-step'] ) ) {
+		if ( ! isset( $_POST['iawmlf-next-step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$this->add_notice( __( 'Next step is not set', 'internet-archive-wayback-machine-link-fixer' ), 'error' );
 			return;
 		}

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -205,8 +205,8 @@ class Report_Table extends \WP_List_Table {
 			return;
 		}
 
-		// Verify the nonce and referrer.
-		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-' . $this->_args['plural'] ) && check_admin_referer( 'bulk-' . $this->_args['plural'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
+		// Check if _wpnonce is not set or is not valid.
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-' . $this->_args['plural'] ) || ! check_admin_referer( 'bulk-' . $this->_args['plural'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, from url so no nonce possible
 			// Add a notice.
 			$this->notices[] = array(
 				'message' => __( 'Something went wrong, please try again', 'internet-archive-wayback-machine-link-fixer' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*
This pull request introduces important improvements to the form validation and security checks in the setup wizard and bulk action processing. The main focus is on ensuring that required form fields are present before proceeding and that nonce verification is handled more robustly to prevent unauthorized actions.

Form validation improvements:

* Added checks in `handle_step_2()` and `handle_step_3()` in `Setup_Wizard.php` to ensure the `iawmlf-next-step` field is set before processing, displaying an error notice and stopping execution if it is missing. [[1]](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5R292-R297) [[2]](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5R325-R330)

Security enhancements:

* Updated the nonce and referrer verification logic in `process_bulk_action()` in `Report_Table.php` to explicitly check for the presence and validity of `_wpnonce` and to ensure both nonce and referrer checks pass before proceeding with bulk actions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Setup Wizard: Added clear error messaging and halted processing when the required next-step field is missing, preventing unintended progression and guiding users to complete required inputs.
  - Reports: Bulk actions now validate request authenticity more strictly. If verification fails, an error message is shown and the action is stopped, preventing accidental or unauthorized operations.
  - Improved overall reliability of multi-step flows and bulk operations by adding consistent early checks and user-facing notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->