### PR TITLE
Feature/ensure no output when do nothing selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,19 @@ add_filter( 'iawmlf_link_checker_timeout', function( int $timeout ): int {
 });
 ```
 
+#### `iawmlf_should_render_html_link_output`
+
+This filter allows you to control whether the HTML link output should be rendered in the frontend for post loops. By default, this is only enabled when the fixer option is set to "Replace Link".
+
+```php
+add_filter( 'iawmlf_should_render_html_link_output', function( bool $allowed, string $option ): bool {
+   // Example: Always render the HTML link output regardless of fixer option
+   return true;
+}, 10, 2 );
+```
+
+> **Note:** The HTML link output is used to provide link data to the frontend JavaScript for post loops. If disabled, the link data won't be available for JavaScript processing in loop contexts.
+
 #### `iawmlf_posts_per_batch`
 
 This is used to define how many posts should be checked, when the plugin is scanning existing posts.

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -402,6 +402,29 @@ class Settings {
 	}
 
 	/**
+	 * Checks if the HTML link output should be rendered in the frontend.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return boolean
+	 */
+	public static function should_render_html_link_output(): bool {
+		$allowed = in_array( self::get_fixer_option(), array( self::FIXER_OPTION_REPLACE_LINK ), true );
+
+		/**
+		 * Filter to allow or disallow the HTML link output in the frontend.
+		 *
+		 * @since 1.3.1
+		 *
+		 * @param boolean $allowed Whether the HTML link output should be rendered.
+		 * @param string  $option  The current fixer option.
+		 *
+		 * @return boolean
+		 */
+		return (bool) apply_filters( 'iawmlf_should_render_html_link_output', $allowed, self::get_fixer_option() );
+	}
+
+	/**
 	 * Clear all the options.
 	 *
 	 * @since 1.3.0

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -61,7 +61,8 @@ class WP_Post_Controller {
 		add_action( 'save_post', array( $this, 'on_save_post_process_post_links' ), 10, 3 );
 		add_action( 'save_post', array( $this, 'on_save_post_process_own_post' ), 10, 3 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_script' ) );
-		add_filter( 'render_block', array( $this, 'render_block' ), 999, 2 );  }
+		add_filter( 'render_block', array( $this, 'render_block' ), 999, 2 );
+	}
 
 	/**
 	 * Handles the save post action.
@@ -260,6 +261,10 @@ class WP_Post_Controller {
 	 * @return string
 	 */
 	public function render_block( string $block_content, array $block ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( ! Settings::should_render_html_link_output() ) {
+			return $block_content;
+		}
+
 		static $posts = array();
 
 		$post_id = get_the_ID();

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -302,4 +302,30 @@ class Test_Settings extends \WP_UnitTestCase {
 		$this->assertEmpty( get_option( Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE ) );
 		$this->assertEmpty( get_option( Settings::ROUTINELY_UPDATE_WAYBACK_MACHINE_INTERVAL ) );
 	}
+
+	/**
+	 * @testdox It should be possible to check if the HTML link output should be rendered in the frontend.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return void
+	 */
+	public function test_should_render_html_link_output(): void {
+		// Set the option to replace link.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+		$this->assertTrue( Settings::should_render_html_link_output() );
+
+		// Set the option to do nothing.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_DO_NOTHING );
+		$this->assertFalse( Settings::should_render_html_link_output() );
+
+		// Set the option to replace link via a filter.
+		add_filter( 'iawmlf_should_render_html_link_output', function () {
+			return true;
+		} );
+		$this->assertTrue( Settings::should_render_html_link_output() );
+
+		// Clean up.
+		remove_all_filters( 'iawmlf_should_render_html_link_output' );
+	}
 }

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -494,4 +494,70 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		$this->assertEmpty( get_post_meta( $post_id_2, Settings::OWN_LINK_LAST_PROCESSED ) );
 		$this->assertEmpty( get_post_meta( $post_id_3, Settings::OWN_LINK_LAST_PROCESSED ) );
 	}
+
+	/**
+	 * @testdox When an option is selected to fix links, it should be rendered out the HTML.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return void
+	 */
+	public function test_render_html_link_output(): void {
+		// Set the option to render the HTML link output.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		$post_id = \WP_UnitTestCase_Base::factory()->post->create();
+
+		$content = 'This is a post with a link to <a href="https://from.post/content">example</a><br>And another link to <a href="https://from.post/content_twice">example</a>';
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+				'post_type'    => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// Render the block.
+		$rendered = do_blocks( $GLOBALS['post']->post_content );
+
+		// Check contains the data-iawmlf-post-links attribute.
+		$this->assertStringContainsString( 'data-iawmlf-post-links', $rendered );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * @testdox When an option is selected to do nothing, it should not render out the HTML link output.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return void
+	 */
+	public function test_do_nothing_option_not_render_html_link_output(): void {
+		// Set the option to do nothing.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_DO_NOTHING );
+
+		$post_id = \WP_UnitTestCase_Base::factory()->post->create();
+
+		$content = 'This is a post with a link to <a href="https://from.post/content">example</a><br>And another link to <a href="https://from.post/content_twice">example</a>';
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+				'post_type'    => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// Render the block.
+		$rendered = do_blocks( $GLOBALS['post']->post_content );
+
+		// Check does not contain the data-iawmlf-post-links attribute.
+		$this->assertStringNotContainsString( 'data-iawmlf-post-links', $rendered );
+
+		unset( $GLOBALS['post'] );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure that choosing "Do Nothing" will not render out the DIV with the links
* Adds a filter (`iawmlf_should_render_html_link_output`) that allow overriding this. This means someone can add there own link handler via JS
* Adds tests to ensure it works on rendering and the filtering.
* Adds filter docs to the readme.md

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New configuration filter for controlling HTML link output rendering in post loops. Default behavior tied to existing settings, with documentation showing how to customize behavior.

* **Documentation**
  * Enhanced configuration documentation with new examples and clarified settings descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->