### PR TITLE
Adds a cast to http option, this is enabled by default on new install…

### DIFF
--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -957,7 +957,7 @@ class Settings_Page {
 				name="<?php echo esc_attr( Settings::CAST_ARCHIVED_TO_HTTPS ); ?>"
 				value="1"
 				data-group="link_fixer"
-				<?php checked( Settings::should_cast_archived_to_https() ); ?>
+				<?php checked( Settings::should_cast_archived_to_https( false ) ); ?>
 			/>
 			<?php esc_html_e( 'Force HTTPS', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</label>

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -360,6 +360,22 @@ class Settings_Page {
 
 		register_setting(
 			self::PAGE_SLUG,
+			Settings::CAST_ARCHIVED_TO_HTTPS,
+			array(
+				'type'              => 'boolean',
+				'sanitize_callback' => 'wp_validate_boolean',
+				'default'           => false,
+				'show_in_rest'      => array(
+					'name'   => Settings::CAST_ARCHIVED_TO_HTTPS,
+					'schema' => array(
+						'type' => 'boolean',
+					),
+				),
+			)
+		);
+
+		register_setting(
+			self::PAGE_SLUG,
 			Settings::ALLOW_OWN_CONTENT_SUBMISSIONS,
 			array(
 				'type'              => 'boolean',
@@ -558,6 +574,15 @@ class Settings_Page {
 			Settings::MINIMUM_CHECKS_BEFORE_BROKEN,
 			__( 'Failure Threshold', 'internet-archive-wayback-machine-link-fixer' ),
 			array( $this, 'render_minimum_checks_before_broken_field' ),
+			self::PAGE_SLUG,
+			self::GROUP_LINK_FIXER,
+			array( 'class' => Settings::is_link_processing_enabled() ? 'iawmlf_toggle_setting__fixer' : 'iawmlf_toggle_setting__fixer hidden' )
+		);
+
+		add_settings_field(
+			Settings::CAST_ARCHIVED_TO_HTTPS,
+			__( 'Cast Archived Links to HTTPS', 'internet-archive-wayback-machine-link-fixer' ),
+			array( $this, 'render_cast_archived_to_https_field' ),
 			self::PAGE_SLUG,
 			self::GROUP_LINK_FIXER,
 			array( 'class' => Settings::is_link_processing_enabled() ? 'iawmlf_toggle_setting__fixer' : 'iawmlf_toggle_setting__fixer hidden' )
@@ -912,6 +937,32 @@ class Settings_Page {
 		/>
 		<p class="description">
 			<?php esc_html_e( 'Number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 5.', 'internet-archive-wayback-machine-link-fixer' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the setting to cast archived links to HTTPS.
+	 *
+	 * @since 1.3.5
+	 *
+	 * @return void
+	 */
+	public function render_cast_archived_to_https_field(): void {
+		?>
+		<label for="<?php echo esc_attr( Settings::CAST_ARCHIVED_TO_HTTPS ); ?>">
+			<input
+				type="checkbox"
+				id="<?php echo esc_attr( Settings::CAST_ARCHIVED_TO_HTTPS ); ?>"
+				name="<?php echo esc_attr( Settings::CAST_ARCHIVED_TO_HTTPS ); ?>"
+				value="1"
+				data-group="link_fixer"
+				<?php checked( Settings::should_cast_archived_to_https() ); ?>
+			/>
+			<?php esc_html_e( 'Force HTTPS', 'internet-archive-wayback-machine-link-fixer' ); ?>
+		</label>
+		<p class="description">
+			<?php esc_html_e( 'Enabling this will convert all archived urls from http to https.', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</p>
 		<?php
 	}

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -957,7 +957,7 @@ class Settings_Page {
 				name="<?php echo esc_attr( Settings::CAST_ARCHIVED_TO_HTTPS ); ?>"
 				value="1"
 				data-group="link_fixer"
-				<?php checked( Settings::should_cast_archived_to_https( false ) ); ?>
+				<?php checked( Settings::should_cast_archived_to_https() ); ?>
 			/>
 			<?php esc_html_e( 'Force HTTPS', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</label>

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -345,6 +345,9 @@ class Setup_Wizard {
 		if ( Settings::ONBOARDING_PENDING_OPTION === Settings::get_onboarding_status() ) {
 			// Force the scan own content to trigger early.
 			Scan_Posts_Event::force_add_to_action_scheduler();
+
+			// Set to true on first run to ensure the archived urls are cast to https by default.
+			update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
 		}
 
 		// Mark as onboarding completed.

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -278,6 +278,18 @@ class Link implements \JsonSerializable {
 			$archived_href = str_replace( 'http://web.archive.org/web/', 'http://web-wp.archive.org/web/', $archived_href );
 		}
 
+		// If the setting to cast to https is enabled, cast the start of the url to https.
+		if ( Settings::should_cast_archived_to_https() ) {
+			// Replace only a leading insecure protocol for the web-wp host using a
+			// regex anchored to the start of the string. This avoids touching any
+			// other occurrences of "http://" later in the URL.
+			$archived_href = preg_replace(
+				'#^http://web-wp\.archive\.org/#i',
+				'https://web-wp.archive.org/',
+				$archived_href
+			);
+		}
+
 		return $archived_href;
 	}
 

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -280,14 +280,8 @@ class Link implements \JsonSerializable {
 
 		// If the setting to cast to https is enabled, cast the start of the url to https.
 		if ( Settings::should_cast_archived_to_https() ) {
-			// Replace only a leading insecure protocol for the web-wp host using a
-			// regex anchored to the start of the string. This avoids touching any
-			// other occurrences of "http://" later in the URL.
-			$archived_href = preg_replace(
-				'#^http://web-wp\.archive\.org/#i',
-				'https://web-wp.archive.org/',
-				$archived_href
-			);
+			// Replace http with https at the start of the url.
+			$archived_href = preg_replace( '#^http://web-wp\.archive\.org/#i', 'https://web-wp.archive.org/', $archived_href );
 		}
 
 		return $archived_href;

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -492,7 +492,7 @@ class Link implements \JsonSerializable {
 		return array(
 			'id'            => $this->id,
 			'href'          => $this->href,
-			'archived_href' => $this->archived_href,
+			'archived_href' => $this->get_archived_href(),
 			'redirect_href' => $this->redirect_href,
 			'checks'        => $this->checks,
 			'broken'        => $this->is_broken,

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -43,6 +43,7 @@ class Settings {
 	public const SETUP_WIZARD_STEP_KEY          = self::SETTINGS_PREFIX . 'setup_wizard';
 	public const SETUP_WIZARD_COMPLETED_KEY     = self::SETTINGS_PREFIX . 'setup_wizard_completed';
 	public const ONBOARDING_DATE_KEY            = self::SETTINGS_PREFIX . 'onboarding_date';
+	public const CAST_ARCHIVED_TO_HTTPS         = self::SETTINGS_PREFIX . 'cast_archived_to_https';
 
 	// Table names.
 	public const LINK_TABLE = 'iawmlf_link_archive';
@@ -560,6 +561,19 @@ class Settings {
 	}
 
 	/**
+	 * Checks if archived links should be cast as HTTPS.
+	 *
+	 * @since 1.3.5
+	 *
+	 * @param boolean $default_value Optional default, set to true.
+	 *
+	 * @return boolean
+	 */
+	public static function should_cast_archived_to_https( bool $default_value = false ): bool {
+		return (bool) get_option( self::CAST_ARCHIVED_TO_HTTPS, $default_value );
+	}
+
+	/**
 	 * Clear all the options.
 	 *
 	 * @since 1.3.0
@@ -588,5 +602,7 @@ class Settings {
 		delete_option( self::LINK_CHECK_DURATION_IN_DAYS );
 		delete_option( self::SETUP_WIZARD_STEP_KEY );
 		delete_option( self::SETUP_WIZARD_COMPLETED_KEY );
+		delete_option( self::ONBOARDING_DATE_KEY );
+		delete_option( self::CAST_ARCHIVED_TO_HTTPS );
 	}
 }

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -564,7 +564,6 @@ class Settings {
 	 * Checks if archived links should be cast as HTTPS.
 	 *
 	 * @since 1.3.5
-
 	 *
 	 * @return boolean
 	 */

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -43,7 +43,7 @@ class Settings {
 	public const SETUP_WIZARD_STEP_KEY          = self::SETTINGS_PREFIX . 'setup_wizard';
 	public const SETUP_WIZARD_COMPLETED_KEY     = self::SETTINGS_PREFIX . 'setup_wizard_completed';
 	public const ONBOARDING_DATE_KEY            = self::SETTINGS_PREFIX . 'onboarding_date';
-	public const CAST_ARCHIVED_TO_HTTPS         = self::SETTINGS_PREFIX . 'cast_archived_to_https';
+	public const CAST_ARCHIVED_TO_HTTPS         = self::SETTINGS_PREFIX . 'cast_to_https';
 
 	// Table names.
 	public const LINK_TABLE = 'iawmlf_link_archive';
@@ -564,13 +564,12 @@ class Settings {
 	 * Checks if archived links should be cast as HTTPS.
 	 *
 	 * @since 1.3.5
-	 *
-	 * @param boolean $default_value Optional default, set to true.
+
 	 *
 	 * @return boolean
 	 */
-	public static function should_cast_archived_to_https( bool $default_value = false ): bool {
-		return (bool) get_option( self::CAST_ARCHIVED_TO_HTTPS, $default_value );
+	public static function should_cast_archived_to_https(): bool {
+		return (bool) get_option( self::CAST_ARCHIVED_TO_HTTPS, false );
 	}
 
 	/**

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Link;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 
 /**
  * Test_Link
@@ -414,5 +415,29 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'http://example.com' );
 		$link->set_archived_href( 'http://web.archive.org/web/20240101000000/https://example.com' );
 		$this->assertSame( 'http://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+	}
+
+	/**
+	 * @testdox When an archive link is fetched, it should be possible to cast to https based on settings.
+	 *
+	 * @since 1.3.5
+	 *
+	 * @return void
+	 */
+	public function test_cast_to_https_based_on_settings(): void {
+		$link = new Link( 'http://example.com' );
+		$link->set_archived_href( 'http://web.archive.org/web/20240101000000/https://example.com' );
+
+		// By default, should not cast to https.
+		$this->assertSame( 'http://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+
+		// Set the option to cast to https.
+		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
+
+		// Should now cast to https.
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+
+		// Clear the option.
+		delete_option( Settings::CAST_ARCHIVED_TO_HTTPS );
 	}
 }

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -305,7 +305,8 @@ class Test_Link extends \WP_UnitTestCase {
 		$this->assertJson( $json );
 		$this->assertStringContainsString( '"id":1', $json );
 		$this->assertStringContainsString( '"href":"https:\/\/example.com"', $json );
-		$this->assertStringContainsString( '"archived_href":"https:\/\/web.archive.org\/web\/20240101000000\/https:\/\/example.com"', $json );
+		// Also check we are casting to wp urls.
+		$this->assertStringContainsString( '"archived_href":"https:\/\/web-wp.archive.org\/web\/20240101000000\/https:\/\/example.com"', $json );
 		$this->assertStringContainsString( '"redirect_href":"https:\/\/example.com"', $json );
 		$this->assertStringContainsString( '"checks":[{', $json );
 		$this->assertStringContainsString( '"date":"20240101000000"', $json );
@@ -434,7 +435,7 @@ class Test_Link extends \WP_UnitTestCase {
 		// Set the option to cast to https.
 		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
 
-		// Should now cast to https.
+		// Should now NOT cast to https.
 		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
 
 		// Clear the option.

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -31,7 +31,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		delete_option( Settings::SCAN_EXISTING_POSTS );
 		delete_option( Settings::FIXER_OPTION );
 
-		update_option(Settings::PROCESS_LINKS, true);
+		update_option( Settings::PROCESS_LINKS, true );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Test_Settings extends \WP_UnitTestCase {
 	public function test_can_set_and_get_migrations(): void {
 		$migration_1 = $this->createMock( Abstract_Migration::class );
 		$migration_2 = $this->createMock( Abstract_Migration::class );
-		$migrations = [get_class($migration_1), get_class($migration_2)];
+		$migrations  = array( get_class( $migration_1 ), get_class( $migration_2 ) );
 		Settings::update_migrations( $migrations );
 		$this->assertEquals( $migrations, Settings::migrations() );
 	}
@@ -260,19 +260,19 @@ class Test_Settings extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_should_scan_existing_posts_should_return_false_if_option_is_not_enabled(): void {
-		update_option(Settings::PROCESS_LINKS, false);
-		$this->assertFalse(Settings::should_scan_existing_posts());
+		update_option( Settings::PROCESS_LINKS, false );
+		$this->assertFalse( Settings::should_scan_existing_posts() );
 
 		// Set the scan existing posts to true.
-		update_option(Settings::SCAN_EXISTING_POSTS, true);
-		$this->assertFalse(Settings::should_scan_existing_posts());
+		update_option( Settings::SCAN_EXISTING_POSTS, true );
+		$this->assertFalse( Settings::should_scan_existing_posts() );
 
 		// Set the process links to true.
-		update_option(Settings::PROCESS_LINKS, true);
-		$this->assertTrue(Settings::should_scan_existing_posts());
+		update_option( Settings::PROCESS_LINKS, true );
+		$this->assertTrue( Settings::should_scan_existing_posts() );
 
 		// Set the scan existing posts to false.
-		update_option(Settings::SCAN_EXISTING_POSTS, false);
+		update_option( Settings::SCAN_EXISTING_POSTS, false );
 	}
 
 	/**
@@ -286,16 +286,13 @@ class Test_Settings extends \WP_UnitTestCase {
 		// By default, the cast to HTTPS option should be false.
 		$this->assertFalse( Settings::should_cast_archived_to_https() );
 
-		// You should be able to set the default value to true.
-		$this->assertTrue( Settings::should_cast_archived_to_https( true ) );
-
 		// When set, the defined option should override the default.
 		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
-		$this->assertTrue( Settings::should_cast_archived_to_https( false ) );
+		$this->assertTrue( Settings::should_cast_archived_to_https() );
 	}
 
 	/**
-	 * @testdox It should be possible to clear all the settings, this can then be used to clear on uninistall.
+	 * @testdox It should be possible to clear all the settings, this can then be used to clear on uninstall.
 	 *
 	 * @return void
 	 */
@@ -321,7 +318,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		update_option( Settings::LINK_CHECK_DURATION_IN_DAYS, 14 );
 		update_option( Settings::SETUP_WIZARD_STEP_KEY, 'step-2' );
 		update_option( Settings::SETUP_WIZARD_COMPLETED_KEY, true );
-		update_option(Settings::CAST_ARCHIVED_TO_HTTPS, true);
+		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
 
 		// Clear all the settings.
 		Settings::clear_all_options();
@@ -367,9 +364,12 @@ class Test_Settings extends \WP_UnitTestCase {
 		$this->assertFalse( Settings::should_render_html_link_output() );
 
 		// Set the option to replace link via a filter.
-		add_filter( 'iawmlf_should_render_html_link_output', function () {
-			return true;
-		} );
+		add_filter(
+			'iawmlf_should_render_html_link_output',
+			function () {
+				return true;
+			}
+		);
 		$this->assertTrue( Settings::should_render_html_link_output() );
 
 		// Clean up.

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -14,6 +14,7 @@ namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Settings;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Migration\Abstract_Migration;
+use PhpParser\Node\Expr\Cast\Void_;
 
 class Test_Settings extends \WP_UnitTestCase {
 
@@ -276,6 +277,25 @@ class Test_Settings extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox It should be possible to get the cast to HTTPS option, with defineable fallbacks.
+	 *
+	 * @since 1.3.5
+	 *
+	 * @return void
+	 */
+	public function test_can_get_cast_to_https_option_with_fallbacks(): void {
+		// By default, the cast to HTTPS option should be false.
+		$this->assertFalse( Settings::should_cast_archived_to_https() );
+
+		// You should be able to set the default value to true.
+		$this->assertTrue( Settings::should_cast_archived_to_https( true ) );
+
+		// When set, the defined option should override the default.
+		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
+		$this->assertTrue( Settings::should_cast_archived_to_https( false ) );
+	}
+
+	/**
 	 * @testdox It should be possible to clear all the settings, this can then be used to clear on uninistall.
 	 *
 	 * @return void
@@ -302,6 +322,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		update_option( Settings::LINK_CHECK_DURATION_IN_DAYS, 14 );
 		update_option( Settings::SETUP_WIZARD_STEP_KEY, 'step-2' );
 		update_option( Settings::SETUP_WIZARD_COMPLETED_KEY, true );
+		update_option(Settings::CAST_ARCHIVED_TO_HTTPS, true);
 
 		// Clear all the settings.
 		Settings::clear_all_options();
@@ -327,6 +348,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		$this->assertEmpty( get_option( Settings::LINK_CHECK_DURATION_IN_DAYS ) );
 		$this->assertEmpty( get_option( Settings::SETUP_WIZARD_STEP_KEY ) );
 		$this->assertEmpty( get_option( Settings::SETUP_WIZARD_COMPLETED_KEY ) );
+		$this->assertEmpty( get_option( Settings::CAST_ARCHIVED_TO_HTTPS ) );
 	}
 
 	/**

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -14,7 +14,6 @@ namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Settings;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Migration\Abstract_Migration;
-use PhpParser\Node\Expr\Cast\Void_;
 
 class Test_Settings extends \WP_UnitTestCase {
 
@@ -277,7 +276,7 @@ class Test_Settings extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox It should be possible to get the cast to HTTPS option, with defineable fallbacks.
+	 * @testdox It should be possible to get the cast to HTTPS option, with definable fallbacks.
 	 *
 	 * @since 1.3.5
 	 *

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -30,6 +30,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		delete_option( Settings::LINK_EXCLUSIONS );
 		delete_option( Settings::SCAN_EXISTING_POSTS );
 		delete_option( Settings::FIXER_OPTION );
+		delete_option( Settings::CAST_ARCHIVED_TO_HTTPS );
 
 		update_option( Settings::PROCESS_LINKS, true );
 	}

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -277,7 +277,7 @@ class Test_Settings extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox It should be possible to get the cast to HTTPS option, with definable fallbacks.
+	 * @testdox It should be possible to get the cast to HTTPS option.
 	 *
 	 * @since 1.3.5
 	 *
@@ -287,7 +287,7 @@ class Test_Settings extends \WP_UnitTestCase {
 		// By default, the cast to HTTPS option should be false.
 		$this->assertFalse( Settings::should_cast_archived_to_https() );
 
-		// When set, the defined option should override the default.
+		// When set.
 		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
 		$this->assertTrue( Settings::should_cast_archived_to_https() );
 	}


### PR DESCRIPTION
…s, but false on existing installs.

#### Changes proposed in this Pull Request

This pull request introduces a new feature that allows users to force archived URLs to use HTTPS instead of HTTP. This is accomplished by adding a new setting to the plugin, updating the setup wizard to enable this option by default for new users, modifying the link handling logic to respect this setting, and providing comprehensive tests for the new functionality.

**New HTTPS-forcing feature:**

* Added a new setting constant `CAST_ARCHIVED_TO_HTTPS` in the `Settings` class, and registered it as a boolean option in the settings page. [[1]](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aR46) [[2]](diffhunk://#diff-2ad02316ffadba1bd1476340dc53e92ea494f6b363d6567fe8691594bc00602bR361-R376)
* Added a new settings field and UI checkbox labeled "Cast Archived Links to HTTPS" in the dashboard, with an explanation for users. [[1]](diffhunk://#diff-2ad02316ffadba1bd1476340dc53e92ea494f6b363d6567fe8691594bc00602bR582-R590) [[2]](diffhunk://#diff-2ad02316ffadba1bd1476340dc53e92ea494f6b363d6567fe8691594bc00602bR944-R969)

**Default behavior and onboarding:**

* Updated the setup wizard to enable the HTTPS-casting setting by default for new users, ensuring all archived URLs are cast to HTTPS on first run.

**Core logic changes:**

* Modified the `Link` class so that, when the new setting is enabled, archived URLs are rewritten to use `https://web-wp.archive.org/` instead of `http://web-wp.archive.org/`.
* Added a helper method `should_cast_archived_to_https()` to the `Settings` class to retrieve the setting value, and ensured the setting is cleared with all other options when appropriate. [[1]](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aR563-R575) [[2]](diffhunk://#diff-901b6186e9a962a3994e96b8f593d51d3e4e8fdd6ac79939053acb08c784958aR605-R606)

**Testing:**

* Added and updated tests to verify the new setting's behavior, including default values, option overrides, and clearing the setting. [[1]](diffhunk://#diff-c6b42f8b224ee86702ed94822418c20bca2dce8cf9275ddcbd6c8e5aa30de35eR419-R442) [[2]](diffhunk://#diff-2b56a266af4aa5bfa02f3cf20970fe636ea7f183b0c7123cd35cf0867b289144R279-R297) [[3]](diffhunk://#diff-2b56a266af4aa5bfa02f3cf20970fe636ea7f183b0c7123cd35cf0867b289144R325) [[4]](diffhunk://#diff-2b56a266af4aa5bfa02f3cf20970fe636ea7f183b0c7123cd35cf0867b289144R351)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #293 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard setting "Cast Archived Links to HTTPS" (shown when Link Fixer is enabled) to convert archived HTTP links to HTTPS.
  * Initial onboarding now enables HTTPS casting by default on first-run setup.

* **Tests**
  * Added and updated tests to verify HTTPS casting behavior, serialized archived-link output, settings persistence, and clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->