### PR TITLE
BUmped to 1.4.2-rc1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
             ".git/*" \
             ".github/*" \
             ".gitignore" \
+            ".distignore" \
             "index.php" \
             "node_modules/*" \
             "models/*" \
@@ -60,7 +61,16 @@ jobs:
             ".vscode/*" \
             "assets/css/src/*" \
             "assets/js/src/*" \
-            "_docs/*"
+            "_docs/*" \
+            "README.md" \
+            "AGENTS.md" \
+            "CLAUDE.md" \
+            "SECURITY.md" \
+            ".agents/*" \
+            "e2e/*" \
+            ".wp-env.json" \
+            "playwright-report/*" \
+            "test-results/*"
 
       - name:  Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.4.1 
+**Stable tag:** 1.4.2
 **License:** GPL-3.0-or-later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/internet-archive-wayback-machine-link-fixer.php
+++ b/internet-archive-wayback-machine-link-fixer.php
@@ -3,7 +3,7 @@
  * The wayback-link-fixer bootstrap file.
  *
  * @since       1.0.0
- * @version     1.4.1
+ * @version     1.4.2-RC1
  * @author       Internet Archive
  * @license     GPL-3.0-or-later
  *
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:             Internet Archive Wayback Machine Link Fixer
  * Description:             This plugin scans your content for links, replacing broken ones with archived versions from the Wayback Machine. It also features Auto Archiving, which automatically creates snapshots of your own pages and any other links on your site that aren’t yet archived, ensuring long-term accessibility.
- * Version:                 1.4.1
+ * Version:                 1.4.2-RC1
  * Requires at least:       6.4
  * Tested up to:            7.0
  * Requires PHP:            7.4
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'IAWMLF_BASENAME', plugin_basename( __FILE__ ) );
 define( 'IAWMLF_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IAWMLF_URL', plugin_dir_url( __FILE__ ) );
-define( 'IAWMLF_VERSION', '1.4.1' );
+define( 'IAWMLF_VERSION', '1.4.2-RC1' );
 define(
 	'IAWMLF_MINIMUM_VERSIONS',
 	array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: waybackmachineplugin, wpspecialprojects, cagrimmett, glynnquelch
 Tags: wayback machine, internet archive, broken links, archive links
 Requires at least: 6.4
 Tested up to: 6.9
-Stable tag: 1.4.1-RC1
+Stable tag: 1.4.2
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -115,6 +115,9 @@ This service checks if web pages are accessible and retrieves final URLs after r
 The Internet Archive is a non-profit organization dedicated to preserving digital content for public access. URLs sent to these services become part of the public archive and may be accessible through the Wayback Machine interface. No personal information beyond the URLs themselves is transmitted to these services.
 
 == Changelog ==
+
+= 1.4.2 =
+* Fix: Manually excluded links sometimes revert to unexcluded and can still be run through the link checker process. Now fully respects manual exclusions.
 
 = 1.4.1 =
 * Fix: link data span now survives themes that wrap post content in `wp_kses_post` (previously the JSON could leak as visible text on category and archive templates).


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request prepares for the 1.4.2 release of the Internet Archive Wayback Machine Link Fixer plugin. The main focus is on updating version numbers, documenting the new release, and improving the release workflow by excluding additional files and directories from the final release package. It also documents a bug fix for manual link exclusions.

**Release Preparation and Documentation:**

* Updated version numbers in `README.md`, `readme.txt`, and `internet-archive-wayback-machine-link-fixer.php` to reflect the 1.4.2 (and 1.4.2-RC1) release. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL6-R6) [[4]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL15-R15) [[5]](diffhunk://#diff-7cbc597963dcbf6ff8a3b72f6926361040cea7171213ff6290d9511b4b99093aL33-R33)
* Added a changelog entry in `readme.txt` for version 1.4.2, highlighting a fix where manually excluded links are now properly respected and not re-checked.

**Release Workflow Improvements:**

* Updated `.github/workflows/release.yml` to exclude additional files and directories (e.g., documentation, test results, `.agents`, `e2e`, and various markdown files) from release builds, ensuring cleaner and smaller release packages. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R49) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L63-R73)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where manually excluded links could revert to included state and be reprocessed by the link checker. Manual exclusions are now fully respected.

* **Chores**
  * Updated to version 1.4.2 and optimized release package configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/internet-archive-wayback-machine-link-fixer/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->