### PR TITLE
now the unauthenticated messages are only shown on the settings page. T…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -271,12 +271,13 @@ function iawmlf_get_date_format(): string {
  * @return void
  */
 function iawmlf_render_not_authenticated_notice(): void {
+
 	$in_unauthenticated_mode = __( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'internet-archive-wayback-machine-link-fixer' );
 
 	// If the archive api is not configured.
 	if ( ! Settings::is_archive_api_configured() ) {
 		?>
-		<div class="notice notice-error">
+		<div class="notice notice-error is-dismissible">
 			<p>
 				<?php echo esc_html( $in_unauthenticated_mode ); ?>
 			</p>

--- a/functions.php
+++ b/functions.php
@@ -271,7 +271,6 @@ function iawmlf_get_date_format(): string {
  * @return void
  */
 function iawmlf_render_not_authenticated_notice(): void {
-
 	$in_unauthenticated_mode = __( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'internet-archive-wayback-machine-link-fixer' );
 
 	// If the archive api is not configured.

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -267,7 +267,6 @@ class Report_Page {
 
 		// Render any notices.
 		$table->render_notices();
-		iawmlf_render_not_authenticated_notice();
 
 		// Get the current page.
 		$current_page = isset( $_REQUEST['page'] ) ? \sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : self::SLUG; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -567,6 +567,8 @@ class Settings_Page {
 			array( 'class' => Settings::is_link_processing_enabled() ? 'iawmlf_toggle_setting__fixer' : 'iawmlf_toggle_setting__fixer hidden' )
 		);
 
+		$empty_api_creds = '' === Settings::get_archive_access_key() && '' === Settings::get_archive_secret_key();
+
 		add_settings_field(
 			Settings::ARCHIVE_ORG_ACCESS_KEY,
 			__( 'Archive.org Access Key', 'internet-archive-wayback-machine-link-fixer' ),
@@ -574,7 +576,7 @@ class Settings_Page {
 			self::PAGE_SLUG,
 			self::GROUP_IA_SETTINGS,
 			array(
-				'class' => Settings::has_valid_archive_api_credentials() ? '' : 'iawmlf_toggle_setting__invalid_api_keys',
+				'class' => Settings::has_valid_archive_api_credentials() || $empty_api_creds ? '' : 'iawmlf_toggle_setting__invalid_api_keys',
 			)
 		);
 
@@ -585,7 +587,7 @@ class Settings_Page {
 			self::PAGE_SLUG,
 			self::GROUP_IA_SETTINGS,
 			array(
-				'class' => Settings::has_valid_archive_api_credentials() ? '' : 'iawmlf_toggle_setting__invalid_api_keys',
+				'class' => Settings::has_valid_archive_api_credentials() || $empty_api_creds ? '' : 'iawmlf_toggle_setting__invalid_api_keys',
 			)
 		);
 
@@ -633,6 +635,11 @@ class Settings_Page {
 	 * @return string
 	 */
 	public function render_invalid_api_keys_message(): string {
+		// If both keys are empty, do not show any message.
+		if ( '' === Settings::get_archive_access_key() && '' === Settings::get_archive_secret_key() ) {
+			return '';
+		}
+
 		if ( ! Settings::has_valid_archive_api_credentials() ) {
 			return '<div id="invalid_api_creds"><p class="description">' . esc_html__( 'The Archive.org API keys are invalid. Please check your settings.', 'internet-archive-wayback-machine-link-fixer' ) . '</p></div>' .
 			'<div id="unchecked_api_creds" style="display: none;"><p class="description">' . esc_html__( 'API credentials will be verified when you save the settings.', 'internet-archive-wayback-machine-link-fixer' ) . '</p></div>';

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -22,12 +22,6 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <div class="iawmlf_dashboard-wrapper">
-	<?php if ( ! $iawmlf_api_configured ) : ?>
-		<div class="iawmlf_dashboard-warning">
-			<?php esc_html_e( 'You are using Link Fixer in unauthenticated mode, which restricts you to 4000 new snapshots per day. To unlock higher limits, please enter your API credentials to authenticate with Archive.org.', 'internet-archive-wayback-machine-link-fixer' ); ?>
-		</div>
-	<?php endif; ?>
-
 	<?php if ( $iawmlf_api_configured && ! \Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings::has_valid_archive_api_credentials() ) : ?>
 		<div class="iawmlf_dashboard-warning">
 			<?php esc_html_e( 'Your Archive.org API credentials are invalid. Please check your settings.', 'internet-archive-wayback-machine-link-fixer' ); ?>

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -52,6 +52,4 @@ $iawmlf_existing_secret_key = isset( $_POST['iawmlf_wizard_archive_secret_key_te
 	<input type="<?php echo esc_html( $iawmlf_secret_type ); ?>" name="iawmlf_wizard_archive_secret_key" value="<?php echo esc_attr( $iawmlf_existing_secret_key ); ?>"<?php echo $iawmlf_invalid_keys ? ' class="invalid"' : ''; ?>/>
 </div>
 
-
-
 <?php echo wp_kses( $footer, \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Esc::wizard_allowed_tags() ); ?>

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -35,7 +35,7 @@ $iawmlf_existing_secret_key = isset( $_POST['iawmlf_wizard_archive_secret_key_te
 </div>
 
 <div class="iawmlf-wizard__content__intro">
-	<p><?php esc_html_e( 'To archive more than 4000 links from your site to the Wayback Machine per day, you\'ll need a free archive.org account. Once you have your account, enter the API Access Key and Secret Key below.', 'internet-archive-wayback-machine-link-fixer' ); ?>
+	<p><?php esc_html_e( 'To archive more than 4000 links from your site to the Wayback Machine per day, you\'ll need a free archive.org account. Once you have your account, enter the API Access Key and Secret Key below. (Optional)', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		<br /><a href="https://archive.org/account/s3.php" target="_blank"><?php esc_html_e( 'Get your API keys here.', 'internet-archive-wayback-machine-link-fixer' ); ?></a></p>
 </div>
 
@@ -51,6 +51,7 @@ $iawmlf_existing_secret_key = isset( $_POST['iawmlf_wizard_archive_secret_key_te
 	</label>
 	<input type="<?php echo esc_html( $iawmlf_secret_type ); ?>" name="iawmlf_wizard_archive_secret_key" value="<?php echo esc_attr( $iawmlf_existing_secret_key ); ?>"<?php echo $iawmlf_invalid_keys ? ' class="invalid"' : ''; ?>/>
 </div>
+
 
 
 <?php echo wp_kses( $footer, \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Esc::wizard_allowed_tags() ); ?>


### PR DESCRIPTION
…he notice of invalid API creds, doenst show if no keys entered, only if we have keys and they are wrong.

#### Changes proposed in this Pull Request

This pull request refines how unauthenticated and invalid API credential notices are displayed in the Link Fixer plugin. It ensures that users only see relevant warnings, improves the logic for showing/hiding messages, and clarifies that providing API credentials is optional for higher limits. The changes focus on better user experience in both the dashboard and settings wizard.

**User notice improvements:**

* The unauthenticated mode notice is now dismissible, enhancing user experience in the admin area.
* The dashboard widget no longer displays the unauthenticated mode warning, reducing redundant messaging to users.

**Settings page logic and messaging:**

* The settings page now only shows the "invalid API keys" warning if credentials are entered but invalid, and hides it entirely if both keys are empty.
* The CSS class logic for API key fields was updated to avoid marking fields as invalid when both keys are empty, ensuring clearer feedback to users. [[1]](diffhunk://#diff-2ad02316ffadba1bd1476340dc53e92ea494f6b363d6567fe8691594bc00602bR570-R579) [[2]](diffhunk://#diff-2ad02316ffadba1bd1476340dc53e92ea494f6b363d6567fe8691594bc00602bL588-R590)

**Wizard improvements:**

* The wizard step now clarifies that entering API credentials is optional for unlocking higher limits.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #241 
