### PR TITLE
add a check to skip deleting actions that are due to run in this batc…

### DIFF
--- a/src/Event/Process_Local_Post_Event.php
+++ b/src/Event/Process_Local_Post_Event.php
@@ -168,9 +168,16 @@ class Process_Local_Post_Event {
 		$action = $store->fetch_action( $action_id );
 
 		// If we have the right action.
-		if ( self::HANDLE === $action->get_hook() ) {
-			// Delete the action.
-			$store->delete_action( $action_id );
+		if ( self::HANDLE !== $action->get_hook() ) {
+			return;
 		}
+
+		// Skip actions that are currently claimed by a queue runner, prevent action removed exceptions.
+		if ( $store->get_claim_id( $action_id ) ) {
+			// return;
+		}
+
+		// Delete the action.
+		$store->delete_action( $action_id );
 	}
 }

--- a/src/Event/Process_Local_Post_Event.php
+++ b/src/Event/Process_Local_Post_Event.php
@@ -174,7 +174,7 @@ class Process_Local_Post_Event {
 
 		// Skip actions that are currently claimed by a queue runner, prevent action removed exceptions.
 		if ( $store->get_claim_id( $action_id ) ) {
-			// return;
+			return;
 		}
 
 		// Delete the action.

--- a/tests/Event/Test_Process_Local_Post_Event.php
+++ b/tests/Event/Test_Process_Local_Post_Event.php
@@ -383,4 +383,72 @@ class Test_Process_Local_Post_Event extends TestCase {
 
 
 	}
+
+	/**
+	 * @testdox Reproduces the InvalidArgumentException from mark_failure when
+	 * ensure_single_event hard-deletes an action that AS then tries to process.
+	 *
+	 * Flow: process action A (offline → ensure_single_event deletes action B)
+	 * → then process deleted action B → get_status throws → mark_failure throws.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_mark_failure_after_action_deleted_by_ensure_single_event(): void {
+		$post_id = 42;
+
+		// Mock offline so __invoke → add_to_queue_with_delay → ensure_single_event.
+		$this->create_service( false );
+
+		// Register the action callback.
+		$event = new Process_Local_Post_Event();
+		add_action( Process_Local_Post_Event::HANDLE, $event );
+
+		// Schedule 2 pending actions for the same post.
+		$action_ids   = array();
+		$action_ids[] = as_schedule_single_action(
+			time(),
+			Process_Local_Post_Event::HANDLE,
+			array( 'post_id' => $post_id )
+		);
+		$action_ids[] = as_schedule_single_action(
+			time(),
+			Process_Local_Post_Event::HANDLE,
+			array( 'post_id' => $post_id )
+		);
+
+		// Use DBStore directly (matches production — HybridStore can swallow errors).
+		$store  = new \ActionScheduler_DBStore();
+		$runner = new \ActionScheduler_QueueRunner( $store );
+
+		// Stake a claim and attach a FatalErrorMonitor (mirrors do_batch).
+		$claim   = $store->stake_claim( 10 );
+		$monitor = new \ActionScheduler_FatalErrorMonitor( $store );
+		$monitor->attach( $claim );
+
+		// Process action[0]: __invoke → offline → add_to_queue_with_delay
+		// → ensure_single_event → as_unschedule_all_actions → handle_hard_delete
+		// → with fix: action[1] is claimed so skip delete.
+		// → without fix: action[1] row is deleted from DB.
+		$runner->process_action( $action_ids[0] );
+
+		// Simulate race condition: process the deleted/canceled action[1].
+		// In production this happens when another concurrent process has
+		// already passed the find_actions_by_claim_id check before the
+		// row was deleted.
+		$runner->process_action( $action_ids[1] );
+
+		// Fire the shutdown hook — guard the output buffer level so
+		// WordPress cleanup does not trip PHPUnit's risky-test check.
+		$ob_level = ob_get_level();
+		do_action( 'shutdown' );
+		while ( ob_get_level() < $ob_level ) {
+			ob_start();
+		}
+
+		// If we reach here, no exception was thrown.
+		$this->assertTrue( true, 'No InvalidArgumentException thrown during shutdown' );
+	}
 }

--- a/tests/Event/Test_Process_Local_Post_Event.php
+++ b/tests/Event/Test_Process_Local_Post_Event.php
@@ -385,14 +385,16 @@ class Test_Process_Local_Post_Event extends TestCase {
 	}
 
 	/**
-	 * @testdox Reproduces the InvalidArgumentException from mark_failure when
-	 * ensure_single_event hard-deletes an action that AS then tries to process.
+	 * @testdox When ensure_single_event runs during processing, claimed actions should not be hard-deleted, preventing InvalidArgumentException from mark_failure.
 	 *
-	 * Flow: process action A (offline → ensure_single_event deletes action B)
-	 * → then process deleted action B → get_status throws → mark_failure throws.
+	 * Flow: process action A (offline → ensure_single_event cancels all actions
+	 * → handle_hard_delete skips claimed rows) → mark_failure works because
+	 * the row still exists → then process action B (canceled, execution ignored).
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * Without the fix, handle_hard_delete deletes the DB rows and mark_failure
+	 * throws: "Unidentified action: we were unable to mark this action as having failed".
+	 *
+	 * @see https://github.com/a8cteam51/internet-archive-wayback-machine-link-fixer/issues/294
 	 *
 	 * @return void
 	 */
@@ -423,32 +425,20 @@ class Test_Process_Local_Post_Event extends TestCase {
 		$store  = new \ActionScheduler_DBStore();
 		$runner = new \ActionScheduler_QueueRunner( $store );
 
-		// Stake a claim and attach a FatalErrorMonitor (mirrors do_batch).
-		$claim   = $store->stake_claim( 10 );
-		$monitor = new \ActionScheduler_FatalErrorMonitor( $store );
-		$monitor->attach( $claim );
+		// Stake a claim so both actions are claimed (simulates queue runner batch).
+		$store->stake_claim( 10 );
 
 		// Process action[0]: __invoke → offline → add_to_queue_with_delay
 		// → ensure_single_event → as_unschedule_all_actions → handle_hard_delete
-		// → with fix: action[1] is claimed so skip delete.
-		// → without fix: action[1] row is deleted from DB.
+		// → with fix: both actions are claimed so skip delete, mark_failure works.
+		// → without fix: both rows deleted, mark_failure throws InvalidArgumentException.
 		$runner->process_action( $action_ids[0] );
 
-		// Simulate race condition: process the deleted/canceled action[1].
-		// In production this happens when another concurrent process has
-		// already passed the find_actions_by_claim_id check before the
-		// row was deleted.
+		// Process action[1]: with fix, row still exists (status=canceled),
+		// execution is ignored. Without fix, row is gone, get_status throws.
 		$runner->process_action( $action_ids[1] );
 
-		// Fire the shutdown hook — guard the output buffer level so
-		// WordPress cleanup does not trip PHPUnit's risky-test check.
-		$ob_level = ob_get_level();
-		do_action( 'shutdown' );
-		while ( ob_get_level() < $ob_level ) {
-			ob_start();
-		}
-
-		// If we reach here, no exception was thrown.
-		$this->assertTrue( true, 'No InvalidArgumentException thrown during shutdown' );
+		// If we reach here, no InvalidArgumentException was thrown.
+		$this->assertTrue( true, 'No InvalidArgumentException thrown during action processing' );
 	}
 }


### PR DESCRIPTION
…h, just cancel only

#### Changes proposed in this Pull Request

This pull request addresses a race condition in the action deletion logic and adds a regression test to ensure robust handling of deleted actions during concurrent processing. The main focus is to prevent exceptions when an action is deleted while it is being processed by another queue runner.

**Improvements to action deletion logic:**

* Updated `handle_hard_delete` in `Process_Local_Post_Event.php` to skip deleting actions that are currently claimed by a queue runner, preventing potential exceptions from removing actions that are in the middle of being processed.

**Testing and regression coverage:**

* Added a regression test `test_mark_failure_after_action_deleted_by_ensure_single_event` in `Test_Process_Local_Post_Event.php` to simulate and verify the scenario where an action is deleted by `ensure_single_event` while another process attempts to process it, ensuring no exceptions are thrown in this edge case.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented exceptions during concurrent action processing when scheduled actions are removed or claimed before completion, improving stability.
  * Improved queue shutdown robustness to better handle edge cases in action lifecycle.
  * Enhanced reliability when multiple scheduled actions target the same resource under high concurrency.

* **Tests**
  * Added a test to validate correct behavior and error handling in the race condition where an action may be deleted before failure is recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->