### PR TITLE
Feature/add better spn2 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,31 @@ add_filter( 'iawmlf_valid_http_status_codes', function( array $codes ): array {
 });
 ```
 
+#### `iawmlf_human_readable_status_message`
+
+This filter allows you to customize the human-readable message for a given Wayback Machine status code.
+
+```php
+add_filter( 'iawmlf_human_readable_status_message', function( string $message, string $status_code ): string {
+   if ( 'error:not-found' === $status_code ) {
+      return 'Custom 404 message.';
+   }
+   return $message;
+}, 10, 2 );
+```
+
+#### `iawmlf_excluded_status_codes`
+
+This filter controls the allowlist of Wayback Machine error codes that **do not** exclude a link. Any error code not in this list will be treated as excluded.
+
+```php
+add_filter( 'iawmlf_excluded_status_codes', function( array $allowed_codes ): array {
+   $allowed_codes[] = 'error:browsing-timeout';
+   return $allowed_codes;
+});
+```
+```
+
 #### `iawmlf_failed_count`
 
 This is used to define how many checks with non valid status codes are encountered before marking a link as broken. The default is 3.

--- a/functions.php
+++ b/functions.php
@@ -522,3 +522,100 @@ function iawmlf_is_archive_api_online( bool $force = false ): bool {
 	set_transient( 'iawmlf_archive_api_online', $online, $duration );
 	return (bool) $online;
 }
