### PR TITLE
move to using a script tag over a div with data attribute

### DIFF
--- a/assets/js/src/front_link_checker.js
+++ b/assets/js/src/front_link_checker.js
@@ -120,12 +120,12 @@ const getRenderedLinks = () => {
 		});
 	}
 
-	// Look for all divs with '__iawmlf-post-loop-links' class
-	const loopLinks = document.querySelectorAll('.__iawmlf-post-loop-links');
+	// Look for all script tags with '__iawmlf-post-loop-links' class
+	const loopLinks = document.querySelectorAll('script.__iawmlf-post-loop-links');
 
-	// Get the links from data-iawmlf-post-links attribute
+	// Get the links from the script tag content
 	loopLinks.forEach((loopLink) => {
-		const links = JSON.parse(loopLink.getAttribute('data-iawmlf-post-links'));
+		const links = JSON.parse(loopLink.textContent);
 		addLinks(links);
 	});
 

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -312,8 +312,8 @@ class WP_Post_Controller {
 			return $block_content;
 		}
 
-		$json      = esc_attr( wp_json_encode( $links ) );
-		$html_data = "<div class='__iawmlf-post-loop-links' style='display:none;' data-iawmlf-post-links='{$json}'></div>";
+		$json      = wp_json_encode( $links );
+		$html_data = "<script type='application/json' class='__iawmlf-post-loop-links'>{$json}</script>";
 
 		return $html_data . $block_content;
 	}

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -312,7 +312,7 @@ class WP_Post_Controller {
 			return $block_content;
 		}
 
-		$json      = wp_json_encode( $links );
+		$json      = wp_json_encode( $links, JSON_HEX_TAG );
 		$html_data = "<script type='application/json' class='__iawmlf-post-loop-links'>{$json}</script>";
 
 		return $html_data . $block_content;

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -577,8 +577,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Render the block.
 		$rendered = do_blocks( $GLOBALS['post']->post_content );
 
-		// Check contains the data-iawmlf-post-links attribute.
-		$this->assertStringContainsString( 'data-iawmlf-post-links', $rendered );
+		// Check contains the link data script tag.
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
 
 		unset( $GLOBALS['post'] );
 	}
@@ -611,8 +611,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Render the block.
 		$rendered = do_blocks( $GLOBALS['post']->post_content );
 
-		// Check does NOT contain the data-iawmlf-post-links attribute.
-		$this->assertStringNotContainsString( 'data-iawmlf-post-links', $rendered );
+		// Check does NOT contain the link data script tag.
+		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $rendered );
 
 		// Clean up.
 		unset( $GLOBALS['post'] );
@@ -654,14 +654,14 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Render the block.
 		$rendered = do_blocks( $GLOBALS['post']->post_content );
 
-		// The data attribute should be present (we still have one non-excluded link).
-		$this->assertStringContainsString( 'data-iawmlf-post-links', $rendered );
+		// The script tag should be present (we still have one non-excluded link).
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
 
-		// Extract the JSON from the data attribute.
-		preg_match( "/data-iawmlf-post-links='([^']*)'/", $rendered, $matches );
-		$this->assertNotEmpty( $matches, 'Should find the data attribute in rendered output.' );
+		// Extract the JSON from the script tag.
+		preg_match( "/<script[^>]*class='__iawmlf-post-loop-links'[^>]*>(.*?)<\/script>/s", $rendered, $matches );
+		$this->assertNotEmpty( $matches, 'Should find the script tag in rendered output.' );
 
-		$links_data = json_decode( html_entity_decode( $matches[1] ), true );
+		$links_data = json_decode( $matches[1], true );
 		$this->assertIsArray( $links_data );
 
 		// Collect all hrefs from the links data.
@@ -716,14 +716,14 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Render the block.
 		$rendered = do_blocks( $GLOBALS['post']->post_content );
 
-		// The data attribute should be present (we still have one non-excluded link).
-		$this->assertStringContainsString( 'data-iawmlf-post-links', $rendered );
+		// The script tag should be present (we still have one non-excluded link).
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
 
-		// Extract the JSON from the data attribute.
-		preg_match( "/data-iawmlf-post-links='([^']*)'/", $rendered, $matches );
-		$this->assertNotEmpty( $matches, 'Should find the data attribute in rendered output.' );
+		// Extract the JSON from the script tag.
+		preg_match( "/<script[^>]*class='__iawmlf-post-loop-links'[^>]*>(.*?)<\/script>/s", $rendered, $matches );
+		$this->assertNotEmpty( $matches, 'Should find the script tag in rendered output.' );
 
-		$links_data = json_decode( html_entity_decode( $matches[1] ), true );
+		$links_data = json_decode( $matches[1], true );
 		$this->assertIsArray( $links_data );
 
 		// Should only have 1 link (the non-excluded one).
@@ -773,8 +773,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Render the block.
 		$rendered = do_blocks( $GLOBALS['post']->post_content );
 
-		// Check does not contain the data-iawmlf-post-links attribute.
-		$this->assertStringNotContainsString( 'data-iawmlf-post-links', $rendered );
+		// Check does not contain the link data script tag.
+		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $rendered );
 
 		unset( $GLOBALS['post'] );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request refactors how post link data is rendered and consumed in the frontend. Instead of using a hidden `div` with a data attribute, the link data is now output in a `script` tag with a specific class, and the frontend JavaScript is updated to read from this script tag. Associated tests are also updated to reflect this new approach.

Rendering and data output changes:

* Changed the output of link data from a hidden `div` with a `data-iawmlf-post-links` attribute to a `script` tag of type `application/json` with the class `__iawmlf-post-loop-links`, and removed the use of `esc_attr` for JSON encoding in `WP_Post_Controller.php`.

Frontend JavaScript update:

* Updated `front_link_checker.js` so it now queries for `script` tags with the class `__iawmlf-post-loop-links` and parses their text content as JSON, instead of querying `div`s and reading from a data attribute.

Testing changes:

* Updated all relevant tests in `Test_WP_Post_Controller.php` to check for the presence (or absence) of the new script tag, rather than the old data attribute, and to extract and decode JSON from the script tag content. [[1]](diffhunk://#diff-59817116549d18d52a18dfd8c3caa0927eda7105983de9f5e1379084cc149d91L580-R581) [[2]](diffhunk://#diff-59817116549d18d52a18dfd8c3caa0927eda7105983de9f5e1379084cc149d91L614-R615) [[3]](diffhunk://#diff-59817116549d18d52a18dfd8c3caa0927eda7105983de9f5e1379084cc149d91L657-R664) [[4]](diffhunk://#diff-59817116549d18d52a18dfd8c3caa0927eda7105983de9f5e1379084cc149d91L719-R726) [[5]](diffhunk://#diff-59817116549d18d52a18dfd8c3caa0927eda7105983de9f5e1379084cc149d91L776-R777)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how post link data is delivered to the frontend by embedding JSON payloads directly in the page markup for more robust parsing and safer HTML encoding.
* **Tests**
  * Adjusted automated tests to validate the new embedded JSON delivery and decoding flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->