### PR TITLE
Fix/improve memory overhead counting links

### DIFF
--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -406,8 +406,9 @@ class Link_Repository {
 		?array $snapshot_process = null,
 		?bool $has_checks = null
 	): array {
-		$rows = $this->perform_query( $limit, $page, $status, $link_ids, $archive_status, $order_by, $search_term, $date, $excluded, $snapshot_process, $has_checks );
-		return array_map( array( $this, 'map_link' ), $rows );
+		$query = $this->build_query( 'select', $limit, $page, $status, $link_ids, $archive_status, $order_by, $search_term, $date, $excluded, $snapshot_process, $has_checks );
+		$rows  = $this->wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
+		return array_map( array( $this, 'map_link' ), $rows ?? array() );
 	}
 
 	/**
@@ -440,12 +441,14 @@ class Link_Repository {
 		?array $snapshot_process = null,
 		?bool $has_checks = null
 	): int {
-		return count( $this->perform_query( $limit, $page, $status, $link_ids, $archive_status, $order_by, $search_term, $date, $excluded, $snapshot_process, $has_checks ) );
+		$query = $this->build_query( 'count', $limit, $page, $status, $link_ids, $archive_status, $order_by, $search_term, $date, $excluded, $snapshot_process, $has_checks );
+		return (int) $this->wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
 	}
 
 	/**
-	 * Performs a link query.
+	 * Builds a SQL query for links.
 	 *
+	 * @param string        $mode             The query mode: 'select' for SELECT *, 'count' for SELECT COUNT(*).
 	 * @param integer       $limit            The limit of links to return.
 	 * @param integer       $page             The page of links to return.
 	 * @param array         $status           The status of the links to return.
@@ -458,9 +461,10 @@ class Link_Repository {
 	 * @param string[]|NULL $snapshot_process The snapshot status of the links to return.
 	 * @param boolean|NULL  $has_checks       Whether to return links with or without checks.
 	 *
-	 * @return stdClass[]
+	 * @return string
 	 */
