### PR TITLE
now will use the custom web-wp subdomain for most calls and archive u…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -342,6 +342,8 @@ function iawmlf_is_archive_link( string $url ): bool {
 	$urls = array(
 		'https://web.archive.org/web/',
 		'http://web.archive.org/web/',
+		'https://web-wp.archive.org/web/',
+		'http://web-wp.archive.org/web/',
 	);
 
 	foreach ( $urls as $archive_url ) {

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -264,8 +264,23 @@ class Link implements \JsonSerializable {
 	 * @return string
 	 */
 	public function get_archived_href(): ?string {
-		return $this->archived_href;
+		$archived_href = $this->archived_href;
+
+		if ( null === $archived_href || '' === $archived_href ) {
+			return $archived_href;
+		}
+
+		// If the url starts http(s)://web.archive.org/web/, replace it with http(s)://web-wp.archive.org/web/
+		if ( 0 === strpos( $archived_href, 'https://web.archive.org/web/' ) ) {
+			$archived_href = str_replace( 'https://web.archive.org/web/', 'https://web-wp.archive.org/web/', $archived_href );
+		}
+		if ( 0 === strpos( $archived_href, 'http://web.archive.org/web/' ) ) {
+			$archived_href = str_replace( 'http://web.archive.org/web/', 'http://web-wp.archive.org/web/', $archived_href );
+		}
+
+		return $archived_href;
 	}
+
 
 	/**
 	 * Get the checks.

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
@@ -298,7 +298,7 @@ class HTTP_Snapshot_Client implements Snapshot_Client {
 			throw new Exception( 'Invalid snapshot job id' );
 		}
 
-		$query_url = 'https://web.archive.org/save/status/' . $job_id;
+		$query_url = 'https://web-wp.archive.org/save/status/' . $job_id;
 
 		// Get the status of the job.
 		$response = wp_safe_remote_get( $query_url, array( 'headers' => $this->get_headers() ) );

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -145,7 +145,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		// Check the link status is now done.
 		$this->assertEquals( Link::PROCESS_DONE, $link->get_archive_process() );
 
-		$this->assertEquals( 'https://web.archive.org/web/iawmlf_glynn/https://example.com', $link->get_archived_href() );
+		$this->assertEquals( 'https://web-wp.archive.org/web/iawmlf_glynn/https://example.com', $link->get_archived_href() );
 
 		// Remove the filter.
 		remove_all_filters( 'iawmlf_snapshot_client' );

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -65,7 +65,7 @@ class Test_Link extends \WP_UnitTestCase {
 		$this->assertNull( $link->get_archived_href() );
 
 		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
-		$this->assertSame( 'https://web.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
 	}
 
 	/**
@@ -257,7 +257,7 @@ class Test_Link extends \WP_UnitTestCase {
 			array(
 				'id'            => 1,
 				'href'          => 'https://example.com',
-				'archived_href' => 'https://web.archive.org/web/20240101000000/https://example.com',
+				'archived_href' => 'https://web-wp.archive.org/web/20240101000000/https://example.com',
 				'redirect_href' => 'https://example.com',
 				'checks'        => array(
 					array(
@@ -274,7 +274,7 @@ class Test_Link extends \WP_UnitTestCase {
 
 		$this->assertSame( 1, $link->get_id() );
 		$this->assertSame( 'https://example.com', $link->get_href() );
-		$this->assertSame( 'https://web.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
 		$this->assertSame( 'https://example.com', $link->get_redirect_href() );
 		$this->assertSame(
 			array(
@@ -395,5 +395,24 @@ class Test_Link extends \WP_UnitTestCase {
 
 		$link->set_excluded();
 		$this->assertTrue( $link->is_excluded() );
+	}
+
+	/**
+	 * @testdox When we get a snapshot url from the model, it should be reparsed as web-wp.archive.org to web.archive.org
+	 *
+	 * @since 1.3.2
+	 *
+	 * @return void
+	 */
+	public function test_can_reparse_snapshot_url(): void {
+		// HTTPS
+		$link = new Link( 'https://example.com' );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101000000/https://example.com' );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+
+		// HTTP
+		$link = new Link( 'http://example.com' );
+		$link->set_archived_href( 'http://web.archive.org/web/20240101000000/https://example.com' );
+		$this->assertSame( 'http://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
 	}
 }

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -49,6 +49,28 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Archive link check data provider.
+	 *
+	 * @return array
+	 */
+	public static function is_archive_link_provider(): array {
+		return array(
+			'HTTPS web.archive.org'         => array( 'https://web.archive.org/web/20230101000000/https://example.com', true ),
+			'HTTP web.archive.org'          => array( 'http://web.archive.org/web/20230101000000/https://example.com', true ),
+			'HTTPS web-wp.archive.org'      => array( 'https://web-wp.archive.org/web/20230101000000/https://example.com', true ),
+			'HTTP web-wp.archive.org'       => array( 'http://web-wp.archive.org/web/20230101000000/https://example.com', true ),
+			'HTTPS web.archive.org no path' => array( 'https://web.archive.org/web/', true ),
+			'HTTP web.archive.org no path'  => array( 'http://web.archive.org/web/', true ),
+			'Regular HTTPS URL'             => array( 'https://example.com', false ),
+			'Regular HTTP URL'              => array( 'http://example.com', false ),
+			'Archive.org but not web'       => array( 'https://archive.org/details/something', false ),
+			'Contains but not starts with'  => array( 'https://example.com/web.archive.org/web/', false ),
+			'Almost matching URL'           => array( 'https://web.archive.org/details/', false ),
+			'Empty string'                  => array( '', false ),
+		);
+	}
+
+	/**
 	 * @testdox It should be possible to normalize a URL.
 	 *
 	 * @dataProvider normalize_url_provider
@@ -60,6 +82,20 @@ class Test_Functions extends \WP_UnitTestCase {
 	 */
 	public function test_can_normalize_url( string $url, string $expected ): void {
 		$this->assertSame( $expected, \iawmlf_normalize_url( $url ) );
+	}
+
+	/**
+	 * @testdox It should correctly identify Internet Archive links.
+	 *
+	 * @dataProvider is_archive_link_provider
+	 *
+	 * @param string $url      The URL to check.
+	 * @param bool   $expected The expected result.
+	 *
+	 * @return void
+	 */
+	public function test_can_identify_archive_links( string $url, bool $expected ): void {
+		$this->assertSame( $expected, \iawmlf_is_archive_link( $url ) );
 	}
 
 	/**


### PR DESCRIPTION
…rls provided. This includes changes to the base urls used for api calls and updates all url when the link model gets the archive url using the helper function. This is includes new tests to ensure that web.archive and web-wp.archive are ignored, not just web.archive]

#### Changes proposed in this Pull Request

This pull request updates the handling of Internet Archive snapshot URLs to use the `web-wp.archive.org` domain instead of `web.archive.org` throughout the codebase. It ensures that all generated and processed archive links are consistent with this new domain, and updates tests accordingly to validate the new behavior.

**Archive URL handling updates:**

* Updated the list of recognized archive URL prefixes in `iawmlf_is_archive_link` to include both `http(s)://web-wp.archive.org/web/` and `http(s)://web.archive.org/web/`.
* Modified `Link::get_archived_href()` to automatically convert any `web.archive.org` URL to the `web-wp.archive.org` format when retrieving the archived link.
* Changed the snapshot status query URL in `HTTP_Snapshot_Client::get_snapshot_status` to use `web-wp.archive.org`.

**Test updates:**

* Updated all relevant tests in `Test_Link.php` and `Test_Find_Or_Create_Snapshot.php` to expect and assert the `web-wp.archive.org` domain in archived URLs. [[1]](diffhunk://#diff-a8f3c1ff4c456d25da78763b7ab2603a5ee2b9c149175accc9b06d8c3b91b5e5L148-R148) [[2]](diffhunk://#diff-c6b42f8b224ee86702ed94822418c20bca2dce8cf9275ddcbd6c8e5aa30de35eL68-R68) [[3]](diffhunk://#diff-c6b42f8b224ee86702ed94822418c20bca2dce8cf9275ddcbd6c8e5aa30de35eL260-R260) [[4]](diffhunk://#diff-c6b42f8b224ee86702ed94822418c20bca2dce8cf9275ddcbd6c8e5aa30de35eL277-R277)
* Added a new test to verify that `get_archived_href()` always returns the `web-wp.archive.org` version, even if the original value was set to `web.archive.org`.
* Introduced a new data provider and test in `Test_Functions.php` to ensure `iawmlf_is_archive_link()` correctly identifies both `web.archive.org` and `web-wp.archive.org` URLs as archive links. [[1]](diffhunk://#diff-180f71bee5dcfd679ea80d5b3ecbf715e4055eac69e9deb83f4d622ba4bd8434R51-R72) [[2]](diffhunk://#diff-180f71bee5dcfd679ea80d5b3ecbf715e4055eac69e9deb83f4d622ba4bd8434R87-R100)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Look at existing or new links, the urls you should see in reports and when links are fixed, using the new subdomain
<img width="1091" height="376" alt="image" src="https://github.com/user-attachments/assets/e4d4f68b-94bb-49c7-aaa8-5ad1ed99e469" />


Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Added support for an alternative archive domain variant. The system now recognizes and normalizes archive links consistently across both domain variants.
  * Updated the service endpoint used for checking archive snapshot status.

* **Tests**
  * Added comprehensive tests for archive link identification and URL normalization verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->