### PR TITLE
Add a conditional hook on settings page load that will redirect to th…

### DIFF
--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -93,6 +93,23 @@ class Settings_Page {
 			self::PAGE_SLUG,
 			array( $this, 'render_page' )
 		);
+
+		// If the setup has not been completed, add a on load hook.
+		if ( ! Setup_Wizard::is_setup_complete() ) {
+			add_action( 'load-' . $this->menu_hook, array( $this, 'redirect_to_setup_wizard' ) );
+		}
+	}
+
+	/**
+	 * Redirect to setup wizard if API keys are invalid.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @return  void
+	 */
+	public function redirect_to_setup_wizard(): void {
+		wp_safe_redirect( Setup_Wizard::get_wizard_url() );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
…e wizard

#### Changes proposed in this Pull Request

* When the settings page is accessed and the wizard has not been completed, the wizard should be loaded in place of settings

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #223 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic setup wizard redirection: users with incomplete setup will be directed to the setup wizard when accessing the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->