### PR TITLE
Fix/resolve settings defaults

### DIFF
--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -220,7 +220,19 @@ class Setup_Wizard {
 			return;
 		}
 
-		$index    = array_keys( self::STEPS );
+		$steps = self::STEPS;
+
+		// If we are on staging, ensure, the step-3 is skipped.
+		if ( ! Environmental::is_production() ) {
+			unset( $steps['step-3'] );
+
+			// If the current state is step-3, set to 2.
+			if ( 'step-3' === $current_step ) {
+				$current_step = 'step-2';
+			}
+		}
+
+		$index    = array_keys( $steps );
 		$previous = array_search( $current_step, $index, true ) - 1;
 
 		// Update the step.
@@ -312,8 +324,16 @@ class Setup_Wizard {
 		update_option( Settings::FIXER_OPTION, $outcome );
 
 		// Update the step.
-		$next = sanitize_text_field( wp_unslash( $_POST['iawmlf-next-step'] ) );
-		update_option( self::OPTION_NAME, $next );
+
+		// If we are not on production, mark the setup as complete, else just step 2.
+		if ( ! Environmental::is_production() ) {
+			// Update the step.
+			update_option( self::OPTION_NAME, 'complete' );
+			update_option( self::HAS_COMPLETED, true );
+		} else {
+			$next = sanitize_text_field( wp_unslash( $_POST['iawmlf-next-step'] ) );
+			update_option( self::OPTION_NAME, $next );
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
@@ -417,11 +437,21 @@ class Setup_Wizard {
 	private function get_step_data(): array {
 		$state = get_option( self::OPTION_NAME, 'step-1' );
 
+		// If state is not valid, set to step-1.
+		if ( ! array_key_exists( $state, self::STEPS ) ) {
+			$state = 'step-1';
+		}
+
 		$steps = self::STEPS;
 
 		// If we are on staging, ensure, the step-3 is skipped.
 		if ( ! Environmental::is_production() ) {
 			unset( $steps['step-3'] );
+
+			// If the current state is step-3, set to 2.
+			if ( 'step-3' === $state ) {
+				$state = 'step-2';
+			}
 		}
 
 		$index      = array_keys( $steps );

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -196,14 +196,16 @@ class Settings {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @param boolean $default_value Optional default value if not set. Default false.
+	 *
 	 * @return boolean
 	 */
-	public static function should_scan_existing_posts(): bool {
+	public static function should_scan_existing_posts( bool $default_value = false ): bool {
 		// If you can not process links, return false.
-		if ( ! self::is_link_processing_enabled() ) {
+		if ( ! self::is_link_processing_enabled( $default_value ) ) {
 			return false;
 		}
-		return (bool) get_option( self::SCAN_EXISTING_POSTS, true );
+		return (bool) get_option( self::SCAN_EXISTING_POSTS, $default_value );
 	}
 
 	/**
@@ -256,10 +258,12 @@ class Settings {
 	 *
 	 * @since 1.3.0
 	 *
+	 * @param string $default_value Optional default value if not set. Default FIXER_OPTION_REPLACE_LINK.
+	 *
 	 * @return string
 	 */
-	public static function get_fixer_option(): string {
-		return esc_attr( get_option( self::FIXER_OPTION, self::FIXER_OPTION_REPLACE_LINK ) );
+	public static function get_fixer_option( string $default_value = self::FIXER_OPTION_REPLACE_LINK ): string {
+		return esc_attr( get_option( self::FIXER_OPTION, $default_value ) );
 	}
 
 	/**

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 
 // Holds the class to hide all inputs if not enabled.
-$iawmlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
+$iawmlf_hide_class = Settings::is_link_processing_enabled( true ) ? '' : ' disabled';
 ?>
 
 <?php echo wp_kses( $header, \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Esc::wizard_allowed_tags() ); ?>
@@ -65,7 +65,7 @@ $iawmlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 			<label for="iawmlf_wizard_scan_existing_content">
 				<?php esc_html_e( 'Scan Existing Content', 'internet-archive-wayback-machine-link-fixer' ); ?>
 			</label>
-			<input type="checkbox" name="iawmlf_wizard_scan_existing_content" id="iawmlf_wizard_scan_existing_content" value="1" <?php checked( Settings::should_scan_existing_posts() ); ?> />
+			<input type="checkbox" name="iawmlf_wizard_scan_existing_content" id="iawmlf_wizard_scan_existing_content" value="1" <?php checked( Settings::should_scan_existing_posts( true ) ); ?> />
 		</div>
 		<p class="description"><?php esc_html_e( 'If enabled, all existing posts of the selected types will be scanned and processed. Please note this process can take significant time (potentially hours or days) depending on the amount of content and number of links.', 'internet-archive-wayback-machine-link-fixer' ); ?></p>
 	</div>
@@ -80,10 +80,10 @@ $iawmlf_hide_class = Settings::is_link_processing_enabled() ? '' : ' disabled';
 		id="iawmlf_wizard_outcome"
 		name="iawmlf_wizard_outcome"
 	>
-		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
+		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option( Settings::FIXER_OPTION_REPLACE_LINK ), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
 			<?php esc_html_e( 'Replace Link (No Notification)', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</option>
-		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
+		<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option( Settings::FIXER_OPTION_REPLACE_LINK ), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
 			<?php esc_html_e( 'Do Nothing', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</option>
 	</select>

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 
 // Holds the class to hide all inputs if not enabled.
-$iawmlf_hide_class = Settings::add_own_links() ? '' : ' disabled';
+$iawmlf_hide_class = Settings::add_own_links( true ) ? '' : ' disabled';
 ?>
 
 <?php echo wp_kses( $header, \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Esc::wizard_allowed_tags() ); ?>

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -216,12 +216,28 @@ class Test_Settings extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_can_define_if_existing_posts_should_be_scanned(): void {
-		// By default, existing posts should be scanned.
-		$this->assertTrue( Settings::should_scan_existing_posts() );
+		// By default, existing posts should not be scanned.
+		$this->assertFalse( Settings::should_scan_existing_posts() );
 
 		\update_option( Settings::SCAN_EXISTING_POSTS, true );
 
 		$this->assertTrue( Settings::should_scan_existing_posts() );
+	}
+
+	/**
+	 * @testdox It should be possible to force the default value for getting if existing posts should be scanned.
+	 *
+	 * @return void
+	 */
+	public function test_can_force_default_value_for_should_scan_existing_posts(): void {
+		// Remove the option to ensure we are using the default.
+		\delete_option( Settings::SCAN_EXISTING_POSTS );
+
+		// When we force the default value to false, it should return false.
+		$this->assertFalse( Settings::should_scan_existing_posts( false ) );
+
+		// When we force the default value to true, it should return true.
+		$this->assertTrue( Settings::should_scan_existing_posts( true ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request introduces improvements to the setup wizard flow and enhances the flexibility of settings retrieval by allowing default values to be specified. The main changes include conditional skipping of step 3 in the setup wizard for non-production environments, marking setup as complete earlier in staging, and updating settings methods to support custom default values. Additionally, the related templates and tests were updated to reflect these changes.

### Setup Wizard Flow Improvements

* The setup wizard now conditionally skips `step-3` when not in production, ensuring smoother onboarding in staging environments. The wizard also marks the setup as complete after step 2 in non-production, rather than advancing to step 3. (`src/Dashboard/Setup_Wizard.php`) [[1]](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5L223-R235) [[2]](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5R327-R336) [[3]](diffhunk://#diff-24847d354acb022634b27d75e1bd460a9a7a92cb9e9d3a0968a41d875119edc5R440-R454)

### Settings API Enhancements

* The methods `should_scan_existing_posts` and `get_fixer_option` in `Settings` now accept optional default values, allowing callers to specify what should be returned if the option is not set. (`src/Settings/Settings.php`) [[1]](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aR199-R208) [[2]](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aR261-R266)

### Template Updates

* The setup wizard templates (`step-2.php` and `step-3.php`) were updated to use the new default value parameters in `Settings` methods, ensuring correct UI behavior when options are unset. (`templates/admin/wizard/step-2.php`, `templates/admin/wizard/step-3.php`) [[1]](diffhunk://#diff-4cd8c837ca523e3c54a705bf1c4b439c82986693686783d435a76e47acfa7ad7L20-R20) [[2]](diffhunk://#diff-4cd8c837ca523e3c54a705bf1c4b439c82986693686783d435a76e47acfa7ad7L68-R68) [[3]](diffhunk://#diff-4cd8c837ca523e3c54a705bf1c4b439c82986693686783d435a76e47acfa7ad7L83-R86) [[4]](diffhunk://#diff-ad7b1aabbf8c1b40eb4bb4b12771fb72b048cd3bc6a4bf82abd6703f29e18424L20-R20)

### Test Coverage

* Added and updated tests to verify the new default value functionality in settings retrieval, ensuring that both true and false defaults behave as expected when options are missing. (`tests/Settings/Test_Settings.php`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
