### PR TITLE
Now we see the last checks when the report loads and the earlier ones…

### DIFF
--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -147,8 +147,8 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 									<?php endif; ?>
 
 									<?php foreach ( array_reverse( $iawmlf_link->get_checks() ) as $iawmlf_index => $iawmlf_check ) : ?>
-										<?php // Hide the first n posts to the value of $iawmlf_hide_check_count. ?>
-										<?php if ( $iawmlf_index < $iawmlf_hide_check_count ) : ?>
+										<?php // Hide the oldest checks (beyond the newest 10). ?>
+										<?php if ( $iawmlf_index >= ( $iawmlf_check_count - $iawmlf_hide_check_count ) ) : ?>
 											<tr class="iawmlf_hidden_check" style="display: none;">
 										<?php else : ?>
 											<tr>


### PR DESCRIPTION
… are revealed with the button press

#### Changes proposed in this Pull Request

This pull request updates the logic for hiding check entries in the `link-details.php` admin report template. The change ensures that only the oldest checks—those beyond the newest 10—are hidden, rather than hiding the first (newest) checks.

Display logic update:

* Changed the condition in the foreach loop to hide the oldest checks (beyond the newest 10), improving the clarity and usefulness of the displayed check history. (`templates/admin/reports/link-details.php`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Link Checks table display logic in admin reports to correctly hide older entries beyond the most recent 10 items, providing better visibility of recent link check activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->