### PR TITLE
Release/1.3.3 rc3

### DIFF
--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.3-RC2
+ * @version     1.3.3-RC3
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.3-RC2
+ * Version:                 1.3.3-RC3
  * Requires at least:       6.4
  * Tested up to:            6.8
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.3-RC2' );
+define( 'IAWMLF_VERSION', '1.3.3-RC3' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ The Internet Archive is a non-profit organization dedicated to preserving digita
 * Fixes various issues with the dashboard icons and counts
 * Better handling of authentication issues and notices
 * Detect staging sites and prevent auto archiving from running.
+* Fixes bug where a missing auto archiving database option can result in posts still be indexed.
 
 = 1.3.2 =
 * Bugfix


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin to version `1.3.3-RC3` and includes a bugfix related to auto archiving. The main change is to address an issue where posts could still be indexed if the auto archiving database option was missing.

Version update:

* Bumped the plugin version from `1.3.3-RC2` to `1.3.3-RC3` in `internet-archive-wayback-machine-link-fixer.php` and updated the version constant. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33)

Bugfix:

* Fixed a bug where a missing auto archiving database option could result in posts still being indexed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.3.3-RC3.

* **Bug Fixes**
  * Fixed missing auto archiving database option that prevented posts from being indexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->