### PR TITLE
now if you choose do nothing, not even the jS or css is enqueued

### DIFF
--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -206,6 +206,12 @@ class WP_Post_Controller {
 	 * @return void
 	 */
 	public function enqueue_frontend_script(): void {
+
+		// If the HTML link output should not be rendered, do not enqueue the script.
+		if ( ! Settings::should_render_html_link_output() ) {
+			return;
+		}
+
 		// Get the post id.
 		$post_id = get_the_ID();
 

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -560,4 +560,27 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		unset( $GLOBALS['post'] );
 	}
+
+	/**
+	 * @testdox When the HTML link output should not be rendered, it should not enqueue the script.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return void
+	 */
+	public function test_do_nothing_option_not_enqueue_script(): void {
+		// Set the option to do nothing.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_DO_NOTHING );
+		// update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		// Enqueue the script.
+		$handler = new WP_Post_Controller();
+		$handler->enqueue_frontend_script();
+		do_action( 'wp_enqueue_scripts' );
+
+		// Ensure the script is not enqueued.
+		$enqueued_scripts = wp_scripts()->queue;
+
+		$this->assertNotContains( 'iawm-link-fixer-front-link-checker', $enqueued_scripts );
+	}
 }

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -571,7 +571,6 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	public function test_do_nothing_option_not_enqueue_script(): void {
 		// Set the option to do nothing.
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_DO_NOTHING );
-		// update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
 
 		// Enqueue the script.
 		$handler = new WP_Post_Controller();

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -35,7 +35,24 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		\remove_all_filters( 'iawmlf_own_content_post_types' );
 		\remove_all_filters( 'iawmlf_own_content_allow_post' );
 
+		// Reset the wp scripts globals
+		$GLOBALS['wp_scripts'] = new \WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
 		parent::set_up();
+	}
+
+	/**
+	 * Tare Down
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		// Reset the wp scripts globals
+		$GLOBALS['wp_scripts'] = new \WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
+		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds a conditional check to prevent the frontend script from being enqueued when the HTML link output is disabled, and introduces a corresponding test to ensure this behavior works as expected.

Frontend script loading logic:

* Updated `enqueue_frontend_script` in `WP_Post_Controller.php` to return early and skip enqueuing the script if `Settings::should_render_html_link_output()` is false.

Testing:

* Added `test_do_nothing_option_not_enqueue_script` in `Test_WP_Post_Controller.php` to verify that the script is not enqueued when the "do nothing" option is set.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Front-end link checker no longer loads when HTML link output rendering is disabled.

* **Tests**
  * Added test ensuring the script is not enqueued when rendering is disabled.
  * Improved test lifecycle setup/teardown to reset script state between tests for reliable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->