+
+/**
+ * Converts a Internet Archive status code to a human readable message.
+ *
+ * @since 1.4.0
+ *
+ * @param string $status_code The status code to convert.
+ *
+ * @return string
+ */
+function iawmlf_get_human_readable_status_message( string $status_code ): string {
+
+	// If the error message doesnt start with error:, return the original message.
+	if ( 0 !== strpos( $status_code, 'error:' ) ) {
+		return $status_code;
+	}
+
+	$status_code = trim( $status_code );
+
+	$messages = array(
+		'error:bad-gateway'                     => 'Bad Gateway for URL (HTTP status=502).',
+		'error:bad-request'                     => 'The server could not understand the request due to invalid syntax. (HTTP status=401)',
+		'error:bandwidth-limit-exceeded'        => 'The target server has exceeded the bandwidth specified by the server administrator. (HTTP status=509).',
+		'error:blocked'                         => 'The target site is blocking us (HTTP status=999).',
+		'error:blocked-client-ip'               => 'Anonymous clients which are listed in https://www.spamhaus.org/xbl/ or https://www.spamhaus.org/sbl/ lists (spams & exploits) are blocked. Tor exit nodes are excluded from this filter.',
+		'error:blocked-url'                     => 'We use a URL block list based on Mozilla web tracker lists to avoid unwanted captures.',
+		'error:browsing-timeout'                => 'SPN2 back-end headless browser timeout.',
+		'error:capture-location-error'          => 'SPN2 back-end cannot find the created capture location. (system error).',
+		'error:cannot-fetch'                    => 'Cannot fetch the target URL due to system overload.',
+		'error:celery'                          => 'Cannot start capture task.',
+		'error:filesize-limit'                  => 'Cannot capture web resources over 2GB.',
+		'error:ftp-access-denied'               => 'Tried to capture an FTP resource but access was denied.',
+		'error:gateway-timeout'                 => 'The target server didn\'t respond in time. (HTTP status=504).',
+		'error:http-version-not-supported'      => 'The target server does not support the HTTP protocol version used in the request for URL (HTTP status=505).',
+		'error:internal-server-error'           => 'SPN internal server error.',
+		'error:invalid-url-syntax'              => 'Target URL syntax is not valid.',
+		'error:invalid-server-response'         => 'The target server response was invalid. (e.g. invalid headers, invalid content encoding, etc).',
+		'error:invalid-host-resolution'         => 'Couldn\'t resolve the target host.',
+		'error:job-failed'                      => 'Capture failed due to system error.',
+		'error:method-not-allowed'              => 'The request method is known by the server but has been disabled and cannot be used (HTTP status=405).',
+		'error:not-implemented'                 => 'The request method is not supported by the server and cannot be handled for URL (HTTP status=501).',
+		'error:no-browsers-available'           => 'SPN2 back-end headless browser cannot run.',
+		'error:network-authentication-required' => 'The client needs to authenticate to gain network access to the URL (HTTP status=511).',
+		'error:no-access'                       => 'Target URL could not be accessed (status=403).',
+		'error:not-found'                       => 'Target URL not found (status=404).',
+		'error:proxy-error'                     => 'SPN2 back-end proxy error.',
+		'error:protocol-error'                  => 'HTTP connection broken. (A possible cause of this error is "IncompleteRead").',
+		'error:read-timeout'                    => 'HTTP connection read timeout.',
+		'error:soft-time-limit-exceeded'        => 'Capture duration exceeded 45s time limit and was terminated.',
+		'error:service-unavailable'             => 'Service unavailable for URL (HTTP status=503).',
+		'error:too-many-daily-captures'         => 'This URL has been captured 10 times today. We cannot make any more captures.',
+		'error:too-many-redirects'              => 'Too many redirects. SPN2 tries to follow 3 redirects automatically.',
+		'error:too-many-requests'               => 'The target host has received too many requests from SPN and it is blocking it. (HTTP status=429). Note that captures to the same host will be delayed for 10-20s after receiving this response to remedy the situation.',
+		'error:user-session-limit'              => 'User has reached the limit of concurrent active capture sessions.',
+		'error:unauthorized'                    => 'The server requires authentication (HTTP status=401).',
+		'error:max-daily-bandwidth'             => 'An authenticated user can archive up to 5GB per day.',
+		'error:max-daily-bandwidth-from-ip'     => 'An anonymous user can archive up to 2GB per day.',
+		'error:max-daily-bandwidth-host'        => 'SPN2 can archive up to 100GB per day from a host.',
+	);
+
+	$message = $messages[ $status_code ] ?? ( 'Uknown: ' . $status_code );
+
+	return (string) apply_filters( 'iawmlf_human_readable_status_message', $message, $status_code );
+}
+
+/**
+ * Checks if a given status code should make the link excluded.
+ *
+ * @since 1.4.0
+ *
+ * @param string $status_code The status code to check.
+ *
+ * @return boolean
+ */
+function iawmlf_is_excluded_status_code( string $status_code ): bool {
+	// If status code doesnt start with error, return true.
+	if ( 0 !== strpos( $status_code, 'error' ) ) {
+		return false;
+	}
+
+	$allowed_status_codes = array(
+		'error:browsing-timeout',
+		'error:capture-location-error',
+		'error:internal-server-error',
+		'error:job-failed',
+		'error:proxy-error',
+		'error:too-many-daily-captures',
+		'error:too-many-requests',
+		'error:max-daily-bandwidth',
+		'error:max-daily-bandwidth-from-ip',
+		'error:max-daily-bandwidth-host',
+	);
+
+	$allowed_status_codes = apply_filters( 'iawmlf_excluded_status_codes', $allowed_status_codes );
+
+	return ! in_array( $status_code, $allowed_status_codes, true );
+}

