### PR TITLE
Fix/gh325 quick edit column shifts

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -2,7 +2,7 @@ name: PHP Coding Standards
 
 on:
   pull_request:
-    branches: [ trunk, develop ]
+    branches: [ trunk, develop, 1-4-0__development ]
 
 jobs:
   build:

--- a/.github/workflows/php-syntax-errors.yml
+++ b/.github/workflows/php-syntax-errors.yml
@@ -2,9 +2,9 @@ name: PHP Syntax Errors
 
 on:
   push:
-    branches: [ trunk, develop ]
+    branches: [ trunk, develop, 1-4-0__development ]
   pull_request:
-    branches: [ trunk, develop ]
+    branches: [ trunk, develop, 1-4-0__development ]
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ trunk ]
   pull_request:
-    branches: [ trunk, develop ]
+    branches: [ trunk, develop, 1-4-0__development ]
 
 jobs:
   build:

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -77,4 +77,42 @@ if ( is_wp_error( IAWMLF_MINIMUM_REQUIREMENTS ) ) {
 
 	register_activation_hook( __FILE__, 'iawmlf_activate' );
 	register_uninstall_hook( __FILE__, 'iawmlf_uninstall' );
+
+	// Debug: Show post ID column on all post type tables.
+	add_filter(
+		'manage_posts_columns',
+		function ( $columns ) {
+			$columns['iawmlf_post_id'] = 'Post ID';
+			return $columns;
+		},
+		999
+	);
+	add_filter(
+		'manage_pages_columns',
+		function ( $columns ) {
+			$columns['iawmlf_post_id'] = 'Post ID';
+			return $columns;
+		},
+		999
+	);
+	add_action(
+		'manage_posts_custom_column',
+		function ( $column_name, $post_id ) {
+			if ( 'iawmlf_post_id' === $column_name ) {
+				echo absint( $post_id );
+			}
+		},
+		999,
+		2
+	);
+	add_action(
+		'manage_pages_custom_column',
+		function ( $column_name, $post_id ) {
+			if ( 'iawmlf_post_id' === $column_name ) {
+				echo absint( $post_id );
+			}
+		},
+		999,
+		2
+	);
 }

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -77,42 +77,4 @@ if ( is_wp_error( IAWMLF_MINIMUM_REQUIREMENTS ) ) {
 
 	register_activation_hook( __FILE__, 'iawmlf_activate' );
 	register_uninstall_hook( __FILE__, 'iawmlf_uninstall' );
-
-	// Debug: Show post ID column on all post type tables.
-	add_filter(
-		'manage_posts_columns',
-		function ( $columns ) {
-			$columns['iawmlf_post_id'] = 'Post ID';
-			return $columns;
-		},
-		999
-	);
-	add_filter(
-		'manage_pages_columns',
-		function ( $columns ) {
-			$columns['iawmlf_post_id'] = 'Post ID';
-			return $columns;
-		},
-		999
-	);
-	add_action(
-		'manage_posts_custom_column',
-		function ( $column_name, $post_id ) {
-			if ( 'iawmlf_post_id' === $column_name ) {
-				echo absint( $post_id );
-			}
-		},
-		999,
-		2
-	);
-	add_action(
-		'manage_pages_custom_column',
-		function ( $column_name, $post_id ) {
-			if ( 'iawmlf_post_id' === $column_name ) {
-				echo absint( $post_id );
-			}
-		},
-		999,
-		2
-	);
 }

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -106,7 +106,16 @@ class WP_Post_Table_Controller {
 	 */
 	public function add_column( array $columns ): array {
 		// Get the post type.
-		$post_type = get_current_screen()->post_type;
+		$screen = get_current_screen();
+		if ( $screen ) {
+			$post_type = $screen->post_type;
+		} else {
+			// Fall back to the request's post_type or the post being edited.
+			$post_type = isset( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				? \sanitize_key( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				: 'post';
+		}
+
 		// Get the post types from settings.
 		$allowed_post_types = Settings::get_allowed_post_types();
 


### PR DESCRIPTION
Whenever we attempt to add the links column to a post types wp list table, we try to get the current post type from the screen object. This fails on ajax, so now we use the REQUEST object to attempt to check if we can show the column

#### Changes proposed in this Pull Request

This pull request improves the robustness of the `add_column` method in `WP_Post_Table_Controller.php` by handling cases where `get_current_screen()` returns null. This ensures the correct post type is determined even outside of the standard admin screen context.

**Improvements to post type detection:**

* Updated the `add_column` method to check if `get_current_screen()` returns a valid screen object before accessing `post_type`, and added a fallback to use the `post_type` from the request or default to `'post'` if unavailable.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #325 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of post-type detection in the admin interface; now handles cases where the admin screen context is unavailable by using safe fallbacks to maintain consistent behavior.
* **Chores**
  * CI workflows updated to also run for the 1-4-0__development branch, extending automated checks to that branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->