### PR TITLE
Changed labels in the dashboard pages and added tool tips

### DIFF
--- a/src/Dashboard/Dashboard_Page.php
+++ b/src/Dashboard/Dashboard_Page.php
@@ -192,25 +192,32 @@ class Dashboard_Page {
 	 * }
 	 */
 	private function compile_statistics(): array {
-		$all_links = $this->link_repository->query_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, null, false );
+		$all_links = $this->link_repository->query_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, null, null );
 
 		// Get all the links stats.
-		$broken           = array();
-		$has_archive_link = array();
-		$not_checked      = array();
-		$process_done     = array();
-		$process_new      = array();
-		$process_pending  = array();
-		$last_checks      = array();
+		$all_broken        = array();
+		$redirected_broken = array();
+		$has_archive_link  = array();
+		$not_checked       = array();
+		$process_done      = array();
+		$process_new       = array();
+		$process_pending   = array();
+		$last_checks       = array();
 
 		// Loop through all links to gather stats.
 		foreach ( $all_links as $link ) {
-			if ( $link->is_broken() && $link->has_archived_href() ) {
-				$broken[] = $link->get_id();
+			if ( $link->is_broken() ) {
+				$all_broken[] = $link->get_id();
 			}
+
+			if ( $link->is_broken() && $link->has_archived_href() ) {
+				$redirected_broken[] = $link->get_id();
+			}
+
 			if ( $link->has_archived_href() ) {
 				$has_archive_link[] = $link->get_id();
 			}
+
 			if ( null === $link->get_last_check() ) {
 				$not_checked[] = $link->get_id();
 			} else {
@@ -243,15 +250,17 @@ class Dashboard_Page {
 		);
 
 		$stats = array(
-			'total_links'           => count( $all_links ),
-			'broken_links'          => count( $broken ),
-			'links_with_archive'    => count( $has_archive_link ),
-			'links_without_archive' => count( $all_links ) - count( $has_archive_link ),
-			'not_checked'           => count( $not_checked ),
-			'process_done'          => count( $process_done ),
-			'process_new'           => count( $process_new ),
-			'process_pending'       => count( $process_pending ),
-			'last_checks'           => array_slice( $last_checks, 0, $this->links_per_section ),
+			'total_links'                 => count( $all_links ),
+			'all_broken_links'            => count( $all_broken ),
+			'broken_and_redirected_links' => count( $redirected_broken ),
+			'broken_not_redirected_links' => count( $all_broken ) - count( $redirected_broken ),
+			'links_with_archive'          => count( $has_archive_link ),
+			'links_without_archive'       => count( $all_links ) - count( $has_archive_link ),
+			'not_checked'                 => count( $not_checked ),
+			'process_done'                => count( $process_done ),
+			'process_new'                 => count( $process_new ),
+			'process_pending'             => count( $process_pending ),
+			'last_checks'                 => array_slice( $last_checks, 0, $this->links_per_section ),
 		);
 
 		return $stats;
@@ -311,10 +320,17 @@ class Dashboard_Page {
 			$filtered_url_base
 		);
 
-		$broken_link = add_query_arg(
+		$broken_with_redirected = add_query_arg(
 			array(
 				'iawmlf_status'      => '1',
 				'iawmlf_has_archive' => '1',
+			),
+			$filtered_url_base
+		);
+
+		$all_broken_link = add_query_arg(
+			array(
+				'iawmlf_status' => '1',
 			),
 			$filtered_url_base
 		);
@@ -329,24 +345,25 @@ class Dashboard_Page {
 		iawmlf_render_template(
 			'admin/dashboard/page.php',
 			array(
-				'iawmlf_link_stats'              => $link_stats,
-				'iawmlf_last_checks'             => $last_checks,
-				'iawmlf_latest_links'            => $latest_links,
-				'iawmlf_account_details'         => Dashboard_Notifications::get_account_details(),
-				'iawmlf_api_configured'          => Settings::is_archive_api_configured(),
-				'iawmlf_is_online'               => iawmlf_is_archive_api_online(),
-				'iawmlf_link_to_settings'        => Settings_Page::get_page_url(),
-				'iawmlf_link_table'              => Report_Page::get_page_url(),
-				'iawmlf_auto_archiver_enabled'   => Settings::add_own_links(),
-				'iawmlf_scan_existing_enabled'   => Settings::should_scan_existing_posts(),
-				'iawmlf_link_processing_enabled' => Settings::is_link_processing_enabled(),
-				'iawmlf_link_check_duration'     => Settings::get_link_check_duration(),
-				'iawmlf_failed_check_count'      => Settings::get_failed_count(),
-				'iawmlf_report_page_base'        => $report_page_base,
-				'iawmlf_filtered_broken'         => esc_url( $broken_link ),
-				'iawmlf_filtered_valid'          => esc_url( $valid_link ),
-				'iawmlf_filtered_has_archive'    => esc_url( $has_archive_link ),
-				'iawmlf_filtered_no_archive'     => esc_url( $has_no_archive_link ),
+				'iawmlf_link_stats'                 => $link_stats,
+				'iawmlf_last_checks'                => $last_checks,
+				'iawmlf_latest_links'               => $latest_links,
+				'iawmlf_account_details'            => Dashboard_Notifications::get_account_details(),
+				'iawmlf_api_configured'             => Settings::is_archive_api_configured(),
+				'iawmlf_is_online'                  => iawmlf_is_archive_api_online(),
+				'iawmlf_link_to_settings'           => Settings_Page::get_page_url(),
+				'iawmlf_link_table'                 => Report_Page::get_page_url(),
+				'iawmlf_auto_archiver_enabled'      => Settings::add_own_links(),
+				'iawmlf_scan_existing_enabled'      => Settings::should_scan_existing_posts(),
+				'iawmlf_link_processing_enabled'    => Settings::is_link_processing_enabled(),
+				'iawmlf_link_check_duration'        => Settings::get_link_check_duration(),
+				'iawmlf_failed_check_count'         => Settings::get_failed_count(),
+				'iawmlf_report_page_base'           => $report_page_base,
+				'iawmlf_filtered_broken_redirected' => esc_url( $broken_with_redirected ),
+				'iawmlf_filtered_broken_all'        => esc_url( $all_broken_link ),
+				'iawmlf_filtered_valid'             => esc_url( $valid_link ),
+				'iawmlf_filtered_has_archive'       => esc_url( $has_archive_link ),
+				'iawmlf_filtered_no_archive'        => esc_url( $has_no_archive_link ),
 			)
 		);
 	}

--- a/templates/admin/dashboard/page.php
+++ b/templates/admin/dashboard/page.php
@@ -39,15 +39,14 @@ $iawmlf_process_new           = $iawmlf_link_stats['process_new'] ?? 0;
 $iawmlf_process_pending       = $iawmlf_link_stats['process_pending'] ?? 0;
 $iawmlf_still_processing      = $iawmlf_process_new + $iawmlf_process_pending;
 $iawmlf_broken_redirected     = $iawmlf_link_stats['broken_and_redirected_links'] ?? 0;
-$iawmlf_broken_not_redirected = $iawmlf_link_stats['broken_and_not_redirected_links'] ?? 0;
+$iawmlf_broken_not_redirected = $iawmlf_link_stats['broken_not_redirected_links'] ?? 0;
 
 // Compile the tooltips
-$iawmlf_tooltip_links_saved          = __( 'These broken links are being redirected to archived snapshots on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
-$iawmlf_tooltip_archived_sucessfully = __( 'These links have snapshots available on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
-$iawmlf_tooltip_with_archive         = __( 'These links do not have snapshots available on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
-$iawmlf_tooltip_no_archive           = __( 'These links do not have archived snapshots on the Wayback Machine, so we can\'t redirect them.', 'internet-archive-wayback-machine-link-fixer' );
-$iawmlf_tooltip_checks_in_progress   = __( 'The plugin is still working through checking the status of these links and whether archived snapshots are available.', 'internet-archive-wayback-machine-link-fixer' );
-$iawmlf_tooltip_broken_links         = sprintf(
+$iawmlf_tooltip_links_saved           = __( 'These broken links are being redirected to archived snapshots on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_archived_successfully = __( 'These links have snapshots available on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_no_archive            = __( 'These links do not have archived snapshots on the Wayback Machine, so we can\'t redirect them.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_checks_in_progress    = __( 'The plugin is still working through checking the status of these links and whether archived snapshots are available.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_broken_links          = sprintf(
 	// translators: 1: number of broken links being redirected, 2: number of broken links not being redirected.
 	__( '%1$s being redirected, %2$s inedible for redirect', 'internet-archive-wayback-machine-link-fixer' ),
 	$iawmlf_broken_redirected,
@@ -136,10 +135,10 @@ $iawmlf_tooltip_broken_links         = sprintf(
 
 						<!-- Row 2: With Archive | Without -->
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--success">
-							<a href="<?php echo esc_url( $iawmlf_filtered_has_archive ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_archived_sucessfully ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
+							<a href="<?php echo esc_url( $iawmlf_filtered_has_archive ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_archived_successfully ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
 								<?php echo esc_html( $iawmlf_links_with_archive ); ?>
 							</a>
-							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_archived_sucessfully ); ?>"><?php esc_html_e( 'Archived Successfully', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_archived_successfully ); ?>"><?php esc_html_e( 'Archived Successfully', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--warning">
 							<a href="<?php echo esc_url( $iawmlf_filtered_no_archive ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_no_archive ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">

--- a/templates/admin/dashboard/page.php
+++ b/templates/admin/dashboard/page.php
@@ -4,33 +4,33 @@
  *
  * @since 1.3.0
  *
- * @param array  $iawmlf_account_details       The account details from Archive.org.
- * @param bool   $iawmlf_api_configured   Whether the Archive.org API is configured.
- * @param bool   $iawmlf_is_online        Whether the Archive.org API is online.
- * @param string $iawmlf_link_to_settings URL to the settings page.
- * @param string $iawmlf_link_table       URL to the links report page.
- * @param string $iawmlf_report_page_base Base URL to the report page.
- * @param string $iawmlf_filtered_broken  URL to filtered broken links report.
- * @param string $iawmlf_filtered_valid   URL to filtered valid links report.
- * @param string $iawmlf_filtered_has_archive URL to filtered links with archive report.
- * @param string $iawmlf_filtered_no_archive  URL to filtered links without archive report.
- * @param array  $iawmlf_total_links            Array of all links in the system (for widget).
+ * @param array  $iawmlf_account_details         The account details from Archive.org.
+ * @param bool   $iawmlf_api_configured          Whether the Archive.org API is configured.
+ * @param bool   $iawmlf_is_online               Whether the Archive.org API is online.
+ * @param string $iawmlf_link_to_settings        URL to the settings page.
+ * @param string $iawmlf_link_table              URL to the links report page.
+ * @param string $iawmlf_report_page_base        Base URL to the report page.
+ * @param string $iawmlf_filtered_valid          URL to filtered valid links report.
+ * @param string $iawmlf_filtered_has_archive    URL to filtered links with archive report.
+ * @param string $iawmlf_filtered_no_archive     URL to filtered links without archive report.
+ * @param array  $iawmlf_total_links             Array of all links in the system (for widget).
  * @param bool   $iawmlf_auto_archiver_enabled   Whether auto archiver is enabled.
  * @param bool   $iawmlf_scan_existing_enabled   Whether scanning existing posts is enabled.
  * @param bool   $iawmlf_link_processing_enabled Whether link processing is enabled.
  * @param int    $iawmlf_link_check_duration     Number of days between link checks.
  * @param int    $iawmlf_failed_check_count      Number of failed checks before marking as broken.
- * @param array  $iawmlf_link_stats       Link statistics array.
- * @param array  $iawmlf_last_checks      Array of last 10 link checks with associated posts.
- * @param array  $iawmlf_latest_links     Array of latest links with associated posts.
+ * @param array  $iawmlf_link_stats              Link statistics array.
+ * @param array  $iawmlf_last_checks             Array of last 10 link checks with associated posts.
+ * @param array  $iawmlf_latest_links            Array of latest links with associated posts.
+ * @param string $iawmlf_filtered_broken_all     URL to all broken links report.
+ * @param string $iawmlf_filtered_redirected     URL to all redirected links report.
  */
-
 defined( 'ABSPATH' ) || exit;
 
 
 // Extract link statistics
 $iawmlf_total_links_count     = $iawmlf_link_stats['total_links'] ?? 0;
-$iawmlf_broken_links          = $iawmlf_link_stats['broken_links'] ?? 0;
+$iawmlf_all_broken_links      = $iawmlf_link_stats['all_broken_links'] ?? 0;
 $iawmlf_links_with_archive    = $iawmlf_link_stats['links_with_archive'] ?? 0;
 $iawmlf_links_without_archive = $iawmlf_link_stats['links_without_archive'] ?? 0;
 $iawmlf_not_checked           = $iawmlf_link_stats['not_checked'] ?? 0;
@@ -38,6 +38,21 @@ $iawmlf_process_done          = $iawmlf_link_stats['process_done'] ?? 0;
 $iawmlf_process_new           = $iawmlf_link_stats['process_new'] ?? 0;
 $iawmlf_process_pending       = $iawmlf_link_stats['process_pending'] ?? 0;
 $iawmlf_still_processing      = $iawmlf_process_new + $iawmlf_process_pending;
+$iawmlf_broken_redirected     = $iawmlf_link_stats['broken_and_redirected_links'] ?? 0;
+$iawmlf_broken_not_redirected = $iawmlf_link_stats['broken_and_not_redirected_links'] ?? 0;
+
+// Compile the tooltips
+$iawmlf_tooltip_links_saved          = __( 'These broken links are being redirected to archived snapshots on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_archived_sucessfully = __( 'These links have snapshots available on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_with_archive         = __( 'These links do not have snapshots available on the Wayback Machine.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_no_archive           = __( 'These links do not have archived snapshots on the Wayback Machine, so we can\'t redirect them.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_checks_in_progress   = __( 'The plugin is still working through checking the status of these links and whether archived snapshots are available.', 'internet-archive-wayback-machine-link-fixer' );
+$iawmlf_tooltip_broken_links         = sprintf(
+	// translators: 1: number of broken links being redirected, 2: number of broken links not being redirected.
+	__( '%1$s being redirected, %2$s inedible for redirect', 'internet-archive-wayback-machine-link-fixer' ),
+	$iawmlf_broken_redirected,
+	$iawmlf_broken_not_redirected
+);
 ?>
 
 <div class="wrap">
@@ -105,47 +120,44 @@ $iawmlf_still_processing      = $iawmlf_process_new + $iawmlf_process_pending;
 						<div class="iawmlf_dashboard-status-section">
 					<h3 class="iawmlf_dashboard-section-title"><?php esc_html_e( 'Link Statistics Overview', 'internet-archive-wayback-machine-link-fixer' ); ?></h3>
 					<div class="iawmlf_dashboard-stats-grid iawmlf_dashboard-stats-sidebar">
-						<!-- Row 1: Total Links | Still Processing -->
+						<!-- Row 1: Total Links | Being Redirected -->
 						<div class="iawmlf_dashboard-stats-box">
 							<a href="<?php echo esc_url( $iawmlf_link_table ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
 								<?php echo esc_html( $iawmlf_total_links_count ); ?>
 							</a>
 							<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'Total Links', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
-						<div class="iawmlf_dashboard-stats-box <?php echo 0 === $iawmlf_still_processing ? 'iawmlf_dashboard-stats-box--success' : 'iawmlf_dashboard-stats-box--info'; ?>">
-							<?php if ( 0 === $iawmlf_still_processing ) : ?>
-								<div class="iawmlf_dashboard-stats-number">✓</div>
-								<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'All Links Processed', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
-							<?php else : ?>
-								<div class="iawmlf_dashboard-stats-number"><?php echo esc_html( $iawmlf_still_processing ); ?></div>
-								<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'Still Processing', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
-							<?php endif; ?>
+						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--danger">
+							<a href="<?php echo esc_url( $iawmlf_filtered_broken_redirected ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_links_saved ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
+								<?php echo esc_html( $iawmlf_broken_redirected ); ?>
+							</a>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_links_saved ); ?>"><?php esc_html_e( 'Links Saved', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 
 						<!-- Row 2: With Archive | Without -->
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--success">
-							<a href="<?php echo esc_url( $iawmlf_filtered_has_archive ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
+							<a href="<?php echo esc_url( $iawmlf_filtered_has_archive ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_archived_sucessfully ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
 								<?php echo esc_html( $iawmlf_links_with_archive ); ?>
 							</a>
-							<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'With Archive', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_archived_sucessfully ); ?>"><?php esc_html_e( 'Archived Successfully', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--warning">
-							<a href="<?php echo esc_url( $iawmlf_filtered_no_archive ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
+							<a href="<?php echo esc_url( $iawmlf_filtered_no_archive ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_no_archive ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
 								<?php echo esc_html( $iawmlf_links_without_archive ); ?>
 							</a>
-							<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'Without Archive', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_no_archive ); ?>"><?php esc_html_e( 'Ineligible for redirect', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 
-						<!-- Row 3: Not Checked | Broken Links -->
+						<!-- Row 3: Checks in progress | Broken Links -->
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--info">
-							<div class="iawmlf_dashboard-stats-number"><?php echo esc_html( $iawmlf_not_checked ); ?></div>
-							<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'Not Checked', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+							<div class="iawmlf_dashboard-stats-number" title="<?php echo esc_attr( $iawmlf_tooltip_checks_in_progress ); ?>"><?php echo esc_html( $iawmlf_not_checked ); ?></div>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_checks_in_progress ); ?>"><?php esc_html_e( 'Checks in progress', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 						<div class="iawmlf_dashboard-stats-box iawmlf_dashboard-stats-box--danger">
-							<a href="<?php echo esc_url( $iawmlf_filtered_broken ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
-								<?php echo esc_html( $iawmlf_broken_links ); ?>
+							<a href="<?php echo esc_url( $iawmlf_filtered_broken_all ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_broken_links ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
+								<?php echo esc_html( $iawmlf_all_broken_links ); ?>
 							</a>
-							<div class="iawmlf_dashboard-stats-label"><?php esc_html_e( 'Broken Links', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+							<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_broken_links ); ?>"><?php esc_html_e( 'Total Broken Links', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request refactors and enhances the link statistics and dashboard display for the Internet Archive Wayback Machine Link Fixer plugin. The main improvements are the introduction of more granular broken link statistics, better tooltips for dashboard clarity, and updated URLs for filtered reports. These changes make it easier for users to understand the status of their links and which ones are being redirected or are ineligible for redirection.

**Statistics and logic improvements:**

* Separated broken link statistics into three categories: all broken links, broken links being redirected (have an archive), and broken links not being redirected (no archive). This provides more detailed insight into link status. [[1]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58L195-R199) [[2]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58R209-R220) [[3]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58L247-R256)

* Updated the dashboard statistics array and variable names to reflect the new categories, replacing the old `broken_links` count with `all_broken_links`, `broken_and_redirected_links`, and `broken_not_redirected_links`. [[1]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58L247-R256) [[2]](diffhunk://#diff-b411cf73dce12ec62da4b7537438f70595475f2f9d69ad059a6e58c74352a3fdR25-R55)

**Dashboard UI and UX enhancements:**

* Added new dashboard stats boxes and updated existing ones to display the new link categories, including "Links Saved" (redirected broken links) and "Total Broken Links". Tooltips have been added for better user understanding.

* Improved the labeling and tooltips for stats related to archived links, ineligible links, and checks in progress, making the dashboard more informative and user-friendly.

**URL and template updates:**

* Introduced new filtered report URLs for all broken links and redirected broken links, and updated the dashboard and template parameter documentation accordingly. [[1]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58L314-R337) [[2]](diffhunk://#diff-6052914230b88b4632b04aec8a6561ee25f46a8f0c218a60e91ea071b5c21f58L346-R363) [[3]](diffhunk://#diff-b411cf73dce12ec62da4b7537438f70595475f2f9d69ad059a6e58c74352a3fdL13) [[4]](diffhunk://#diff-b411cf73dce12ec62da4b7537438f70595475f2f9d69ad059a6e58c74352a3fdR25-R55)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #226 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reorganized dashboard metrics for clearer link-status visualization, including separate counts for broken+redirected and broken-not-redirected.
  * Updated dashboard labels and tooltips: "Links Saved," "Archived Successfully," "Checks in Progress," and "Total Broken Links."
  * Enhanced link filtering on the dashboard to expose redirected-broken and all-broken views for easier investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->