### PR TITLE
Used a alternative css pattern to show the same on wp 6.9.x and wp 7.0.x

### DIFF
--- a/assets/css/src/admin/_dashboard.scss
+++ b/assets/css/src/admin/_dashboard.scss
@@ -120,10 +120,15 @@
         gap: 10px;
         justify-content: flex-end;
         a {
-            display: flex;
+            display: flex !important;
             align-items: center;
             white-space: nowrap;
             text-decoration: none;
+            justify-content: center;
+            .dashicons {
+                line-height: initial !important;
+                margin-right: 4px;
+            }
         }
     }
 }
@@ -154,7 +159,6 @@
         gap: 20px;
     }
     margin-top: 15px;
-    ;
 }
 
 .iawmlf_dashboard-page-main {
@@ -279,13 +283,13 @@
         gap: 10px;
         justify-content: flex-end;
         a {
-            display: flex;
+            display: flex !important;
             align-items: center;
             white-space: nowrap;
+            justify-content: center;
             .dashicons {
-                @media (max-width: 782px) {
-                    margin-top: 8px !important;
-                }
+                line-height: initial !important;
+                margin-right: 4px;
             }
         }
     }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the spacing strat for button on dashboard, now is universal between versions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* WP 6.9.4
<img width="597" height="205" alt="image" src="https://github.com/user-attachments/assets/9f686ecd-71f9-4c05-9c77-03f7faf8af50" />

<img width="522" height="363" alt="image" src="https://github.com/user-attachments/assets/be3ea70e-86ef-489e-87b2-9171893d0155" />


* WP 7.1-alpha-62290
<img width="694" height="290" alt="image" src="https://github.com/user-attachments/assets/87f2b61a-1bde-42e5-b9f7-05b467b1e70e" />
<img width="530" height="299" alt="image" src="https://github.com/user-attachments/assets/8087e345-05c0-45d8-b032-30c6b5fa5fff" />


Mentions #329 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved visual alignment and spacing of navigation links and icons in the admin dashboard for better consistency across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->