### PR TITLE
will now show that a link is still pending if it has never been check…

### DIFF
--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1102,6 +1102,11 @@ class Report_Table extends \WP_List_Table {
 
 			case self::COLUMN_LINK_HEALTH:
 				if ( $item->has_archived_href() || Link::PROCESS_DONE === $item->get_archive_process() ) {
+					// If we have no checks yet, show still pending.
+					if ( 0 === count( $item->get_checks() ) ) {
+						return $this->get_dashicon( 'dashicons-clock', __( 'Link has not been checked yet', 'internet-archive-wayback-machine-link-fixer' ) );
+					}
+
 					return ! $item->is_broken()
 						? $this->get_dashicon( 'dashicons-yes-alt', __( 'Link is active', 'internet-archive-wayback-machine-link-fixer' ) )
 						: $this->get_dashicon( 'dashicons-editor-unlink', __( 'Link is broken', 'internet-archive-wayback-machine-link-fixer' ) );


### PR DESCRIPTION
…ed, in regards to link health

#### Changes proposed in this Pull Request

This pull request makes a small but important improvement to the `column_default` method in `Report_Table.php`. Now, if a link has not yet been checked, the table will display a clock icon to indicate the pending status, providing clearer feedback to users.

* Display a clock icon with a "Link has not been checked yet" message when there are no checks for a link in the `COLUMN_LINK_HEALTH` column.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You should see the following
<img width="1059" height="1003" alt="image" src="https://github.com/user-attachments/assets/b41f4f23-2828-4d94-8ae8-4eb04a4c56a3" />


Mentions #222 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced link status verification to display a new pending state with a visual indicator when a link hasn't been checked yet, improving clarity on verification progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->