-	private function perform_query(
+	private function build_query(
+		string $mode = 'select',
 		int $limit = 10,
 		int $page = 1,
 		array $status = array(),
@@ -472,8 +476,8 @@ class Link_Repository {
 		?bool $excluded = null,
 		?array $snapshot_process = null,
 		?bool $has_checks = null
-	): array {
-				// Remove any invalid statuses.
+	): string {
+		// Remove any invalid statuses.
 		$status = array_filter(
 			$status,
 			function ( $status ): bool {
@@ -507,7 +511,9 @@ class Link_Repository {
 		$date = $date ? gmdate( 'Y-m', strtotime( esc_attr( $date ) ) ) : null;
 
 		// Prepare the query.
-		$query = "SELECT * FROM {$this->table_name}";
+		$query = 'count' === $mode
+			? "SELECT COUNT(*) FROM {$this->table_name}"
+			: "SELECT * FROM {$this->table_name}";
 
 		// Where statement has been used.
 		$where = false;
@@ -586,23 +592,19 @@ class Link_Repository {
 			$where  = true;
 		}
 
-		// Add the order by.
-		$query .= $this->compile_order_by( $order_by );
+		// Only add order by and limit for select queries.
+		if ( 'count' !== $mode ) {
+			// Add the order by.
+			$query .= $this->compile_order_by( $order_by );
 
-		// Add the limit and offset.
-		$offset = ( $page - 1 ) * $limit;
-		$query .= $this->wpdb->prepare( ' LIMIT %d OFFSET %d', $limit, $offset ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
-
-		// Get the rows.
-		$rows = $this->wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
-
-		// If no rows, return an empty collection.
-		if ( empty( $rows ) ) {
-			return array();
+			// Add the limit and offset.
+			$offset = ( $page - 1 ) * $limit;
+			$query .= $this->wpdb->prepare( ' LIMIT %d OFFSET %d', $limit, $offset ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
 		}
 
-		return $rows;
+		return $query;
 	}
+
 
 	/**
 	 * Gets the date range from a defined date.

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -592,15 +592,12 @@ class Link_Repository {
 			$where  = true;
 		}
 
-		// Only add order by and limit for select queries.
-		if ( 'count' !== $mode ) {
-			// Add the order by.
-			$query .= $this->compile_order_by( $order_by );
+		// Add the order by.
+		$query .= $this->compile_order_by( $order_by );
 
-			// Add the limit and offset.
-			$offset = ( $page - 1 ) * $limit;
-			$query .= $this->wpdb->prepare( ' LIMIT %d OFFSET %d', $limit, $offset ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
-		}
+		// Add the limit and offset.
+		$offset = ( $page - 1 ) * $limit;
+		$query .= $this->wpdb->prepare( ' LIMIT %d OFFSET %d', $limit, $offset ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
 
 		return $query;
 	}

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1040,8 +1040,12 @@ class Report_Table extends \WP_List_Table {
 	 */
 	public function prepare_items() {
 
+		echo '<script>console.log("prepare_items: start pagination args - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
+
 		// Set the pagination args.
 		$this->define_pagination_args();
+
+		echo '<script>console.log("prepare_items: end pagination args - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
 
 		// Set the headers
 		$columns               = $this->get_columns();
@@ -1050,6 +1054,8 @@ class Report_Table extends \WP_List_Table {
 		$primary               = self::COLUMN_LINK_URL;
 		$this->_column_headers = array( $columns, $hidden, $sortable, $primary );
 
+		echo '<script>console.log("prepare_items: start get_links - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
+
 		// Get the reports.
 		$this->items = $this->get_links(
 			$this->get_links_per_page(),
@@ -1057,6 +1063,8 @@ class Report_Table extends \WP_List_Table {
 			array( $this->get_status_from_url() ),
 			$this->get_search_term()
 		);
+
+		echo '<script>console.log("prepare_items: end get_links (' . count( $this->items ) . ' items) - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB / peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
 	}
 
 	/**

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1040,12 +1040,8 @@ class Report_Table extends \WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		echo '<script>console.log("prepare_items: start pagination args - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
-
 		// Set the pagination args.
 		$this->define_pagination_args();
-
-		echo '<script>console.log("prepare_items: end pagination args - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
 
 		// Set the headers
 		$columns               = $this->get_columns();
@@ -1054,8 +1050,6 @@ class Report_Table extends \WP_List_Table {
 		$primary               = self::COLUMN_LINK_URL;
 		$this->_column_headers = array( $columns, $hidden, $sortable, $primary );
 
-		echo '<script>console.log("prepare_items: start get_links - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
-
 		// Get the reports.
 		$this->items = $this->get_links(
 			$this->get_links_per_page(),
@@ -1063,8 +1057,6 @@ class Report_Table extends \WP_List_Table {
 			array( $this->get_status_from_url() ),
 			$this->get_search_term()
 		);
-
-		echo '<script>console.log("prepare_items: end get_links (' . count( $this->items ) . ' items) - mem: ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'MB / peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'MB");</script>';
 	}
 
 	/**


### PR DESCRIPTION
…elect * to allow for my more efficient memory overhead

#### Changes proposed in this Pull Request

This pull request refactors the way link queries are handled in the `Link_Repository` class, focusing on separating SQL query construction from execution. The main change is replacing the `perform_query` method with a new `build_query` method, which now only builds the query string. Query execution is moved directly into the `query_links` and `count_links` methods, improving code clarity and maintainability.

Refactoring link query handling:

* Replaced the `perform_query` method with a new `build_query` method that constructs SQL query strings for both selecting links and counting links, rather than executing them. (`src/Link/Link_Repository.php`, [[1]](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL461-R467) [[2]](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL475-R479)
* Updated the `query_links` and `count_links` methods to execute the queries returned by `build_query` using `$this->wpdb->get_results` and `$this->wpdb->get_var`, respectively, instead of relying on `perform_query`. (`src/Link/Link_Repository.php`, [[1]](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL409-R411) [[2]](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL443-R451)
* Modified the query construction logic to support both `SELECT *` and `SELECT COUNT(*)` modes based on a new `$mode` parameter. (`src/Link/Link_Repository.php`, [src/Link/Link_Repository.phpL510-R516](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL510-R516))
* Simplified the handling of empty query results by directly returning an empty array from `query_links` if no rows are found. (`src/Link/Link_Repository.php`, [src/Link/Link_Repository.phpL409-R411](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL409-R411))
* Updated documentation and comments to clarify the new responsibilities of `build_query` and its parameters. (`src/Link/Link_Repository.php`, [src/Link/Link_Repository.phpL443-R451](diffhunk://#diff-9a96e37b4725cbc2909805a50271d1c7fcfdf18df33056effb69c74f85e028faL443-R451))

These changes make the codebase more modular and easier to maintain by clearly separating query construction from execution.

### Debug Logging

* Added memory usage debug logging via `console.log` statements in the `prepare_items` method of the `Report_Table` class to help track memory consumption during pagination and link retrieval.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal query construction logic optimized for improved maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->