### PR TITLE
Fix/incorrect auto deploy defintion use with not env

### DIFF
--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install DEV Deps, build i18n files
       - name: Run i18n Build

--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -28,9 +28,10 @@ jobs:
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          dry-run: true
+          generate-zip: true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: internet-archive-wayback-machine-link-fixer
-          dry-run: true
-          generate-zip: true

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install DEV Deps, build i18n files
       - name: Run i18n Build

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the deployment workflow configurations for the WordPress plugin. The main focus is on improving how the deploy actions are configured by moving certain parameters to the correct section, which helps ensure the deploy actions work as intended.

**Workflow configuration improvements:**

* [`.github/workflows/push-deploy-dryrun.yml`](diffhunk://#diff-94466bc04a602175b79f0f84603e289d552156e130354b908e199d374817f018R31-L36): Moved the `dry-run` and `generate-zip` parameters from the `env` section to the `with` section for the `WordPress Plugin Deploy` step, aligning with the expected input format for the action.
* [`.github/workflows/push-deploy.yml`](diffhunk://#diff-d71c3ba30cee07edf9485b33d2e7ee90f8abcb8c853798bea3437187ebb055bbR31-R32): Added the `generate-zip` parameter to the `with` section for the `WordPress Plugin Deploy` step, ensuring the plugin zip is generated during deployment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
