### PR TITLE
Bumped to 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.8  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.3.1 
+**Stable tag:** 1.3.2 
 **License:** GPL-3.0-or-later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.1
+ * @version     1.3.2
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.1
+ * Version:                 1.3.2
  * Requires at least:       6.4
  * Tested up to:            6.8
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.1' );
+define( 'IAWMLF_VERSION', '1.3.2' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "A WordPress plugin that scans content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, creating snapshots of your own pages and other site links that aren’t yet archived. Uses Action Scheduler for background tasks.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -111,12 +111,15 @@ The Internet Archive is a non-profit organization dedicated to preserving digita
 
 == Changelog ==
 
-= 1.3.0 =
-* Initial public release.
+= 1.3.2 =
+* Bugfix
 
 = 1.3.1 =
 * Makes various UI and UX changes around icons, tool tips and labels.
 * Also fixes a few minor bugs regarding the settings and wizard flows.
+
+= 1.3.0 =
+* Initial public release.
 
 Note: All versions prior to 1.3.0 were not publicly released.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* 
This pull request is a version bump for the Internet Archive Wayback Machine Link Fixer plugin, updating it from version 1.3.1 to 1.3.2. The main change is a bugfix release, with all relevant metadata files updated to reflect the new version.

Version and changelog updates:

* Updated the plugin version to `1.3.2` in `internet-archive-wayback-machine-link-fixer.php`, `package.json`, `README.md`, and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8) [[6]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added a new changelog entry for version `1.3.2`, indicating a bugfix release, and adjusted the changelog order in `readme.txt`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version 1.3.2 released with bugfix improvements

* **Chores**
  * Version updated to 1.3.2 across documentation and package files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->