### PR TITLE
Improve translatable strings for better internationalization

### DIFF
--- a/src/Action/Link_Latest_Snapshot_Action.php
+++ b/src/Action/Link_Latest_Snapshot_Action.php
@@ -82,7 +82,7 @@ class Link_Latest_Snapshot_Action {
 				'link'    => $link,
 				'found'   => true,
 				'updated' => false,
-				'message' => __( 'Link is already an archived link.', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'This URL is already an archived link.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -123,7 +123,7 @@ class Link_Latest_Snapshot_Action {
 			'link'    => $link,
 			'found'   => true,
 			'updated' => true,
-			'message' => __( 'Link updated.', 'internet-archive-wayback-machine-link-fixer' ),
+			'message' => __( 'Archived URL updated.', 'internet-archive-wayback-machine-link-fixer' ),
 		);
 	}
 }

--- a/src/Action/Link_New_Snapshot_Action.php
+++ b/src/Action/Link_New_Snapshot_Action.php
@@ -101,7 +101,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already.', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'This URL is already an archived link.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 

--- a/src/Action/Link_New_Snapshot_Action.php
+++ b/src/Action/Link_New_Snapshot_Action.php
@@ -80,7 +80,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => null,
 				'job_id'  => null,
-				'message' => __( 'Link not found', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'Link not found.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -101,7 +101,7 @@ class Link_New_Snapshot_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'Link is an archive link already.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -114,7 +114,7 @@ class Link_New_Snapshot_Action {
 				return array(
 					'link'    => $link,
 					'job_id'  => null,
-					'message' => __( 'Exceeded snapshot limit', 'internet-archive-wayback-machine-link-fixer' ),
+					'message' => __( 'Exceeded snapshot limit.', 'internet-archive-wayback-machine-link-fixer' ),
 				);
 			} else {
 				return array(

--- a/src/Action/Validate_Link_Action.php
+++ b/src/Action/Validate_Link_Action.php
@@ -82,7 +82,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already.', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'This URL is already an archived link.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 

--- a/src/Action/Validate_Link_Action.php
+++ b/src/Action/Validate_Link_Action.php
@@ -65,7 +65,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Service is offline', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'Service is offline.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -73,7 +73,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => null,
 				'job_id'  => null,
-				'message' => __( 'Link not found', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'Link not found.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -82,7 +82,7 @@ class Validate_Link_Action {
 			return array(
 				'link'    => $link,
 				'job_id'  => null,
-				'message' => __( 'Link is an archive link already', 'internet-archive-wayback-machine-link-fixer' ),
+				'message' => __( 'Link is an archive link already.', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 		}
 
@@ -95,7 +95,7 @@ class Validate_Link_Action {
 				return array(
 					'link'    => $link,
 					'job_id'  => null,
-					'message' => __( 'Exceeded snapshot limit', 'internet-archive-wayback-machine-link-fixer' ),
+					'message' => __( 'Exceeded snapshot limit.', 'internet-archive-wayback-machine-link-fixer' ),
 				);
 			} else {
 				return array(

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1199,7 +1199,7 @@ class Report_Table extends \WP_List_Table {
 			: __( 'No HTTP Code', 'internet-archive-wayback-machine-link-fixer' );
 
 		return sprintf(
-			// translators: %1$s is the last check date, %2$s is the last check http code.
+			// translators: %1$s: last check date (e.g. "5 Jan 2025"), %2$s: HTTP status code (e.g. "404 status").
 			__( '%1$s with %2$s', 'internet-archive-wayback-machine-link-fixer' ),
 			$last_check['date']
 				? DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )->format( get_option( 'date_format' ) )

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1086,7 +1086,7 @@ class Report_Table extends \WP_List_Table {
 			case self::COLUMN_LINK_ARCHIVE:
 				// If the link is excluded, return the excluded icon.
 				if ( $item->is_excluded() ) {
-					return $this->get_dashicon( 'dashicons-warning', __( 'Link is excluded from being archived.', 'internet-archive-wayback-machine-link-fixer' ) );
+					return $this->get_dashicon( 'dashicons-warning', __( 'The link is excluded from being archived.', 'internet-archive-wayback-machine-link-fixer' ) );
 				}
 
 				if ( $item->has_archived_href() ) {

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -518,7 +518,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %s is the link url.
-					__( 'Link %s added to the queue and a new snapshot will be created and added as the archived url in the coming minutes..', 'internet-archive-wayback-machine-link-fixer' ),
+					__( 'Link %s added to the queue and a new snapshot will be created and added as the archived URL in the coming minutes.', 'internet-archive-wayback-machine-link-fixer' ),
 					iawmlf_trim_string( $result['link']->get_href(), 54 )
 				),
 				'type'    => 'success',

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -353,7 +353,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'It was not possible to check %s', 'internet-archive-wayback-machine-link-fixer' ),
+						__( 'Could not check the status of %s.', 'internet-archive-wayback-machine-link-fixer' ),
 						esc_html( iawmlf_trim_string( $results['link']->get_href(), 54 ) )
 					),
 					'type'    => 'error',
@@ -448,7 +448,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'It was not possible to update %s, the latest archive link is the same', 'internet-archive-wayback-machine-link-fixer' ),
+						__( 'Could not update %s: the archived URL is already the latest.', 'internet-archive-wayback-machine-link-fixer' ),
 						esc_html( iawmlf_trim_string( $result['link']->get_href(), 54 ) )
 					),
 					'type'    => 'notice',
@@ -505,7 +505,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'Link %1$s could not have a new snapshot created: %2$s', 'internet-archive-wayback-machine-link-fixer' ),
+						__( 'Could not create a new snapshot for %1$s: %2$s', 'internet-archive-wayback-machine-link-fixer' ),
 						iawmlf_trim_string( $result['link']->get_href(), 54 ),
 						esc_html( $result['message'] )
 					),

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -435,7 +435,7 @@ class Report_Table extends \WP_List_Table {
 				$this->notices[] = array(
 					'message' => sprintf(
 						// translators: %s is the link url.
-						__( 'No archived link found for %s', 'internet-archive-wayback-machine-link-fixer' ),
+						__( 'No archived version found for %s.', 'internet-archive-wayback-machine-link-fixer' ),
 						esc_html( iawmlf_trim_string( $result['link']->get_href(), 54 ) )
 					),
 					'type'    => 'error',
@@ -460,7 +460,7 @@ class Report_Table extends \WP_List_Table {
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %s is the link url.
-					__( 'Link %s updated successfully', 'internet-archive-wayback-machine-link-fixer' ),
+					__( 'Archived URL for %s updated successfully.', 'internet-archive-wayback-machine-link-fixer' ),
 					esc_html( iawmlf_trim_string( $result['link']->get_href(), 54 ) )
 				),
 				'type'    => 'success',
@@ -808,8 +808,8 @@ class Report_Table extends \WP_List_Table {
 			<option value=""><?php esc_html_e( 'Show with or without archived link', 'internet-archive-wayback-machine-link-fixer' ); ?></option>
 			<?php
 			$has_archive = array(
-				Link_Repository::LINK_HAS_ARCHIVE => __( 'Show links with archived link', 'internet-archive-wayback-machine-link-fixer' ),
-				Link_Repository::LINK_NO_ARCHIVE  => __( 'Show links without archived link', 'internet-archive-wayback-machine-link-fixer' ),
+				Link_Repository::LINK_HAS_ARCHIVE => __( 'Show links with archived version', 'internet-archive-wayback-machine-link-fixer' ),
+				Link_Repository::LINK_NO_ARCHIVE  => __( 'Show links without archived version', 'internet-archive-wayback-machine-link-fixer' ),
 			);
 			foreach ( $has_archive as $archive => $label ) {
 				printf(

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -504,7 +504,7 @@ class Report_Table extends \WP_List_Table {
 			if ( ! $result['job_id'] ) {
 				$this->notices[] = array(
 					'message' => sprintf(
-						// translators: %s is the link url.
+						// translators: 1: the link URL, 2: error message.
 						__( 'Could not create a new snapshot for %1$s: %2$s', 'internet-archive-wayback-machine-link-fixer' ),
 						iawmlf_trim_string( $result['link']->get_href(), 54 ),
 						esc_html( $result['message'] )

--- a/src/Util/Link_Summary_Factory.php
+++ b/src/Util/Link_Summary_Factory.php
@@ -72,7 +72,7 @@ class Link_Summary_Factory {
 
 		// If the last check was successful, return early.
 		if ( $last_check_status ) {
-			return __( 'The link is archived on archive.org and still working.', 'internet-archive-wayback-machine-link-fixer' );
+			return __( 'This link has an archived version on archive.org, and the original URL is still accessible.', 'internet-archive-wayback-machine-link-fixer' );
 		}
 
 		// If we have more failed checks than the threshold, return the redirected already message.
@@ -86,7 +86,7 @@ class Link_Summary_Factory {
 
 		return sprintf(
 		// translators: 1: The number of failed checks. 2: The number of remaining checks before redirect. 3: Plural S if needed.
-			__( 'The link is archived on archive.org but currently not working. It has failed %1$d previous consecutive check%3$s, %2$d more and it will redirect to the archived version.', 'internet-archive-wayback-machine-link-fixer' ),
+			__( 'This link has an archived version on archive.org, but the original URL is not accessible. It has failed %1$d previous consecutive check%3$s, %2$d more and it will redirect to the archived version.', 'internet-archive-wayback-machine-link-fixer' ),
 			$last_failed_count,
 			Settings::get_failed_count() - $last_failed_count,
 			1 === $last_failed_count ? '' : 's'

--- a/templates/admin/dashboard/link-list.php
+++ b/templates/admin/dashboard/link-list.php
@@ -64,7 +64,7 @@ defined( 'ABSPATH' ) || exit;
 
 									if ( $iawmlf_date_time && $iawmlf_clean_http_code ) {
 										printf(
-											/* translators: %1$s is the last check date, %2$s is the last check http code. */
+											/* translators: %1$s: last check date (e.g. "5 Jan 2025"), %2$s: HTTP status code (e.g. "404 status") */
 											esc_html__( '%1$s with %2$s', 'internet-archive-wayback-machine-link-fixer' ),
 											esc_html( $iawmlf_date_time->format( 'j M Y' ) ),
 											$iawmlf_http_status_display // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, already escaped above
@@ -178,7 +178,7 @@ defined( 'ABSPATH' ) || exit;
 										<span class="iawmlf_dashboard-link-check-posts-more">
 											<?php
 											printf(
-												/* translators: %d: number of additional posts */
+												/* translators: %d: number of additional posts containing this link beyond the first 12 shown */
 												esc_html__( '... and %d more', 'internet-archive-wayback-machine-link-fixer' ),
 												count( $iawmlf_posts ) - 12
 											);

--- a/templates/admin/dashboard/link-list.php
+++ b/templates/admin/dashboard/link-list.php
@@ -130,7 +130,7 @@ defined( 'ABSPATH' ) || exit;
 													if ( \Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link::PROCESS_NEW === $iawmlf_archive_process ) {
 														esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible.', 'internet-archive-wayback-machine-link-fixer' );
 													} else {
-														esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
+														esc_html_e( 'PENDING - Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
 													}
 												} elseif ( '' !== $iawmlf_link->get_archived_href() ) {
 													esc_html_e( 'HAS ARCHIVE - A snapshot of this link is available on the Internet Archive', 'internet-archive-wayback-machine-link-fixer' );

--- a/templates/admin/dashboard/link-list.php
+++ b/templates/admin/dashboard/link-list.php
@@ -128,14 +128,14 @@ defined( 'ABSPATH' ) || exit;
 												if ( ! $iawmlf_link->is_processed() ) {
 													$iawmlf_archive_process = $iawmlf_link->get_archive_process();
 													if ( \Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link::PROCESS_NEW === $iawmlf_archive_process ) {
-														esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible', 'internet-archive-wayback-machine-link-fixer' );
+														esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible.', 'internet-archive-wayback-machine-link-fixer' );
 													} else {
 														esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
 													}
 												} elseif ( '' !== $iawmlf_link->get_archived_href() ) {
 													esc_html_e( 'HAS ARCHIVE - A snapshot of this link is available on the Internet Archive', 'internet-archive-wayback-machine-link-fixer' );
 												} else {
-													esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible', 'internet-archive-wayback-machine-link-fixer' );
+													esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible.', 'internet-archive-wayback-machine-link-fixer' );
 												}
 												?>
 											</p>

--- a/templates/admin/dashboard/page.php
+++ b/templates/admin/dashboard/page.php
@@ -142,7 +142,10 @@ $iawmlf_tooltip_broken_links          = sprintf(
 									<a href="<?php echo esc_url( $iawmlf_filtered_broken_redirected ); ?>" title="<?php echo esc_attr( $iawmlf_tooltip_links_saved ); ?>" class="iawmlf_dashboard-stats-number iawmlf_dashboard-stats-link">
 										<?php echo esc_html( $iawmlf_broken_redirected ); ?>
 									</a>
-									<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_links_saved ); ?>"><?php esc_html_e( 'Links Saved', 'internet-archive-wayback-machine-link-fixer' ); ?></div>
+									<div class="iawmlf_dashboard-stats-label" title="<?php echo esc_attr( $iawmlf_tooltip_links_saved ); ?>"><?php
+										/* translators: "Links Saved" refers to broken links that are now being redirected to their archived versions on archive.org */
+										esc_html_e( 'Links Saved', 'internet-archive-wayback-machine-link-fixer' );
+										?></div>
 								</div>
 
 								<!-- Row 2: With Archive | Without -->

--- a/templates/admin/links-table/help-tab-bulk-actions.php
+++ b/templates/admin/links-table/help-tab-bulk-actions.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div id="iawmlf_help_tab_bulk_actions" class="iawmlf_help_tab">
 	<h3><?php esc_html_e( 'Update to latest snapshot', 'internet-archive-wayback-machine-link-fixer' ); ?></h3>
-	<p><?php esc_html_e( 'When this option is selected, the link will have its archive updated to the latest snapshot available from the Internet Archive.', 'internet-archive-wayback-machine-link-fixer' ); ?></p>
+	<p><?php esc_html_e( 'When this option is selected, the archived URL will be updated to the latest snapshot from the Internet Archive.', 'internet-archive-wayback-machine-link-fixer' ); ?></p>
 
 	<h3><?php esc_html_e( 'Create new snapshot', 'internet-archive-wayback-machine-link-fixer' ); ?></h3>
 	<p><?php esc_html_e( 'When this option is selected, a request to create a new snapshot of the link on the Internet Archive will be made. This process can take some time, depending on the Archive.org systems. The link\'s archived version in your records will be updated once the snapshot is complete and available.', 'internet-archive-wayback-machine-link-fixer' ); ?></p>

--- a/templates/admin/links-table/help-tab-columns.php
+++ b/templates/admin/links-table/help-tab-columns.php
@@ -20,7 +20,7 @@ $iawmlf_check_frequency = \Internet_Archive\Wayback_Machine_Link_Fixer\Settings\
 		<span class="dashicons dashicons-plus-alt"></span> <?php esc_html_e( 'New link, not yet processed', 'internet-archive-wayback-machine-link-fixer' ); ?><br>
 		<span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Processing in progress', 'internet-archive-wayback-machine-link-fixer' ); ?><br>
 		<span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No archive available', 'internet-archive-wayback-machine-link-fixer' ); ?><br>
-		<span class="dashicons dashicons-warning"></span> <?php esc_html_e( 'Link is excluded from being archived.', 'internet-archive-wayback-machine-link-fixer' ); ?>
+		<span class="dashicons dashicons-warning"></span> <?php esc_html_e( 'The link is excluded from being archived.', 'internet-archive-wayback-machine-link-fixer' ); ?>
 	</p>
 
 	<h3><?php esc_html_e( 'Link Health', 'internet-archive-wayback-machine-link-fixer' ); ?></h3>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -49,7 +49,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 										if ( Link::PROCESS_NEW === $iawmlf_archive_process ) {
 											esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible.', 'internet-archive-wayback-machine-link-fixer' );
 										} else {
-											esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
+											esc_html_e( 'PENDING - Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
 										}
 									} elseif ( '' !== $iawmlf_link->get_archived_href() ) {
 										printf(

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -47,7 +47,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 									if ( ! $iawmlf_link->is_processed() ) {
 										$iawmlf_archive_process = $iawmlf_link->get_archive_process();
 										if ( Link::PROCESS_NEW === $iawmlf_archive_process ) {
-											esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible', 'internet-archive-wayback-machine-link-fixer' );
+											esc_html_e( 'NEW - This link has been queued and will be processed by the Internet Archive as soon as possible.', 'internet-archive-wayback-machine-link-fixer' );
 										} else {
 											esc_html_e( 'PENDING – Queued for submission to the Internet Archive. Processing time varies based on queue size.', 'internet-archive-wayback-machine-link-fixer' );
 										}
@@ -58,7 +58,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 											'<a href="' . esc_url( $iawmlf_link->get_archived_href() ) . '" target="_blank">' . esc_html__( 'View Snapshot', 'internet-archive-wayback-machine-link-fixer' ) . '</a>'
 										);
 									} else {
-										esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible', 'internet-archive-wayback-machine-link-fixer' );
+										esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible.', 'internet-archive-wayback-machine-link-fixer' );
 									}
 									?>
 								</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves translatable strings for better internationalization. During Japanese translation, several issues made accurate translation difficult. Changes are organized into separate commits for easier review.

**1. Fix typos and punctuation**
- Double period at end of snapshot queue message
- Lowercase `url` → `URL`
- Add missing periods to `NO ARCHIVE` and `NEW` status messages

**2. Standardize consistency**
- Add missing periods to status messages (`Service is offline`, `Link not found`, `Exceeded snapshot limit`, etc.)
- Add missing article: `Link is excluded` → `The link is excluded`
- Normalize en dash to hyphen in `PENDING` status message

**3. Clarify terminology**
The word "link" was used interchangeably for the original URL, the archived URL, and the database record — many languages need different words for each:
- `Link updated` → `Archived URL updated`
- `No archived link found` → `No archived version found`
- `Show links with/without archived link` → `...archived version`
- Unify `Link is an archive link already` / `Link is already an archived link` → `This URL is already an archived link`

**4. Improve grammar**
- `the link will have its archive updated to the latest snapshot available from` → `the archived URL will be updated to the latest snapshot from`
- `Link %s could not have a new snapshot created` → `Could not create a new snapshot for %s`
- `It was not possible to update %s, the latest archive link is the same` → `Could not update %s: the archived URL is already the latest.`
- `The link is archived on archive.org and still working` → `This link has an archived version on archive.org, and the original URL is still accessible`

**5. Add translator comments**
- Add concrete examples for ambiguous strings like `%1$s with %2$s` (e.g. "5 Jan 2025", "404 status")
- Add context for `Links Saved` (broken links now redirected to archived versions)

> **Note:** These changes will invalidate existing translations for modified strings. However, the current translations may be inaccurate due to the ambiguity, so re-translation with clearer source strings is beneficial.

#### Testing instructions

* These changes only affect translatable strings and translator comments — no logic changes
* Verify the admin dashboard, link report table, and bulk action help tabs still display correctly
* Confirm that modified strings render properly in all locations (dashboard widget, link details, report notices)

Mentions #290



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified translator comments and help text to better explain placeholders, date/status examples, and posts-count context.

* **Style**
  * Standardized punctuation across status and error messages (added trailing periods).
  * Rephrased several user-facing messages for clarity and consistency (e.g., "This URL is already an archived link.", "Archived URL updated.", "archived version" terminology).
  * Minor wording tweaks in dashboard and report labels for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->