--- a/functions.php
+++ b/functions.php
@@ -526,7 +526,7 @@ function iawmlf_is_archive_api_online( bool $force = false ): bool {
 /**
  * Converts a Internet Archive status code to a human readable message.
  *
- * @since 1.4.0
+ * @since 1.3.5
  *
  * @param string $status_code The status code to convert.
  *
@@ -590,7 +590,7 @@ function iawmlf_get_human_readable_status_message( string $status_code ): string
 /**
  * Checks if a given status code should make the link excluded.
  *
- * @since 1.4.0
+ * @since 1.3.5
  *
  * @param string $status_code The status code to check.
  *

--- a/src/Event/Check_Snapshot_Status_Event.php
+++ b/src/Event/Check_Snapshot_Status_Event.php
@@ -215,7 +215,7 @@ class Check_Snapshot_Status_Event {
 		// If status is error, throw exception with error code.
 		if ( 'error' === $status['status'] ) {
 			// Update the link with the error message.
-			$link = $link->set_message( esc_html( $status['message'] ) );
+			$link = $link->set_message( esc_html( $status['status_ext'] ) );
 
 			// If the status has a 'status_ext' key, set the link as excluded.
 			if ( isset( $status['status_ext'] ) && 'error:no-access' === $status['status_ext'] ) {
@@ -249,6 +249,12 @@ class Check_Snapshot_Status_Event {
 			// If the link is excluded, but now is success, set the link as not excluded.
 			if ( $link->is_excluded() && 'success' === $status['status'] ) {
 				$link = $link->set_excluded( false );
+
+				// If the link has an error message, clear it.
+				if ( '' !== $link->get_message() ) {
+					$link = $link->set_message( '' );
+				}
+
 				$this->link_repository->upsert( $link );
 			}
 

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -157,4 +157,34 @@ class Link_Summary_Factory {
 	private function is_http_code_valid( int $http_code ): bool {
 		return in_array( $http_code, Settings::get_valid_http_status_codes(), true );
 	}
+
+	/**
+	 * Gets the links current message.
+	 *
+	 * @return string
+	 */
+	public function get_current_message(): string {
+		$message = $this->link->get_message();
+		// If the message doesnt start with error:, return the original message.
+		if ( 0 !== strpos( $message, 'error:' ) ) {
+			return $message;
+		}
+
+		// If the link is still is still pending.
+		if ( Link::PROCESS_DONE !== $this->link->get_archive_process() ) {
+			return sprintf(
+				// translators: 1: The error message.
+				'<span class="dashicons dashicons-info" title="%s"></span> - %s',
+				__( 'Error encountered while processing the link, will retry shortly.', 'internet-archive-wayback-machine-link-fixer' ),
+				iawmlf_get_human_readable_status_message( $message )
+			);
+		}
+
+		return sprintf(
+			// translators: 1: The error message.
+			'<span class="dashicons dashicons-warning" title="%s"></span> - %s',
+			__( 'Error encountered while processing the link, no more retries will be made.', 'internet-archive-wayback-machine-link-fixer' ),
+			iawmlf_get_human_readable_status_message( $message )
+		);
+	}
 }

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -73,16 +73,6 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 							<?php endif; ?>
 
 							<?php if ( '' !== $iawmlf_link->get_message() ) : ?>
