### PR TITLE
Feature/gh225 add additional details in stat

### DIFF
--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -166,6 +166,7 @@ class Dashboard_Page {
 	private function get_statistics(): array {
 		// Attempt to get from the transient.
 		$stats = get_transient( self::STATS_TRANSIENT_KEY );
+		$stats = false;
 
 		if ( false === $stats || ! is_array( $stats ) ) {
 			$stats = $this->compile_statistics();
@@ -205,7 +206,7 @@ class Dashboard_Page {
 
 		// Loop through all links to gather stats.
 		foreach ( $all_links as $link ) {
-			if ( $link->is_broken() ) {
+			if ( $link->is_broken() && ! empty( $link->get_archived_href() ) ) {
 				$broken[] = $link->get_id();
 			}
 			if ( ! empty( $link->get_archived_href() ) ) {
@@ -314,6 +315,7 @@ class Dashboard_Page {
 		$broken_link = add_query_arg(
 			array(
 				'iawmlf_status' => '1',
+				'iawmlf_has_archive' => '1',
 			),
 			$filtered_url_base
 		);

--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -166,13 +166,12 @@ class Dashboard_Page {
 	private function get_statistics(): array {
 		// Attempt to get from the transient.
 		$stats = get_transient( self::STATS_TRANSIENT_KEY );
-		$stats = false;
 
 		if ( false === $stats || ! is_array( $stats ) ) {
 			$stats = $this->compile_statistics();
 
-			// Store for 2 hours.
-			set_transient( self::STATS_TRANSIENT_KEY, $stats, 2 * HOUR_IN_SECONDS );
+			// Store for 15 minutes.
+			set_transient( self::STATS_TRANSIENT_KEY, $stats, 15 * MINUTE_IN_SECONDS );
 		}
 
 		return $stats;

--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -205,10 +205,10 @@ class Dashboard_Page {
 
 		// Loop through all links to gather stats.
 		foreach ( $all_links as $link ) {
-			if ( $link->is_broken() &&  $link->has_archived_href() ) {
+			if ( $link->is_broken() && $link->has_archived_href() ) {
 				$broken[] = $link->get_id();
 			}
-			if (  $link->has_archived_href() ) {
+			if ( $link->has_archived_href() ) {
 				$has_archive_link[] = $link->get_id();
 			}
 			if ( null === $link->get_last_check() ) {

--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -205,10 +205,10 @@ class Dashboard_Page {
 
 		// Loop through all links to gather stats.
 		foreach ( $all_links as $link ) {
-			if ( $link->is_broken() && ! empty( $link->get_archived_href() ) ) {
+			if ( $link->is_broken() &&  $link->has_archived_href() ) {
 				$broken[] = $link->get_id();
 			}
-			if ( ! empty( $link->get_archived_href() ) ) {
+			if (  $link->has_archived_href() ) {
 				$has_archive_link[] = $link->get_id();
 			}
 			if ( null === $link->get_last_check() ) {

--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -313,7 +313,7 @@ class Dashboard_Page {
 
 		$broken_link = add_query_arg(
 			array(
-				'iawmlf_status' => '1',
+				'iawmlf_status'      => '1',
 				'iawmlf_has_archive' => '1',
 			),
 			$filtered_url_base

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -113,11 +113,6 @@ class Link_Summary_Factory {
 	 */
 	private function was_last_check_successful(): bool {
 		$last_check = $this->link->get_last_check();
-		if ( null === $last_check ) {
-			return false;
-		}
-
-		$last_check = $this->link->get_last_check();
 		if ( ! is_array( $last_check ) || ! isset( $last_check['http_code'] ) ) {
 			return false;
 		}

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -149,4 +149,3 @@ class Link_Summary_Factory {
 		return in_array( $http_code, Settings::get_valid_http_status_codes(), true );
 	}
 }
-

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Utility class to create link summaries.
+ *
+ * @since 1.3.1
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer\Util;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Link_Summary_Factory
+ */
+class Link_Summary_Factory {
+
+	/**
+	 * The link being summarized.
+	 *
+	 * @var Link
+	 */
+	private $link;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Link $link The link to summarize.
+	 */
+	public function __construct( Link $link ) {
+		$this->link = $link;
+	}
+
+	/**
+	 * Get the summary of the link.
+	 *
+	 * @return string
+	 */
+	public function get_summary(): string {
+		if ( Link::PROCESS_DONE !== $this->link->get_archive_process() ) {
+			return __( 'The link is still being processed to find or create an archive snapshot. Please check back later.', 'internet-archive-wayback-machine-link-fixer' );
+		}
+
+		return $this->link->has_archived_href()
+			? $this->get_archive_snapshot_message()
+			: $this->get_no_archive_snapshot_message();
+	}
+
+	/**
+	 * Compiles the message if the link has an archive.org snapshot.
+	 *
+	 * @return string
+	 */
+	private function get_archive_snapshot_message(): string {
+		$last_check_status = $this->was_last_check_successful();
+		$last_failed_count = $this->get_consecutive_failed_checks_count();
+
+		// If the last check was successful, return early.
+		if ( $last_check_status ) {
+			return __( 'The link is archived on archive.org and still working.', 'internet-archive-wayback-machine-link-fixer' );
+		}
+
+		// If we have more failed checks than the threshold, return the redirected already message.
+		if ( $last_failed_count >= Settings::get_failed_count() ) {
+			return sprintf(
+				// translators: The number of failed checks.
+				__( 'This link is redirecting to the archived version, after %d failed checks.', 'internet-archive-wayback-machine-link-fixer' ),
+				$last_failed_count
+			);
+		}
+
+		return sprintf(
+		// translators: 1: The number of failed checks. 2: The number of remaining checks before redirect. 3: Plural S if needed.
+			__( 'The link is archived on archive.org but currently not working. It has failed %1$d previous consecutive check%3$s, %2$d more and it will redirect to the archived version.', 'internet-archive-wayback-machine-link-fixer' ),
+			$last_failed_count,
+			Settings::get_failed_count() - $last_failed_count,
+			1 === $last_failed_count ? '' : 's'
+		);
+	}
+
+	/**
+	 * Compiles the message if the link does not have an archive.org snapshot.
+	 *
+	 * @return string
+	 */
+	private function get_no_archive_snapshot_message(): string {
+		if ( $this->was_last_check_successful() ) {
+			return __( 'The link is not archived on archive.org but is currently working.', 'internet-archive-wayback-machine-link-fixer' );
+		}
+
+		return sprintf(
+		// translators: 1: The number of failed checks. 2: The plural S if needed.
+			__( 'The link is not archived on archive.org and currently not working. It has failed %1$d previous consecutive check%2$s.', 'internet-archive-wayback-machine-link-fixer' ),
+			$this->get_consecutive_failed_checks_count(),
+			1 === $this->get_consecutive_failed_checks_count() ? '' : 's'
+		);
+	}
+
+	/**
+	 * Checks if the last check was a success.
+	 *
+	 * @return boolean
+	 */
+	private function was_last_check_successful(): bool {
+		$last_check = $this->link->get_last_check();
+		if ( null === $last_check ) {
+			return false;
+		}
+
+		return $this->is_http_code_valid( absint( $last_check['http_code'] ) );
+	}
+
+	/**
+	 * Gets the count of consecutive failed checks.
+	 *
+	 * @return integer
+	 */
+	private function get_consecutive_failed_checks_count(): int {
+		$checks       = $this->link->get_checks();
+		$failed_count = 0;
+		foreach ( array_reverse( $checks ) as $check ) {
+			// If we dont have a http code, skip it.
+			if ( is_array( $check ) === false || ! isset( $check['http_code'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->is_http_code_valid( absint( $check['http_code'] ) ) ) {
+				++$failed_count;
+			} else {
+				break;
+			}
+		}
+		return $failed_count;
+	}
+
+	/**
+	 * Checks if a given HTTP code is considered valid.
+	 *
+	 * @param integer $http_code The HTTP code to check.
+	 *
+	 * @return boolean
+	 */
+	private function is_http_code_valid( int $http_code ): bool {
+		return in_array( $http_code, Settings::get_valid_http_status_codes(), true );
+	}
+}
+

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -59,6 +59,11 @@ class Link_Summary_Factory {
 	private function get_archive_snapshot_message(): string {
 		$last_check_status = $this->was_last_check_successful();
 		$last_failed_count = $this->get_consecutive_failed_checks_count();
+		$last_check        = $this->link->get_last_check();
+
+		if ( null === $last_check ) {
+			return __( 'The link is archived on archive.org. No check history yet.', 'internet-archive-wayback-machine-link-fixer' );
+		}
 
 		// If the last check was successful, return early.
 		if ( $last_check_status ) {
@@ -128,8 +133,8 @@ class Link_Summary_Factory {
 		$checks       = $this->link->get_checks();
 		$failed_count = 0;
 		foreach ( array_reverse( $checks ) as $check ) {
-			// If we dont have a http code, skip it.
-			if ( is_array( $check ) === false || ! isset( $check['http_code'] ) ) {
+			// Skip malformed items.
+			if ( ! is_array( $check ) || ! array_key_exists( 'http_code', $check ) ) {
 				continue;
 			}
 

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -112,6 +112,10 @@ class Link_Summary_Factory {
 			return false;
 		}
 
+		$last_check = $this->link->get_last_check();
+		if ( ! is_array( $last_check ) || ! isset( $last_check['http_code'] ) ) {
+			return false;
+		}
 		return $this->is_http_code_valid( absint( $last_check['http_code'] ) );
 	}
 

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -90,17 +90,10 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 						<div class="inside">
 							<p class="iawmlf_link_broken">
 								<?php
-								$iawmlf_normal_state_string = ( 0 === count( $iawmlf_link->get_checks() ) )
-									? esc_html__( 'Not yet checked', 'internet-archive-wayback-machine-link-fixer' )
-									: sprintf(
-										// translators: %d is the number of consecutive failures required to mark a link as 'Broken'.
-										esc_html__( 'Monitoring: Link will be marked as \'Broken\' after %d consecutive failures.', 'internet-archive-wayback-machine-link-fixer' ),
-										Settings::get_failed_count()
-									);
 								printf(
 									'<strong>%s</strong>: %s',
 									esc_html__( 'Current Status', 'internet-archive-wayback-machine-link-fixer' ),
-									$iawmlf_link->is_broken() ? esc_html__( 'Broken', 'internet-archive-wayback-machine-link-fixer' ) : esc_html( $iawmlf_normal_state_string )
+									wp_kses_post( ( new Internet_Archive\Wayback_Machine_Link_Fixer\Util\Link_Summary_Factory( $iawmlf_link ) )->get_summary() )
 								);
 								?>
 							</p>
@@ -129,7 +122,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 										</tr>
 									<?php endif; ?>
 
-									<?php foreach ( $iawmlf_link->get_checks() as $iawmlf_index => $iawmlf_check ) : ?>
+									<?php foreach ( array_reverse( $iawmlf_link->get_checks() ) as $iawmlf_index => $iawmlf_check ) : ?>
 										<?php // Hide the first n posts to the value of $iawmlf_hide_check_count. ?>
 										<?php if ( $iawmlf_index < $iawmlf_hide_check_count ) : ?>
 											<tr class="iawmlf_hidden_check" style="display: none;">

--- a/tests/Util/Test_Link_Summary_Factory.php
+++ b/tests/Util/Test_Link_Summary_Factory.php
@@ -191,7 +191,7 @@ class Test_Link_Summary_Factory extends \WP_UnitTestCase {
 		$summary = $factory->get_summary();
 
 		$this->assertStringContainsString( 'archived on archive.org', $summary );
-		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'No check history yet', $summary );
 	}
 
 	/**

--- a/tests/Util/Test_Link_Summary_Factory.php
+++ b/tests/Util/Test_Link_Summary_Factory.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * Unit tests for the Link_Summary_Factory class.
+ *
+ * @since 1.3.1
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Link_Summary_Factory
+ *
+ * @group Util
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Util;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Util\Link_Summary_Factory;
+
+/**
+ * Test_Link_Summary_Factory
+ */
+class Test_Link_Summary_Factory extends \WP_UnitTestCase {
+
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox It should return a processing message when the link is still being processed.
+	 *
+	 * @return void
+	 */
+	public function test_returns_processing_message_when_link_still_processing(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_PENDING );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'still being processed', $summary );
+	}
+
+	/**
+	 * @testdox It should return a processing message when the link is new.
+	 *
+	 * @return void
+	 */
+	public function test_returns_processing_message_when_link_is_new(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_NEW );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'still being processed', $summary );
+	}
+
+	/**
+	 * @testdox It should return archived and working message when link has archive and last check is successful.
+	 *
+	 * @return void
+	 */
+	public function test_returns_archived_working_message_when_archive_exists_and_working(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 200, '2024-01-01 12:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'still working', $summary );
+	}
+
+	/**
+	 * @testdox It should return archived but failing message with singular check when link has archive and 1 failed check.
+	 *
+	 * @return void
+	 */
+	public function test_returns_archived_failing_message_with_singular_check(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 500, '2024-01-01 12:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 1 previous consecutive check', $summary );
+		$this->assertStringContainsString( '4 more', $summary );
+		$this->assertStringNotContainsString( 'checks', $summary );
+	}
+
+	/**
+	 * @testdox It should return archived but failing message with plural checks when link has archive and multiple failed checks.
+	 *
+	 * @return void
+	 */
+	public function test_returns_archived_failing_message_with_plural_checks(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 2 previous consecutive checks', $summary );
+		$this->assertStringContainsString( '3 more', $summary );
+	}
+
+	/**
+	 * @testdox It should return not archived but working message when link has no archive and is working.
+	 *
+	 * @return void
+	 */
+	public function test_returns_not_archived_working_message_when_no_archive_and_working(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->add_check( 200, '2024-01-01 12:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'not archived on archive.org', $summary );
+		$this->assertStringContainsString( 'currently working', $summary );
+	}
+
+	/**
+	 * @testdox It should return not archived and failing message with singular check when link has no archive and 1 failed check.
+	 *
+	 * @return void
+	 */
+	public function test_returns_not_archived_failing_message_with_singular_check(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->add_check( 500, '2024-01-01 12:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'not archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 1 previous consecutive check', $summary );
+		$this->assertStringNotContainsString( 'checks', $summary );
+	}
+
+	/**
+	 * @testdox It should return not archived and failing message with plural checks when link has no archive and multiple failed checks.
+	 *
+	 * @return void
+	 */
+	public function test_returns_not_archived_failing_message_with_plural_checks(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'not archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 2 previous consecutive checks', $summary );
+	}
+
+	/**
+	 * @testdox It should handle null last check by treating it as failed.
+	 *
+	 * @return void
+	 */
+	public function test_handles_null_last_check_as_failed(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+	}
+
+	/**
+	 * @testdox It should handle checks with missing http_code by skipping them.
+	 *
+	 * @return void
+	 */
+	public function test_handles_checks_with_missing_http_code(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+
+		// Add a check with missing http_code
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 200, '2024-01-01 11:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'still working', $summary );
+	}
+
+	/**
+	 * @testdox It should handle boundary condition when failed checks equal the threshold.
+	 *
+	 * @return void
+	 */
+	public function test_handles_boundary_condition_at_threshold(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 500, '2024-01-01 09:00:00' );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 3 previous consecutive checks', $summary );
+		$this->assertStringContainsString( '2 more', $summary );
+	}
+
+	/**
+	 * @testdox It should handle mixed valid and invalid checks correctly.
+	 *
+	 * @return void
+	 */
+	public function test_handles_mixed_valid_and_invalid_checks(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 200, '2024-01-01 09:00:00' );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'archived on archive.org', $summary );
+		$this->assertStringContainsString( 'not working', $summary );
+		$this->assertStringContainsString( 'failed 2 previous consecutive checks', $summary );
+		$this->assertStringContainsString( '3 more', $summary );
+	}
+
+	/**
+	 * @testdox It should handle empty archived href as no archive.
+	 *
+	 * @return void
+	 */
+	public function test_handles_empty_archived_href_as_no_archive(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( '' );
+		$link->add_check( 200, '2024-01-01 12:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'not archived on archive.org', $summary );
+		$this->assertStringContainsString( 'currently working', $summary );
+	}
+
+	/**
+	 * @testdox It should return redirect message when failed checks meet the threshold.
+	 *
+	 * @return void
+	 */
+	public function test_returns_redirect_message_when_failed_checks_meet_threshold(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 500, '2024-01-01 09:00:00' );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+		$link->add_check( 500, '2024-01-01 12:00:00' );
+		$link->add_check( 500, '2024-01-01 13:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'redirecting to the archived version', $summary );
+		$this->assertStringContainsString( 'after 5 failed checks', $summary );
+	}
+
+	/**
+	 * @testdox It should return redirect message when failed checks exceed the threshold.
+	 *
+	 * @return void
+	 */
+	public function test_returns_redirect_message_when_failed_checks_exceed_threshold(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_archive_process( Link::PROCESS_DONE );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$link->add_check( 500, '2024-01-01 08:00:00' );
+		$link->add_check( 500, '2024-01-01 09:00:00' );
+		$link->add_check( 500, '2024-01-01 10:00:00' );
+		$link->add_check( 500, '2024-01-01 11:00:00' );
+		$link->add_check( 500, '2024-01-01 12:00:00' );
+		$link->add_check( 500, '2024-01-01 13:00:00' );
+
+		$factory = new Link_Summary_Factory( $link );
+		$summary = $factory->get_summary();
+
+		$this->assertStringContainsString( 'redirecting to the archived version', $summary );
+		$this->assertStringContainsString( 'after 6 failed checks', $summary );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds in a text message on the link report page which explains the current link states

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #225 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic link status summaries in reports with clearer archived vs non‑archived messages, correct pluralization, and redirect warnings.

* **Bug Fixes**
  * Broken-link detection now requires an archived copy to be present before counting as broken.

* **Performance**
  * Dashboard statistics cache shortened from 2 hours to 15 minutes for fresher data.

* **Improvements**
  * Check history displayed most-recent-first for readability.

* **Tests**
  * Added comprehensive unit tests covering summary messaging and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->