### PR TITLE
Changes to button icon margins for new ui style in 7.0

### DIFF
--- a/assets/css/src/admin/_dashboard.scss
+++ b/assets/css/src/admin/_dashboard.scss
@@ -119,18 +119,11 @@
         flex-wrap: wrap;
         gap: 10px;
         justify-content: flex-end;
-
         a {
             display: flex;
             align-items: center;
             white-space: nowrap;
             text-decoration: none;
-
-            .dashicons {
-                @media (max-width: 782px) {
-                    margin-top: 8px !important;
-                }
-            }
         }
     }
 }
@@ -285,12 +278,10 @@
         flex-wrap: wrap;
         gap: 10px;
         justify-content: flex-end;
-
         a {
             display: flex;
             align-items: center;
             white-space: nowrap;
-
             .dashicons {
                 @media (max-width: 782px) {
                     margin-top: 8px !important;

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -14,7 +14,7 @@
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
  * Version:                 1.4.0-RC1
  * Requires at least:       6.4
- * Tested up to:            6.9
+ * Tested up to:            7.0
  * Requires PHP:            7.4
  * Author:                  Internet Archive
  * Author URI:              https://archive.org

--- a/templates/admin/dashboard/widget.php
+++ b/templates/admin/dashboard/widget.php
@@ -151,16 +151,16 @@ defined( 'ABSPATH' ) || exit;
 	<div class="iawmlf_dashboard-navigation">
 		<?php if ( ! Dashboard_Page::is_current_page() ) : ?>
 		<a href="<?php echo esc_url( Dashboard_Page::get_page_url() ); ?>" class="button">
-			<span class="dashicons dashicons-dashboard" style="margin-top: 3px;"></span>
+			<span class="dashicons dashicons-dashboard"></span>
 			<span class="link-text"><?php esc_html_e( 'Dashboard', 'internet-archive-wayback-machine-link-fixer' ); ?></span>
 		</a>
 		<?php endif; ?>
 		<a href="<?php echo esc_url( $iawmlf_link_to_settings ); ?>" class="button">
-			<span class="dashicons dashicons-admin-settings" style="margin-top: 3px;"></span>
+			<span class="dashicons dashicons-admin-settings"></span>
 			<span class="link-text"><?php esc_html_e( 'Advanced Settings', 'internet-archive-wayback-machine-link-fixer' ); ?></span>
 		</a>
 		<a href="<?php echo esc_url( $iawmlf_link_table ); ?>" class="button">
-			<span class="dashicons dashicons-list-view" style="margin-top: 3px;"></span>
+			<span class="dashicons dashicons-list-view"></span>
 			<span class="link-text">
 				<?php
 				printf(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request focuses on cleaning up the dashboard button styles and updating compatibility information. The main changes are the removal of inline and responsive CSS for dashicon alignment, relying instead on default styling, and updating the plugin's "Tested up to" version.

**Dashboard button style simplification:**

* Removed custom inline `margin-top` styles from dashicon elements in the dashboard navigation to use default alignment. (`templates/admin/dashboard/widget.php`)
* Removed the responsive CSS rule that added a top margin to `.dashicons` inside dashboard links for small screens. (`assets/css/src/admin/_dashboard.scss`) [[1]](diffhunk://#diff-96aa065d643bb30b153cb4169e2aabce018003cd8471e00281e602ab76c17881L122-L133) [[2]](diffhunk://#diff-96aa065d643bb30b153cb4169e2aabce018003cd8471e00281e602ab76c17881L288-L293)

**Plugin metadata update:**

* Updated the "Tested up to" field to WordPress 7.0 in the plugin header. (`internet-archive-wayback-machine-link-fixer.php`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dashboard navigation icon positioning and alignment for improved visual consistency.

* **Chores**
  * Updated WordPress compatibility support to version 7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->