### PR TITLE
Changed settings to advanced settings in all places£

### DIFF
--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -90,7 +90,7 @@ class Settings_Page {
 		$this->menu_hook = add_submenu_page(
 			Dashboard_Page::DASHBOARD_SLUG,
 			__( 'Wayback Link Fixer Settings', 'internet-archive-wayback-machine-link-fixer' ),
-			__( 'Settings', 'internet-archive-wayback-machine-link-fixer' ),
+			__( 'Advanced Settings', 'internet-archive-wayback-machine-link-fixer' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_page' )
@@ -183,7 +183,7 @@ class Settings_Page {
 			<h1 class="wp-heading-inline iawmlf-settings__header">%s</h1>
 			%s
 			</div>',
-			esc_html__( 'Wayback Link Fixer - Settings', 'internet-archive-wayback-machine-link-fixer' ),
+			esc_html__( 'Wayback Link Fixer - Advanced Settings', 'internet-archive-wayback-machine-link-fixer' ),
 			$wizard_link // phpcs:ignore
 		);
 

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -159,7 +159,7 @@ defined( 'ABSPATH' ) || exit;
 		<?php endif; ?>
 		<a href="<?php echo esc_url( $iawmlf_link_to_settings ); ?>" class="button">
 			<span class="dashicons dashicons-admin-settings" style="margin-top: 3px;"></span>
-			<?php esc_html_e( 'Settings', 'internet-archive-wayback-machine-link-fixer' ); ?>
+			<?php esc_html_e( 'Advanced Settings', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</a>
 		<a href="<?php echo esc_url( $iawmlf_link_table ); ?>" class="button">
 			<span class="dashicons dashicons-list-view" style="margin-top: 3px;"></span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the terminology used throughout the plugin's user interface, changing "Settings" to "Advanced Settings" to provide clearer labeling for users. The changes are applied consistently across the settings page title, menu label, and dashboard widget button.

**User interface text updates:**

* Changed the submenu label in `register_page()` within `Settings_Page.php` to "Advanced Settings" for improved clarity.
* Updated the settings page header in `render_page()` within `Settings_Page.php` to "Wayback Link Fixer - Advanced Settings".
* Modified the dashboard widget button label in `widget.php` to "Advanced Settings" for consistency with the rest of the UI.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #269 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Settings labels to "Advanced Settings" across the dashboard and settings page navigation for consistent terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->