-								<?php
-								// Compile the message
-								$iawmlf_link_message = sprintf(
-									/* translators: 1. An icon indicating the status (e.g., warning or info), 2. A message indicating if the link is excluded or will be retried, 3. The human readable status message based on the error code */
-									'<span class="dashicons dashicons-%s" title="%s"></span> - %s',
-									( iawmlf_is_excluded_status_code( $iawmlf_link->get_message() ) || $iawmlf_link->is_excluded() ) ? 'warning' : 'info',
-									( iawmlf_is_excluded_status_code( $iawmlf_link->get_message() ) || $iawmlf_link->is_excluded() ) ? esc_html__( 'This link is currently excluded from processing. Due to the errors given creating a snapshot', 'internet-archive-wayback-machine-link-fixer' ) : esc_html__( 'There was an issue creating the snapshot, will retry', 'internet-archive-wayback-machine-link-fixer' ),
-									esc_html( iawmlf_get_human_readable_status_message( $iawmlf_link->get_message() ) )
-								);
-								?>
 								<p class="iawmlf_link_message"><strong><?php esc_html_e( 'Message', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>:   <?php echo wp_kses_post( ( new Internet_Archive\Wayback_Machine_Link_Fixer\Util\Link_Summary_Factory( $iawmlf_link ) )->get_current_message() ) ;// phpcs:ignore?></p>
 							<?php endif; ?>
 

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -73,7 +73,17 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 							<?php endif; ?>
 
 							<?php if ( '' !== $iawmlf_link->get_message() ) : ?>
-								<p class="iawmlf_link_message"><strong><?php esc_html_e( 'Message', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <?php echo esc_html( $iawmlf_link->get_message() ); ?></p>
+								<?php
+								// Compile the message
+								$iawmlf_link_message = sprintf(
+									/* translators: 1. An icon indicating the status (e.g., warning or info), 2. A message indicating if the link is excluded or will be retried, 3. The human readable status message based on the error code */
+									'<span class="dashicons dashicons-%s" title="%s"></span> - %s',
+									( iawmlf_is_excluded_status_code( $iawmlf_link->get_message() ) || $iawmlf_link->is_excluded() ) ? 'warning' : 'info',
+									( iawmlf_is_excluded_status_code( $iawmlf_link->get_message() ) || $iawmlf_link->is_excluded() ) ? esc_html__( 'This link is currently excluded from processing. Due to the errors given creating a snapshot', 'internet-archive-wayback-machine-link-fixer' ) : esc_html__( 'There was an issue creating the snapshot, will retry', 'internet-archive-wayback-machine-link-fixer' ),
+									esc_html( iawmlf_get_human_readable_status_message( $iawmlf_link->get_message() ) )
+								);
+								?>
+								<p class="iawmlf_link_message"><strong><?php esc_html_e( 'Message', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>:   <?php echo wp_kses_post( ( new Internet_Archive\Wayback_Machine_Link_Fixer\Util\Link_Summary_Factory( $iawmlf_link ) )->get_current_message() ) ;// phpcs:ignore?></p>
 							<?php endif; ?>
 
 							<?php if ( $iawmlf_link->is_excluded() ) : ?>

--- a/tests/Event/Test_Check_Snapshot_Status_Event.php
+++ b/tests/Event/Test_Check_Snapshot_Status_Event.php
@@ -70,8 +70,10 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 	public function test_error_status_sets_message(): void {
 		$this->set_snapshot_client_response(
 			array(
-				'status'  => 'error',
-				'message' => 'Error message',
+				'status'     => 'error',
+				'message'    => 'Error message',
+				'status_ext' => 'issue:no-access',
+
 			)
 		);
 
@@ -92,8 +94,8 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 		$updated_link = $this->link_repository->find_by_id( $link->get_id() );
 
 		// Check the message is set.
-		$this->assertEquals( 'Error message', $updated_link->get_message() );
-		$this->assertEquals(Link::PROCESS_PENDING, $updated_link->get_archive_process() );
+		$this->assertEquals( 'issue:no-access', $updated_link->get_message() );
+		$this->assertEquals( Link::PROCESS_PENDING, $updated_link->get_archive_process() );
 	}
 
 	/**
@@ -128,7 +130,7 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 
 		// Check the message is set.
 		$this->assertTrue( $updated_link->is_excluded() );
-		$this->assertEquals(Link::PROCESS_DONE, $updated_link->get_archive_process() );
+		$this->assertEquals( Link::PROCESS_DONE, $updated_link->get_archive_process() );
 	}
 
 	/**
@@ -281,7 +283,15 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 		$this->assertCount( 1, $actions );
 
 		$this->assertEquals( 'iawmlf_update_archive_url', $actions[0]->hook );
-		$this->assertEquals( json_encode( array( 'link_id' => $link->get_id(), 'attempt' => 0 ) ), $actions[0]->args );
+		$this->assertEquals(
+			json_encode(
+				array(
+					'link_id' => $link->get_id(),
+					'attempt' => 0,
+				)
+			),
+			$actions[0]->args
+		);
 	}
 
 	/**
@@ -313,6 +323,14 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 		$this->assertCount( 1, $actions );
 
 		$this->assertEquals( 'iawmlf_update_archive_url', $actions[0]->hook );
-		$this->assertEquals( json_encode( array( 'link_id' => $link->get_id(), 'attempt' => 0 ) ), $actions[0]->args );
+		$this->assertEquals(
+			json_encode(
+				array(
+					'link_id' => $link->get_id(),
+					'attempt' => 0,
+				)
+			),
+			$actions[0]->args
+		);
 	}
 }

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -71,6 +71,64 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Status code human readable data provider.
+	 *
+	 * @return array
+	 */ public static function statusCodeHumanReadable(): array {
+		return array(
+			'error:no-access'                   => array( 'error:no-access', 'Target URL could not be accessed (status=403).' ),
+			'error:blocked'                     => array( 'error:blocked', 'The target site is blocking us (HTTP status=999).' ),
+			'error:not-found'                   => array( 'error:not-found', 'Target URL not found (status=404).' ),
+			'error:browsing-timeout'            => array( 'error:browsing-timeout', 'SPN2 back-end headless browser timeout.' ),
+			'error:capture-location-error'      => array( 'error:capture-location-error', 'SPN2 back-end cannot find the created capture location. (system error).' ),
+			'error:internal-server-error'       => array( 'error:internal-server-error', 'SPN internal server error.' ),
+			'error:job-failed'                  => array( 'error:job-failed', 'Capture failed due to system error.' ),
+			'error:proxy-error'                 => array( 'error:proxy-error', 'SPN2 back-end proxy error.' ),
+			'error:too-many-daily-captures'     => array( 'error:too-many-daily-captures', 'This URL has been captured 10 times today. We cannot make any more captures.' ),
+			'error:too-many-requests'           => array( 'error:too-many-requests', 'The target host has received too many requests from SPN and it is blocking it. (HTTP status=429). Note that captures to the same host will be delayed for 10-20s after receiving this response to remedy the situation.' ),
+			'error:max-daily-bandwidth'         => array( 'error:max-daily-bandwidth', 'An authenticated user can archive up to 5GB per day.' ),
+			'error:max-daily-bandwidth-from-ip' => array( 'error:max-daily-bandwidth-from-ip', 'An anonymous user can archive up to 2GB per day.' ),
+			'error:max-daily-bandwidth-host'    => array( 'error:max-daily-bandwidth-host', 'SPN2 can archive up to 100GB per day from a host.' ),
+			'error:browsing-timeout'            => array( 'error:browsing-timeout', 'SPN2 back-end headless browser timeout.' ),
+			'error:capture-location-error'      => array( 'error:capture-location-error', 'SPN2 back-end cannot find the created capture location. (system error).' ),
+			'error:internal-server-error'       => array( 'error:internal-server-error', 'SPN internal server error.' ),
+			'error:job-failed'                  => array( 'error:job-failed', 'Capture failed due to system error.' ),
+			'error:proxy-error'                 => array( 'error:proxy-error', 'SPN2 back-end proxy error.' ),
+			'error:too-many-daily-captures'     => array( 'error:too-many-daily-captures', 'This URL has been captured 10 times today. We cannot make any more captures.' ),
+			'error:too-many-requests'           => array( 'error:too-many-requests', 'The target host has received too many requests from SPN and it is blocking it. (HTTP status=429). Note that captures to the same host will be delayed for 10-20s after receiving this response to remedy the situation.' ),
+			'error:max-daily-bandwidth'         => array( 'error:max-daily-bandwidth', 'An authenticated user can archive up to 5GB per day.' ),
+			'error:max-daily-bandwidth-from-ip' => array( 'error:max-daily-bandwidth-from-ip', 'An anonymous user can archive up to 2GB per day.' ),
+			'error:max-daily-bandwidth-host'    => array( 'error:max-daily-bandwidth-host', 'SPN2 can archive up to 100GB per day from a host.' ),
+			'error:other'                       => array( 'error:other', 'Uknown: error:other' ),
+			'info:not-valid'                    => array( 'info:not-valid', 'info:not-valid' ),
+		);
+}
+
+	/**
+	 * Status codes that mark link as excluded data provider.
+	 *
+	 * @return array
+	 */ public static function statusMarksLinkExcluded(): array {
+		return array(
+			'error:browsing-timeout'            => array( 'error:browsing-timeout', false ),
+			'error:capture-location-error'      => array( 'error:capture-location-error', false ),
+			'error:internal-server-error'       => array( 'error:internal-server-error', false ),
+			'error:job-failed'                  => array( 'error:job-failed', false ),
+			'error:proxy-error'                 => array( 'error:proxy-error', false ),
+			'error:too-many-daily-captures'     => array( 'error:too-many-daily-captures', false ),
+			'error:too-many-requests'           => array( 'error:too-many-requests', false ),
+			'error:max-daily-bandwidth'         => array( 'error:max-daily-bandwidth', false ),
+			'error:max-daily-bandwidth-from-ip' => array( 'error:max-daily-bandwidth-from-ip', false ),
+			'error:max-daily-bandwidth-host'    => array( 'error:max-daily-bandwidth-host', false ),
+			'error:no-access'                   => array( 'error:no-access', true ),
+			'error:blocked'                     => array( 'error:blocked', true ),
+			'error:not-found'                   => array( 'error:not-found', true ),
+			'error:other'                       => array( 'error:other', true ),
+			'info:not-valid'                    => array( 'info:not-valid', false ),
+		);
+}
+
+	/**
 	 * @testdox It should be possible to normalize a URL.
 	 *
 	 * @dataProvider normalize_url_provider
@@ -80,34 +138,62 @@ class Test_Functions extends \WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_can_normalize_url( string $url, string $expected ): void {
-		$this->assertSame( $expected, \iawmlf_normalize_url( $url ) );
-	}
+public function test_can_normalize_url( string $url, string $expected ): void {
+	$this->assertSame( $expected, \iawmlf_normalize_url( $url ) );
+}
 
 	/**
 	 * @testdox It should correctly identify Internet Archive links.
 	 *
 	 * @dataProvider is_archive_link_provider
 	 *
-	 * @param string $url      The URL to check.
-	 * @param bool   $expected The expected result.
+	 * @param string  $url      The URL to check.
+	 * @param boolean $expected The expected result.
 	 *
 	 * @return void
 	 */
-	public function test_can_identify_archive_links( string $url, bool $expected ): void {
-		$this->assertSame( $expected, \iawmlf_is_archive_link( $url ) );
-	}
+public function test_can_identify_archive_links( string $url, bool $expected ): void {
+	$this->assertSame( $expected, \iawmlf_is_archive_link( $url ) );
+}
 
 	/**
 	 * @testdox The constants should be defined and match the plugin metadata.
 	 *
 	 * @return void
 	 */
-	public function test_constants_should_be_defined_and_match_plugin_metadata(): void {
-		// Get the plugin metadata.
-		$plugin_metadata = get_plugin_data( WP_PLUGIN_DIR . '/internet-archive-wayback-machine-link-fixer/internet-archive-wayback-machine-link-fixer.php' );
-		$this->assertSame( IAWMLF_VERSION, $plugin_metadata['Version'], 'Version should match the plugin metadata.' );
-		$this->assertSame( IAWMLF_MINIMUM_VERSIONS['wp'], $plugin_metadata['RequiresWP'], 'RequiresWP should match the plugin metadata.' );
-		$this->assertSame( IAWMLF_MINIMUM_VERSIONS['php'], $plugin_metadata['RequiresPHP'], 'RequiresPHP should match the plugin metadata.' );
-	}
+public function test_constants_should_be_defined_and_match_plugin_metadata(): void {
+	// Get the plugin metadata.
+	$plugin_metadata = get_plugin_data( WP_PLUGIN_DIR . '/internet-archive-wayback-machine-link-fixer/internet-archive-wayback-machine-link-fixer.php' );
+	$this->assertSame( IAWMLF_VERSION, $plugin_metadata['Version'], 'Version should match the plugin metadata.' );
+	$this->assertSame( IAWMLF_MINIMUM_VERSIONS['wp'], $plugin_metadata['RequiresWP'], 'RequiresWP should match the plugin metadata.' );
+	$this->assertSame( IAWMLF_MINIMUM_VERSIONS['php'], $plugin_metadata['RequiresPHP'], 'RequiresPHP should match the plugin metadata.' );
+}
+
+	/**
+	 * @testdox The function should correctly identify excluded status codes and return back a human readable message for the status code. If invalid status code is passed it should return it status code.
+	 *
+	 * @dataProvider statusCodeHumanReadable
+	 *
+	 * @param string $status_code      The status code to check.
+	 * @param string $expected_message The expected human readable message.
+	 *
+	 * @return void
+	 */
+public function test_excluded_status_codes( string $status_code, string $expected_message ): void {
+	$this->assertEquals( $expected_message, iawmlf_get_human_readable_status_message( $status_code ) );
+}
+
+	/**
+	 * @testdox Some status imply we can never get the snapshot, but others dont. Based on the error we should mark or not mark the link as excluded.
+	 *
+	 * @dataProvider statusMarksLinkExcluded
+	 *
+	 * @param string  $status_code The status code.
+	 * @param boolean $expected    The expected outcome.
+	 *
+	 * @return void
+	 */
+public function test_status_codes_that_mark_link_as_excluded( string $status_code, bool $expected ): void {
+	$this->assertEquals( $expected, iawmlf_is_excluded_status_code( $status_code ) );
+}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request introduces improved handling and display of Wayback Machine status codes, including mapping error codes to human-readable messages, identifying which error codes should mark a link as excluded, and updating related UI and tests. The changes enhance clarity for users and developers by providing more informative feedback and flexible customization via filters.

**Status code handling and messaging:**

* Added the `iawmlf_get_human_readable_status_message` function in `functions.php` to map Internet Archive status codes to descriptive, human-readable messages, with support for customization via a new filter (`iawmlf_human_readable_status_message`). [[1]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556R525-R621) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R692-R716)
* Introduced the `iawmlf_is_excluded_status_code` function in `functions.php` to determine whether a status code should mark a link as excluded, with allowlist customization via the `iawmlf_excluded_status_codes` filter. [[1]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556R525-R621) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R692-R716)

**UI and message display improvements:**

* Updated the admin report template (`link-details.php`) and added `get_current_message` to `Link_Summary_Factory` to display status messages with icons and context, using the new human-readable mapping and exclusion logic. [[1]](diffhunk://#diff-d33d8bba68273785cfb8d6e4dd214cdc8774e4c85d9c254fbe602eaa29703277L76-R86) [[2]](diffhunk://#diff-1bea75d33be53450f416911216f255213770b330f7739f2e540b9c9361fc71ffR160-R189)

**Event and link status management:**

* Modified `Check_Snapshot_Status_Event` to set the link message using the extended status code, and to clear the message when a previously excluded link becomes successful. [[1]](diffhunk://#diff-3e30f37e3bfb8099a91de065ea7025da1a18fa8b2b7572deade9f850a5e71672L218-R218) [[2]](diffhunk://#diff-3e30f37e3bfb8099a91de065ea7025da1a18fa8b2b7572deade9f850a5e71672R252-R257)

**Testing and validation:**

* Extended unit tests in `Test_Check_Snapshot_Status_Event.php` and `Test_Functions.php` to cover error message handling, excluded status logic, and human-readable message mapping for various status codes. [[1]](diffhunk://#diff-26d8b977a5566c5eaa3941ff8a8b8d2e84b655f2de036f4db6eebaf667f8382bR75-R76) [[2]](diffhunk://#diff-26d8b977a5566c5eaa3941ff8a8b8d2e84b655f2de036f4db6eebaf667f8382bL95-R97) [[3]](diffhunk://#diff-26d8b977a5566c5eaa3941ff8a8b8d2e84b655f2de036f4db6eebaf667f8382bL284-R294) [[4]](diffhunk://#diff-26d8b977a5566c5eaa3941ff8a8b8d2e84b655f2de036f4db6eebaf667f8382bL316-R334) [[5]](diffhunk://#diff-180f71bee5dcfd679ea80d5b3ecbf715e4055eac69e9deb83f4d622ba4bd8434R73-R130) [[6]](diffhunk://#diff-180f71bee5dcfd679ea80d5b3ecbf715e4055eac69e9deb83f4d622ba4bd8434L93-R151) [[7]](diffhunk://#diff-180f71bee5dcfd679ea80d5b3ecbf715e4055eac69e9deb83f4d622ba4bd8434R171-R198)

These updates collectively make error handling more transparent and customizable, improving both developer experience and end-user clarity.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added human-readable error messages and improved status code exclusion handling
  * Enhanced error message display in admin link details with better formatting

* **Documentation**
  * Added documentation for new filter hooks to customize status messages and exclusion behavior

* **Tests**
  * Added comprehensive test coverage for new status code handling functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->