### PR TITLE
Bumped

### DIFF
--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.3.6-RC2
+ * @version     1.3.6
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.3.6-RC2
+ * Version:                 1.3.6
  * Requires at least:       6.4
  * Tested up to:            6.9
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.3.6-RC2' );
+define( 'IAWMLF_VERSION', '1.3.6' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.6-RC1",
+    "version": "1.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wayback-link-fixer",
-            "version": "1.3.6-RC1",
+            "version": "1.3.6",
             "license": "GPL-2.0-or-later",
             "devDependencies": {
                 "@csstools/postcss-sass": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wayback-link-fixer",
-    "version": "1.3.6-RC2",
+    "version": "1.3.6",
     "description": "A WordPress plugin that scans content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, creating snapshots of your own pages and other site links that aren’t yet archived. Uses Action Scheduler for background tasks.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects, cagrimmett, glynnquelch
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.3.6-RC2
+Stable tag: 1.3.6
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin from the release candidate version (`1.3.6-RC2`) to the stable version (`1.3.6`). The changes are limited to version number updates across key files.

Version updates:

* Updated the version number from `1.3.6-RC2` to `1.3.6` in `internet-archive-wayback-machine-link-fixer.php` header comments, plugin metadata, and constant definition. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33)
* Changed the version in `package.json` to `1.3.6`.
* Updated the `Stable tag` in `readme.txt` to `1.3.6`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.3.6 as final release, transitioning from release candidate status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->