### PR TITLE
Fix/extend error checks

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,9 @@
 	"core": null,
 	"phpVersion": "8.3",
 	"plugins": [ "." ],
+	"mappings": {
+		"wp-content/mu-plugins/iawmlf-e2e-non200.php": "./e2e/mu-plugins/iawmlf-e2e-non200.php"
+	},
 	"port": 57893,
 	"testsPort": 57894,
 	"config": {

--- a/e2e/mu-plugins/iawmlf-e2e-non200.php
+++ b/e2e/mu-plugins/iawmlf-e2e-non200.php
@@ -34,8 +34,7 @@ add_filter(
 
 		return array(
 			'headers'  => array(),
-			// A 200 needs a valid body so the checker reports the link's status;
-			// any non-200 makes the checker treat the service as offline.
+			// 200 needs a valid body; any non-200 makes the checker treat it as offline.
 			'body'     => 200 === $code ? wp_json_encode( array( 'status' => 200 ) ) : '',
 			'response' => array(
 				'code'    => $code,
@@ -79,16 +78,14 @@ WP_CLI::add_command(
 
 		$code = isset( $args[0] ) ? (int) $args[0] : 502;
 
-		// Front-end script only enqueues (and would rewrite broken links) in
-		// "replace_link" mode — use it so a wrongly-broken link is visible.
+		// "replace_link" mode so the front-end enqueues and would rewrite broken links.
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
 		update_option( Settings::LINK_EXCLUSIONS, array() );
 
 		iawmlf_e2e_non200_cleanup();
 		update_option( IAWMLF_E2E_OPTION, $code );
 
-		// A link that is NOT broken and has never been checked, so the
-		// front-end performs a live check.
+		// Not broken and never checked, so the front-end performs a live check.
 		$wpdb->insert(
 			Settings::get_link_table_name(),
 			array(

--- a/e2e/mu-plugins/iawmlf-e2e-non200.php
+++ b/e2e/mu-plugins/iawmlf-e2e-non200.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * E2E helper for: "a non-200 from the Internet Archive link checker must not
+ * mark a link as broken". Mapped into wp-content/mu-plugins via .wp-env.json.
+ *
+ * Self-contained:
+ *   - Forces the live web check endpoint (…/livewebcheck) to return whatever
+ *     HTTP status the `iawmlf_e2e_force_status` option holds (0 = pass through).
+ *   - `wp iawmlf-e2e-non200 seed <code>` seeds a post + a not-broken, never
+ *     checked link, sets the forced status to <code> (default 502), and prints
+ *     KEY=VALUE lines.
+ *   - `wp iawmlf-e2e-non200 cleanup` removes that post + link and the forced status.
+ *
+ * @package Internet_Archive\Wayback_Machine_Link_Fixer\E2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+const IAWMLF_E2E_LINK_URL  = 'https://example.com/iawmlf-e2e-non200';
+const IAWMLF_E2E_POST_SLUG = 'iawmlf-e2e-non200';
+const IAWMLF_E2E_OPTION    = 'iawmlf_e2e_force_status';
+
+// Force the live web check endpoint to the configured status code.
+add_filter(
+	'pre_http_request',
+	function ( $pre, $args, $url ) {
+		$code = (int) get_option( IAWMLF_E2E_OPTION, 0 );
+
+		if ( 0 === $code || ! is_string( $url ) || false === strpos( $url, 'livewebcheck' ) ) {
+			return $pre;
+		}
+
+		return array(
+			'headers'  => array(),
+			// A 200 needs a valid body so the checker reports the link's status;
+			// any non-200 makes the checker treat the service as offline.
+			'body'     => 200 === $code ? wp_json_encode( array( 'status' => 200 ) ) : '',
+			'response' => array(
+				'code'    => $code,
+				'message' => '',
+			),
+		);
+	},
+	10,
+	3
+);
+
+if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+	return;
+}
+
+/**
+ * Delete the seeded post + link and clear the forced status (idempotent).
+ */
+function iawmlf_e2e_non200_cleanup() {
+	global $wpdb;
+
+	delete_option( IAWMLF_E2E_OPTION );
+	$wpdb->delete( Settings::get_link_table_name(), array( 'url' => IAWMLF_E2E_LINK_URL ), array( '%s' ) );
+
+	foreach ( get_posts(
+		array(
+			'name'        => IAWMLF_E2E_POST_SLUG,
+			'post_type'   => 'post',
+			'post_status' => 'any',
+			'numberposts' => 1,
+		)
+	) as $p ) {
+		wp_delete_post( $p->ID, true );
+	}
+}
+
+WP_CLI::add_command(
+	'iawmlf-e2e-non200 seed',
+	function ( $args ) {
+		global $wpdb;
+
+		$code = isset( $args[0] ) ? (int) $args[0] : 502;
+
+		// Front-end script only enqueues (and would rewrite broken links) in
+		// "replace_link" mode — use it so a wrongly-broken link is visible.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+		update_option( Settings::LINK_EXCLUSIONS, array() );
+
+		iawmlf_e2e_non200_cleanup();
+		update_option( IAWMLF_E2E_OPTION, $code );
+
+		// A link that is NOT broken and has never been checked, so the
+		// front-end performs a live check.
+		$wpdb->insert(
+			Settings::get_link_table_name(),
+			array(
+				'url'             => IAWMLF_E2E_LINK_URL,
+				'archived'        => 'https://web.archive.org/web/2024/' . IAWMLF_E2E_LINK_URL,
+				'checks'          => wp_json_encode( array() ),
+				'message'         => '',
+				'redirect_url'    => '',
+				'is_broken'       => 0,
+				'excluded'        => 0,
+				'archive_process' => 'done',
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s' )
+		);
+		$link_id = (int) $wpdb->insert_id;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'IAWMLF E2E Non-200 Link Check',
+				'post_name'    => IAWMLF_E2E_POST_SLUG,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_content' => sprintf( '<p>Check: <a href="%s">checked link</a></p>', esc_url( IAWMLF_E2E_LINK_URL ) ),
+			)
+		);
+
+		update_post_meta( $post_id, Settings::LINK_META_KEY, array( $link_id ) );
+
+		echo 'POST_URL=' . get_permalink( $post_id ) . "\n";
+		echo 'LINK_URL=' . IAWMLF_E2E_LINK_URL . "\n";
+	}
+);
+
+WP_CLI::add_command(
+	'iawmlf-e2e-non200 cleanup',
+	function () {
+		iawmlf_e2e_non200_cleanup();
+		echo "CLEANED=1\n";
+	}
+);

--- a/e2e/specs/link-check-non-200.spec.js
+++ b/e2e/specs/link-check-non-200.spec.js
@@ -1,0 +1,76 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * Regression: whatever HTTP status the Internet Archive link checker endpoint
+ * returns, a working link must NOT be marked as broken on the front end.
+ *
+ * For each status code the mapped e2e mu-plugin forces the live web check to
+ * return, we seed a NOT-broken, never-checked link (so the front-end performs
+ * a live check), load the post and assert the link is left alone — no
+ * `iawmlf-broken-link` class and no href rewrite.
+ *
+ *   - 200            -> the checker reports a valid link.
+ *   - 403/404/500/.. -> the endpoint is unavailable; the REST route returns
+ *                       500 and the front-end must do nothing.
+ *
+ * Seed/cleanup are WP-CLI commands from e2e/mu-plugins/iawmlf-e2e-non200.php.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+
+// 200 baseline + the non-2xx codes seen during the DDoS outage.
+const CODES = [ 200, 403, 404, 500, 502, 503 ];
+
+function wpCli( cmd ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- wp ${ cmd }`,
+		{ cwd: path.join( __dirname, '../..' ), encoding: 'utf8' }
+	);
+}
+
+function seed( code ) {
+	const output = wpCli( `iawmlf-e2e-non200 seed ${ code }` );
+	const parse = ( key ) => {
+		const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+		if ( ! m ) {
+			throw new Error( `Seeder did not print ${ key }. Output was:\n${ output }` );
+		}
+		return m[ 1 ].trim();
+	};
+	return { postUrl: parse( 'POST_URL' ), linkUrl: parse( 'LINK_URL' ) };
+}
+
+test.describe( 'link checker status codes', () => {
+	test.afterEach( () => {
+		wpCli( 'iawmlf-e2e-non200 cleanup' );
+	} );
+
+	for ( const code of CODES ) {
+		test( `link checker returning ${ code } does not mark the link broken`, async ( { page } ) => {
+			const seeded = seed( code );
+
+			const checkResponse = page.waitForResponse( ( response ) =>
+				response.url().includes( 'iawmlf/v1/link-check' )
+			);
+
+			await page.goto( seeded.postUrl );
+
+			const checkedLink = page.locator( 'a', { hasText: 'checked link' } );
+			await expect( checkedLink ).toBeVisible();
+
+			// A 200 is a real verdict (HTTP 200); any non-200 makes the route
+			// return a 500 error rather than a verdict.
+			const response = await checkResponse;
+			expect( response.status() ).toBe( 200 === code ? 200 : 500 );
+
+			// The checker processed the link (proves the JS ran)...
+			await expect( checkedLink ).toHaveAttribute( 'data-iawmlf-archived-url', /.+/ );
+
+			// ...but the link must never be marked broken or have its href rewritten.
+			await expect( checkedLink ).not.toHaveClass( /iawmlf-broken-link/ );
+			await expect( checkedLink ).toHaveAttribute( 'href', seeded.linkUrl );
+		} );
+	}
+} );

--- a/e2e/specs/link-check-non-200.spec.js
+++ b/e2e/specs/link-check-non-200.spec.js
@@ -3,19 +3,8 @@ const { execSync } = require( 'child_process' );
 const path = require( 'path' );
 
 /**
- * Regression: whatever HTTP status the Internet Archive link checker endpoint
- * returns, a working link must NOT be marked as broken on the front end.
- *
- * For each status code the mapped e2e mu-plugin forces the live web check to
- * return, we seed a NOT-broken, never-checked link (so the front-end performs
- * a live check), load the post and assert the link is left alone — no
- * `iawmlf-broken-link` class and no href rewrite.
- *
- *   - 200            -> the checker reports a valid link.
- *   - 403/404/500/.. -> the endpoint is unavailable; the REST route returns
- *                       500 and the front-end must do nothing.
- *
- * Seed/cleanup are WP-CLI commands from e2e/mu-plugins/iawmlf-e2e-non200.php.
+ * Regression: whatever status the link checker returns, a working link must not
+ * be marked broken on the front end. Forces each status via the e2e mu-plugin.
  */
 
 const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
@@ -60,8 +49,7 @@ test.describe( 'link checker status codes', () => {
 			const checkedLink = page.locator( 'a', { hasText: 'checked link' } );
 			await expect( checkedLink ).toBeVisible();
 
-			// A 200 is a real verdict (HTTP 200); any non-200 makes the route
-			// return a 500 error rather than a verdict.
+			// 200 is a real verdict; any non-200 makes the route return a 500.
 			const response = await checkResponse;
 			expect( response.status() ).toBe( 200 === code ? 200 : 500 );
 

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -14,6 +14,7 @@ namespace Internet_Archive\Wayback_Machine_Link_Fixer\Event;
 use Exception;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Repository;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Wayback_Machine_Service;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Service_Offline_Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -132,8 +133,15 @@ class Find_Or_Create_Snapshot_Event {
 
 		$link->set_archived_href( $snapshot['url'] );
 
-		// Get the current link status.
-		$status = $this->wayback_machine->check_single( $link->get_href() );
+		// Get the current link status. If the link checker endpoint is
+		// unavailable (a non-200 response), treat it exactly like the service
+		// being offline: leave the link untouched and try again later.
+		try {
+			$status = $this->wayback_machine->check_single( $link->get_href() );
+		} catch ( Service_Offline_Exception $e ) {
+			self::add_to_queue_with_delay( $link_id, 1 * \HOUR_IN_SECONDS );
+			return;
+		}
 
 		// Add to the link.
 		$link->add_check( $status );

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -133,6 +133,7 @@ class Find_Or_Create_Snapshot_Event {
 
 		$link->set_archived_href( $snapshot['url'] );
 
+		// Get the current link status.
 		try {
 			$status = $this->wayback_machine->check_single( $link->get_href() );
 		} catch ( Service_Offline_Exception $e ) {

--- a/src/Event/Find_Or_Create_Snapshot_Event.php
+++ b/src/Event/Find_Or_Create_Snapshot_Event.php
@@ -133,12 +133,10 @@ class Find_Or_Create_Snapshot_Event {
 
 		$link->set_archived_href( $snapshot['url'] );
 
-		// Get the current link status. If the link checker endpoint is
-		// unavailable (a non-200 response), treat it exactly like the service
-		// being offline: leave the link untouched and try again later.
 		try {
 			$status = $this->wayback_machine->check_single( $link->get_href() );
 		} catch ( Service_Offline_Exception $e ) {
+			// Non-200 from the link checker: treat as offline, reschedule.
 			self::add_to_queue_with_delay( $link_id, 1 * \HOUR_IN_SECONDS );
 			return;
 		}

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -36,6 +36,169 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		delete_transient( 'iawmlf_archive_api_online' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Mocks every archive.org HTTP call the event makes, with the livewebcheck
+	 * (link checker) endpoint returning the supplied HTTP status code.
+	 *
+	 * - save/status/system  (is_online)            -> 200
+	 * - wayback/available   (get_latest_snapshot)  -> 200 + a valid snapshot
+	 * - livewebcheck        (check_single)         -> $link_check_code
+	 *
+	 * @param int $link_check_code The HTTP code the livewebcheck endpoint returns.
+	 *
+	 * @return void
+	 */
+	private function mock_archive_http( int $link_check_code ): void {
+		$snapshot_body = json_encode(
+			array(
+				'url'                => 'http://example.com',
+				'archived_snapshots' => array(
+					'closest' => array(
+						'available' => true,
+						'status'    => 200,
+						'url'       => 'http://web.archive.org/web/20240101000000/http://example.com',
+						'timestamp' => '20240101000000',
+					),
+				),
+			)
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( $link_check_code, $snapshot_body ) {
+				// The system status endpoint (is_online).
+				if ( false !== strpos( $url, 'save/status/system' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => json_encode( array( 'status' => 'ok' ) ),
+					);
+				}
+
+				// The find-snapshot endpoint (get_latest_snapshot).
+				if ( false !== strpos( $url, 'wayback/available' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => $snapshot_body,
+					);
+				}
+
+				// The link checker endpoint (check_single) - the one under test.
+				if ( false !== strpos( $url, 'livewebcheck' ) ) {
+					return array(
+						'response' => array( 'code' => $link_check_code ),
+						'body'     => json_encode( array( 'status' => 200 ) ),
+					);
+				}
+
+				// Anything else, a benign 200.
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * @testdox BASELINE: when the link checker returns a 200, the link is checked and marked done.
+	 *
+	 * @return void
+	 */
+	public function test_200_from_link_checker_processes_link(): void {
+		$this->mock_archive_http( 200 );
+		delete_transient( 'iawmlf_archive_api_online' );
+
+		$repo = new Link_Repository();
+		$link = $repo->upsert( new Link( 'https://example.com' ) );
+
+		$event = new Find_Or_Create_Snapshot_Event();
+		$event->setup();
+		$event( $link->get_id() );
+
+		$link = $repo->find_by_id( $link->get_id() );
+
+		// A successful check means the link is processed/done.
+		$this->assertEquals( Link::PROCESS_DONE, $link->get_archive_process() );
+	}
+
+	/**
+	 * @testdox When a link-check HTTP request comes back as a non-200, the event must do nothing - the link is left untouched.
+	 *
+	 * @dataProvider non_success_status_code_provider
+	 *
+	 * @param int $code The HTTP status code the livewebcheck endpoint returns.
+	 *
+	 * @return void
+	 */
+	public function test_non_2xx_from_link_checker_does_nothing( int $code ): void {
+		$this->mock_archive_http( $code );
+		delete_transient( 'iawmlf_archive_api_online' );
+
+		$repo = new Link_Repository();
+		$link = $repo->upsert( new Link( 'https://example.com' ) );
+		$id   = $link->get_id();
+
+		// Capture the state before the event runs.
+		$process_before = $link->get_archive_process();
+
+		$event = new Find_Or_Create_Snapshot_Event();
+		$event->setup();
+
+		try {
+			$event( $id );
+		} catch ( \Throwable $e ) {
+			// "Do nothing" means it must not bubble an error to the scheduler either.
+			$this->fail( "A {$code} link-check response must be handled silently, but the event threw: " . $e->getMessage() );
+		}
+
+		$link = $repo->find_by_id( $id );
+
+		// The links process state must be unchanged.
+		$this->assertSame(
+			$process_before,
+			$link->get_archive_process(),
+			"A {$code} link-check response must not change the link's process state."
+		);
+
+		// The link must not have been marked done.
+		$this->assertNotEquals(
+			Link::PROCESS_DONE,
+			$link->get_archive_process(),
+			"A {$code} link-check response must not mark the link as done."
+		);
+
+		// The link must not have had an archived url applied.
+		$this->assertEmpty(
+			$link->get_archived_href(),
+			"A {$code} link-check response must not set an archived url on the link."
+		);
+	}
+
+	/**
+	 * Non-2xx (offline) HTTP status codes seen during the DDoS outage.
+	 *
+	 * @return array<string, array{0:int}>
+	 */
+	public static function non_success_status_code_provider(): array {
+		return array(
+			'503 service unavailable' => array( 503 ),
+			'404 not found'           => array( 404 ),
+			'403 forbidden'           => array( 403 ),
+			'500 generic non-2xx'     => array( 500 ),
+		);
+	}
+
+	/**
 	 * @testdox When a link is added to the queue and its url is already an archive.org url (HTTPS), it should not be added to the queue and a message added to the link object.
 	 *
 	 * @return void

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -45,16 +45,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Mocks every archive.org HTTP call the event makes, with the livewebcheck
-	 * (link checker) endpoint returning the supplied HTTP status code.
-	 *
-	 * - save/status/system  (is_online)            -> 200
-	 * - wayback/available   (get_latest_snapshot)  -> 200 + a valid snapshot
-	 * - livewebcheck        (check_single)         -> $link_check_code
-	 *
-	 * @param int $link_check_code The HTTP code the livewebcheck endpoint returns.
-	 *
-	 * @return void
+	 * Mocks the event's archive.org calls; livewebcheck returns $link_check_code.
 	 */
 	private function mock_archive_http( int $link_check_code ): void {
 		$snapshot_body = json_encode(

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -18,6 +18,7 @@ use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Repository;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Rest\Link_Check_Rest;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Service_Offline_Exception;
 
 /**
  * Test_Link_Check_Rest
@@ -254,5 +255,54 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 		$response = $this->dispatch_request( array( 'link' => 'https://error-link.com' ) );
 
 		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	/**
+	 * Non-200 (offline) HTTP status codes the link checker can report.
+	 *
+	 * @return array<string, array{0:int}>
+	 */
+	public static function non_200_code_provider(): array {
+		return array(
+			'503 service unavailable' => array( 503 ),
+			'502 bad gateway'         => array( 502 ),
+			'404 not found'           => array( 404 ),
+			'403 forbidden'           => array( 403 ),
+		);
+	}
+
+	/**
+	 * @testdox When the link checker endpoint returns a non-200, the route just returns the error and must NOT mark the link broken.
+	 *
+	 * @dataProvider non_200_code_provider
+	 *
+	 * @param int $code The HTTP status code the link checker endpoint returned.
+	 *
+	 * @return void
+	 */
+	public function test_non_200_returns_error_and_does_not_mark_broken( int $code ): void {
+		// Create a link with no checks (will trigger a check).
+		$url  = 'https://ia-non200.com';
+		$link = new Link( $url );
+		$link->set_archived_href( 'https://web.archive.org/web/20240101/' . $url );
+		$this->link_repository->upsert( $link );
+
+		// The link checker endpoint returned a non-200, so the client treats it
+		// as offline and throws.
+		$mock_client = $this->createMock( Link_Checker_Client::class );
+		$mock_client->method( 'check_single' )
+			->willThrowException( Service_Offline_Exception::create( 'Response:' . $code ) );
+
+		add_filter( 'iawmlf_link_checker_client', fn() => $mock_client );
+
+		$response = $this->dispatch_request( array( 'link' => $url ) );
+
+		// It just returns the error.
+		$this->assertEquals( 500, $response->get_status() );
+
+		// The link must be left untouched - not broken, no check recorded.
+		$stored = $this->link_repository->find_by_url( $url );
+		$this->assertFalse( $stored->is_broken(), "A {$code} must not mark the link broken." );
+		$this->assertNull( $stored->get_last_check(), "A {$code} must not record a check against the link." );
 	}
 }

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -287,8 +287,7 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 		$link->set_archived_href( 'https://web.archive.org/web/20240101/' . $url );
 		$this->link_repository->upsert( $link );
 
-		// The link checker endpoint returned a non-200, so the client treats it
-		// as offline and throws.
+		// Non-200 from the endpoint: the client treats it as offline and throws.
 		$mock_client = $this->createMock( Link_Checker_Client::class );
 		$mock_client->method( 'check_single' )
 			->willThrowException( Service_Offline_Exception::create( 'Response:' . $code ) );


### PR DESCRIPTION
## What
When the Internet Archive link checker endpoint returns a non-200, treat it as
the service being offline: leave the link untouched (don't mark it broken) and
reschedule, instead of throwing or recording a verdict.

## Why
During the archive.org DDoS the link checker returned 5xx/4xx responses, which
were bubbling out of `Find_Or_Create_Snapshot_Event` and could flip good links
to broken. A non-200 from the checker isn't a verdict about the link.

## Changes
- `Find_Or_Create_Snapshot_Event`: catch `Service_Offline_Exception` around
  `check_single()` and reschedule like the existing offline guard.

## Tests
- Unit (`Test_Find_Or_Create_Snapshot`): 200 baseline + 403/404/500/503 "do nothing".
- Unit (`Test_Link_Check_Rest`): non-200 returns the error, link not marked broken.
- E2E (`link-check-non-200.spec.js`): matrix 200/403/404/500/502/503, via a
  self-contained mapped mu-plugin with `seed`/`cleanup` commands.

## Verification
- Full Playwright suite: 8/8 passing.
- PHPUnit: passing (run locally).