### PR TITLE
bumped to 1.3.5-RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.3.5-RC1
+**Stable tag:** 1.3.5-RC2
 **License:** GPL-3.0-or-later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.5-RC1
+ * @version     1.3.5-RC2
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.5-RC1
+ * Version:                 1.3.5-RC2
  * Requires at least:       6.4
  * Tested up to:            6.9
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.5-RC1' );
+define( 'IAWMLF_VERSION', '1.3.5-RC2' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "A WordPress plugin that scans content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, creating snapshots of your own pages and other site links that aren’t yet archived. Uses Action Scheduler for background tasks.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects, cagrimmett, glynnquelch
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.3.5-RC1
+Stable tag: 1.3.5-RC2
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -116,6 +116,8 @@ The Internet Archive is a non-profit organization dedicated to preserving digita
 = 1.3.5 =
 * Minor tweak to how we log errors in snapshot creation process.
 * Improvement on how link stats are generated.
+* Casts all archived urls to https://, can be disabled in settings.
+* Improvements to how we handle cancelled scan own post actions, to prevent flooding database with cancelled jobs.
 
 = 1.3.4 =
 * Minor UI tweaks and changes


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin version from 1.3.5-RC1 to 1.3.5-RC2 across all relevant files and updates the changelog to reflect new improvements and fixes. There are no functional code changes, only version bumps and documentation updates.

Version and documentation updates:

* Updated the stable tag and plugin version to `1.3.5-RC2` in `README.md`, `readme.txt`, and all relevant plugin headers and constants in `internet-archive-wayback-machine-link-fixer.php`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[4]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[5]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33)

Changelog improvements:

* Added new entries to the changelog in `readme.txt` for HTTPS enforcement on archived URLs and improved handling of cancelled scan jobs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archived URLs are now automatically cast to HTTPS protocol by default, with an option to disable this behavior in settings.

* **Bug Fixes**
  * Enhanced handling of cancelled scan operations to prevent the database from being flooded with abandoned jobs.

* **Chores**
  * Version updated to 1.3.5-RC2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->