### PR TITLE
Release/1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.8  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.3.3 
+**Stable tag:** 1.3.4 
 **License:** GPL-3.0-or-later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.4-RC2
+ * @version     1.3.4
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.4-RC2
+ * Version:                 1.3.4
  * Requires at least:       6.4
  * Tested up to:            6.8
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.4-RC2' );
+define( 'IAWMLF_VERSION', '1.3.4' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.3
+ * @version     1.3.4-RC2
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.3
+ * Version:                 1.3.4-RC2
  * Requires at least:       6.4
  * Tested up to:            6.8
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.3' );
+define( 'IAWMLF_VERSION', '1.3.4-RC2' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.0-RC5",
+    "version": "1.3.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wayback-link-fixer",
-            "version": "1.3.0-RC5",
+            "version": "1.3.4",
             "license": "GPL-2.0-or-later",
             "devDependencies": {
                 "@csstools/postcss-sass": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "A WordPress plugin that scans content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, creating snapshots of your own pages and other site links that aren’t yet archived. Uses Action Scheduler for background tasks.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.3.3
+Stable tag: 1.3.4
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -108,6 +108,11 @@ This service checks if web pages are accessible and retrieves final URLs after r
 The Internet Archive is a non-profit organization dedicated to preserving digital content for public access. URLs sent to these services become part of the public archive and may be accessible through the Wayback Machine interface. No personal information beyond the URLs themselves is transmitted to these services.
 
 == Changelog ==
+
+= 1.3.4 =
+* Minor UI tweaks and changes
+* Default check intervals and total count of broken pages required to trigger redirection lowered.
+* Onboarding process streamlined.
 
 = 1.3.3 =
 * Fixes bug where the links and scripts were loaded even if set to do nothing


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin version for the Internet Archive Wayback Machine Link Fixer in preparation for a new release candidate. The changes are limited to version number updates in the main plugin file.

Version updates:

* Updated the version in the file header docblock to `1.3.4` in `internet-archive-wayback-machine-link-fixer.php`.
* Updated the `@wordpress-plugin` version field to `1.3.4` in `internet-archive-wayback-machine-link-fixer.php`.
* Updated the `IAWMLF_VERSION` constant to `1.3.4` in `internet-archive-wayback-machine-link-fixer.php`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined onboarding experience

* **Improvements**
  * Enhanced user interface with minor UI refinements
  * Adjusted redirection trigger for better responsiveness

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->