### PR TITLE
Update link fixer option language

### DIFF
--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -1064,10 +1064,10 @@ class Settings_Page {
 			data-group="link_fixer"
 		>
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
-				<?php esc_html_e( 'Replace Link (No Notification)', 'internet-archive-wayback-machine-link-fixer' ); ?>
+				<?php esc_html_e( 'Redirect broken links to snapshots on the Wayback Machine', 'internet-archive-wayback-machine-link-fixer' ); ?>
 			</option>
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
-				<?php esc_html_e( 'Do Nothing', 'internet-archive-wayback-machine-link-fixer' ); ?>
+				<?php esc_html_e( 'Do not redirect broken links', 'internet-archive-wayback-machine-link-fixer' ); ?>
 			</option>
 		</select>
 		<p class="description">


### PR DESCRIPTION
Makes the language on the link fixer option clearer.

<img width="1300" height="194" alt="CleanShot 2026-02-11 at 23 09 56@2x" src="https://github.com/user-attachments/assets/76fc3436-5c4b-4ab5-97bf-297ce62ba531" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Settings page option labels for broken link handling to better describe their functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->