### PR TITLE
change path

### DIFF
--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{github.workspace}}/SVN-${{ github.event.repository.name }}.zip
+          files: SVN-${{ github.event.repository.name }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request makes a minor update to the GitHub Actions workflow for release creation. The change simplifies the file path used when attaching the release artifact.

* The `files` input for the `softprops/action-gh-release` step now uses a relative path (`SVN-${{ github.event.repository.name }}.zip`) instead of the previous workspace-based path, potentially improving compatibility and reducing ambiguity.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
