### PR TITLE
Use base_prefix for link table to ensure its shared on network

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -66,7 +66,7 @@ class Settings {
 	 */
 	public static function get_link_table_name(): string {
 		global $wpdb;
-		return $wpdb->prefix . self::LINK_TABLE;
+		return $wpdb->base_prefix . self::LINK_TABLE;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request makes a small change to the method that determines the database table name for links in the `Settings` class. The change ensures that the table uses the global base prefix instead of the site-specific prefix, which is important for multisite WordPress installations.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a post a sub site (not main) and you should not see any editor errors.

Mentions #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multisite WordPress compatibility by correcting how link table names are resolved in multisite environments where different prefixes are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->