### PR TITLE
Fix i18n best practices: HTML tags in translatable strings

### DIFF
--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -156,19 +156,17 @@ class WP_Post_Table_Controller {
 			return;
 		}
 
-		print wp_kses(
-			sprintf(
-			// translators: %2$s is the url to view the links in a report, %2$s is the number of broken links, %3$s is the total number of links.
-				__( '<a href="%1$s"><strong>%2$s</strong> broken out of <strong>%3$s</strong></a>', 'internet-archive-wayback-machine-link-fixer' ),
-				$this->generate_report_page_url( $links, $post_id ),
-				absint( $stats['broken'] ),
-				absint( $stats['total'] )
-			),
-			array(
-				'strong' => array(),
-				'a'      => array(
-					'href' => array(),
+		printf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $this->generate_report_page_url( $links, $post_id ) ),
+			wp_kses(
+				sprintf(
+					/* translators: 1: number of broken links, 2: total number of links */
+					__( '%1$s broken out of %2$s', 'internet-archive-wayback-machine-link-fixer' ),
+					'<strong>' . esc_html( absint( $stats['broken'] ) ) . '</strong>',
+					'<strong>' . esc_html( absint( $stats['total'] ) ) . '</strong>'
 				),
+				array( 'strong' => array() )
 			)
 		);
 	}

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -133,11 +133,13 @@ defined( 'ABSPATH' ) || exit;
 							?>
 						<?php else : ?>
 							<?php
-							printf(
-								/* translators: 1: opening link tag, 2: closing link tag */
-								esc_html__( 'Links are not being checked. %1$sEnable Link Processing%2$s to turn this back on.', 'internet-archive-wayback-machine-link-fixer' ),
-								'<a href="' . esc_url( $iawmlf_link_to_settings ) . '">',
-								'</a>'
+							echo wp_kses(
+								sprintf(
+									/* translators: %s: URL to the settings page */
+									__( 'Links are not being checked. <a href="%s">Enable Link Processing</a> to turn this back on.', 'internet-archive-wayback-machine-link-fixer' ),
+									esc_url( $iawmlf_link_to_settings )
+								),
+								array( 'a' => array( 'href' => array() ) )
 							);
 							?>
 						<?php endif; ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes WordPress i18n best practices violations related to HTML in translatable strings.

**1. Fix split HTML tag placeholders (`widget.php`)**

Before: `%1$sEnable Link Processing%2$s` with opening/closing tags as separate placeholders
After: `<a href="%s">Enable Link Processing</a>` with URL as single placeholder

Also fixes an escaping bug: the original used `esc_html__()` which would have escaped the HTML tags injected via `%1$s`/`%2$s`.

**2. Remove HTML structure from translatable string (`WP_Post_Table_Controller.php`)**

Before: `<a href="%1$s"><strong>%2$s</strong> broken out of <strong>%3$s</strong></a>` — full HTML inside `__()`
After: HTML structure outside `__()`, translators only see `%1$s broken out of %2$s`

Also fixes a typo in the translator comment (duplicate `%2$s`).

Per [WordPress i18n best practices](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/), split tags prevent translators from reordering elements, and including HTML in translatable strings increases XSS risk.

> **Note:** Will rebase after `strings/improve-translatable-strings` is merged if needed, though these PRs touch different areas and conflicts are unlikely.

#### Testing instructions

* Navigate to the dashboard widget when link processing is disabled — verify the "Enable Link Processing" link renders correctly and points to the settings page
* Navigate to the Posts list table with broken links — verify the "X broken out of Y" column renders correctly with the link to the report page
* Inspect both locations to confirm HTML is properly escaped (no raw tags visible)

Mentions #290 #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved output sanitization and escaping for admin dashboard links by streamlining rendering logic with more secure methods.
  * Simplified link generation code through refined translation string handling and standardized output processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->