### PR TITLE
Bumped to 1.3.3£

### DIFF
--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.3-RC4
+ * @version     1.3.3
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.3-RC4
+ * Version:                 1.3.3
  * Requires at least:       6.4
  * Tested up to:            6.8
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.3-RC4' );
+define( 'IAWMLF_VERSION', '1.3.3' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "A WordPress plugin that scans content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, creating snapshots of your own pages and other site links that aren’t yet archived. Uses Action Scheduler for background tasks.",
     "author": {
         "name": "WordPress.com Special Projects Team",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin version from release candidate (`1.3.3-RC4`) to the official `1.3.3` release across both the main plugin file and the `package.json`. No additional code or functionality changes are included.

Version updates:

* Updated the version number in the plugin header and constant in `internet-archive-wayback-machine-link-fixer.php` from `1.3.3-RC4` to `1.3.3`. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33)
* Updated the version in `package.json` from `1.3.2` to `1.3.3`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
