### PR TITLE
bumped to 1.4.1-RC1

### DIFF
--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.4.1
+ * @version     1.4.1-RC1
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.4.1
+ * Version:                 1.4.1-RC1
  * Requires at least:       6.4
  * Tested up to:            7.0
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.4.1' );
+define( 'IAWMLF_VERSION', '1.4.1-RC1' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects, cagrimmett, glynnquelch
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.4.1
+Stable tag: 1.4.1-RC1
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin version from `1.4.1` to `1.4.1-RC1` throughout the codebase and documentation to reflect the release candidate status.

Version update:

* Updated the version number in the plugin header, PHP constants, and documentation (`internet-archive-wayback-machine-link-fixer.php`, `readme.txt`) from `1.4.1` to `1.4.1-RC1`. [[1]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[2]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.4.1-RC1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->