### PR TITLE
Add "Check only" fixer option (check links without redirecting)

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,7 +4,8 @@
 	"plugins": [ "." ],
 	"mappings": {
 		"wp-content/mu-plugins/iawmlf-e2e-non200.php": "./e2e/mu-plugins/iawmlf-e2e-non200.php",
-		"wp-content/mu-plugins/iawmlf-e2e-exclusion.php": "./e2e/mu-plugins/iawmlf-e2e-exclusion.php"
+		"wp-content/mu-plugins/iawmlf-e2e-exclusion.php": "./e2e/mu-plugins/iawmlf-e2e-exclusion.php",
+		"wp-content/mu-plugins/iawmlf-e2e-fixer-mode.php": "./e2e/mu-plugins/iawmlf-e2e-fixer-mode.php"
 	},
 	"port": 57893,
 	"testsPort": 57894,

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Specify the number of consecutive failed checks before a link is marked as broke
 ![Fixer Option](./_docs/settings--fixer-option.png)
 
 You can choose what outcome you want to happen when a link is found to be broken. The options are:
- * **Do Nothing** - This will not change the link at all, but useful for monitoring content.
- * **Replace Link (No Notification)** - This will replace the broken link with the archived version, if one exists. If no archived version exists, the link will not be changed. No notice will be given to the user that the link has been replaced.
+ * **Redirect broken links to snapshots on the Wayback Machine** - This will replace the broken link with the archived version, if one exists. If no archived version exists, the link will not be changed. No notice will be given to the user that the link has been replaced.
+ * **Check broken links but do not redirect them** - Links are still checked and their status recorded internally (so the link report stays up to date), but the link shown to visitors is never changed. Useful for monitoring content without altering the frontend.
+ * **Do not auto check links** - Links are not automatically checked from the frontend and are never changed.
 
 #### Link Icon
 

--- a/assets/js/src/front_link_checker.js
+++ b/assets/js/src/front_link_checker.js
@@ -271,8 +271,9 @@ const addDataAttributes = (link) => {
 				currentLink.setAttribute('data-iawmlf-archived-last-checked', link.last_checked.date);
 			}
 
-			// If the link is broken, add a class and change the href
-			if (link.broken && linkCheckSettings.fixerOption !== 'do_nothing') {
+			// If the link is broken, add a class and change the href.
+			// Only 'replace_link' swaps the href; 'check_only' records the check but leaves the link untouched.
+			if (link.broken && linkCheckSettings.fixerOption === 'replace_link') {
 				currentLink.classList.add('iawmlf-broken-link');
 				currentLink.href = '' !== link.archived_href ? link.archived_href : href;
 			}

--- a/e2e/mu-plugins/iawmlf-e2e-fixer-mode.php
+++ b/e2e/mu-plugins/iawmlf-e2e-fixer-mode.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * E2E helper for the Fixer Option modes. Mapped into wp-content/mu-plugins via .wp-env.json.
+ *
+ * Seeds one broken link that already has an archived version and a recent check, so the
+ * front-end checker resolves it locally (no live API call). A spec can then toggle the
+ * fixer mode and assert the front-end behaviour for each:
+ *
+ *   - replace_link : href rewritten to the archive URL + `iawmlf-broken-link` class added.
+ *   - check_only   : link checked (data-iawmlf-archived-url set) but href left untouched, no class.
+ *   - do_nothing   : the checker script is never enqueued, so the link is left entirely alone.
+ *
+ * Commands:
+ *   wp iawmlf-e2e-fixer-mode seed         -> seeds the post + broken/archived link, prints URLs.
+ *   wp iawmlf-e2e-fixer-mode mode <value> -> sets the fixer option (replace_link|check_only|do_nothing).
+ *   wp iawmlf-e2e-fixer-mode cleanup      -> removes the post + link and resets the fixer option.
+ *
+ * @package Internet_Archive\Wayback_Machine_Link_Fixer\E2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+const IAWMLF_E2E_FIXER_LINK_URL     = 'https://example.com/iawmlf-e2e-fixer-mode';
+const IAWMLF_E2E_FIXER_ARCHIVED_URL = 'https://web.archive.org/web/2024/https://example.com/iawmlf-e2e-fixer-mode';
+const IAWMLF_E2E_FIXER_POST_SLUG    = 'iawmlf-e2e-fixer-mode';
+
+if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+	return;
+}
+
+/**
+ * Delete the seeded post + link and reset the fixer option (idempotent).
+ *
+ * @return void
+ */
+function iawmlf_e2e_fixer_mode_cleanup(): void {
+	global $wpdb;
+
+	update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+	$wpdb->delete( Settings::get_link_table_name(), array( 'url' => IAWMLF_E2E_FIXER_LINK_URL ), array( '%s' ) );
+
+	foreach ( get_posts(
+		array(
+			'name'        => IAWMLF_E2E_FIXER_POST_SLUG,
+			'post_type'   => 'post',
+			'post_status' => 'any',
+			'numberposts' => 1,
+		)
+	) as $p ) {
+		wp_delete_post( $p->ID, true );
+	}
+}
+
+// Seed one broken link with an archived version + a recent check, and a post that links to it.
+WP_CLI::add_command(
+	'iawmlf-e2e-fixer-mode seed',
+	function (): void {
+		global $wpdb;
+
+		update_option( Settings::POST_ACTIVATION_ONBOARDING_KEY, Settings::ONBOARDING_COMPLETED_OPTION );
+		update_option( Settings::SETUP_WIZARD_COMPLETED_KEY, true );
+		update_option( Settings::SETUP_WIZARD_STEP_KEY, 'complete' );
+		update_option( Settings::LINK_EXCLUSIONS, array() );
+
+		iawmlf_e2e_fixer_mode_cleanup();
+
+		// Broken, with an archived version and a recent check so the front-end resolves it
+		// locally (checks within the delay window skip the live REST call).
+		$wpdb->insert(
+			Settings::get_link_table_name(),
+			array(
+				'url'             => IAWMLF_E2E_FIXER_LINK_URL,
+				'archived'        => IAWMLF_E2E_FIXER_ARCHIVED_URL,
+				'checks'          => wp_json_encode( array( array( 'date' => gmdate( 'Y-m-d H:i:s' ), 'http_code' => 404 ) ) ),
+				'message'         => '',
+				'redirect_url'    => '',
+				'is_broken'       => 1,
+				'excluded'        => 0,
+				'archive_process' => 'done',
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s' )
+		);
+		$link_id = (int) $wpdb->insert_id;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'IAWMLF E2E Fixer Mode',
+				'post_name'    => IAWMLF_E2E_FIXER_POST_SLUG,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_content' => sprintf( '<p>Check: <a href="%s">fixer mode link</a></p>', esc_url( IAWMLF_E2E_FIXER_LINK_URL ) ),
+			)
+		);
+
+		update_post_meta( $post_id, Settings::LINK_META_KEY, array( $link_id ) );
+
+		echo 'POST_URL=' . get_permalink( $post_id ) . "\n";
+		echo 'LINK_URL=' . IAWMLF_E2E_FIXER_LINK_URL . "\n";
+		echo 'ARCHIVED_URL=' . IAWMLF_E2E_FIXER_ARCHIVED_URL . "\n";
+	}
+);
+
+// Set the fixer option: wp iawmlf-e2e-fixer-mode mode <replace_link|check_only|do_nothing>.
+WP_CLI::add_command(
+	'iawmlf-e2e-fixer-mode mode',
+	function ( array $args ): void {
+		$mode  = isset( $args[0] ) ? (string) $args[0] : '';
+		$valid = array(
+			Settings::FIXER_OPTION_REPLACE_LINK,
+			Settings::FIXER_OPTION_CHECK_ONLY,
+			Settings::FIXER_OPTION_DO_NOTHING,
+		);
+
+		if ( ! in_array( $mode, $valid, true ) ) {
+			WP_CLI::error( 'Invalid mode: ' . $mode );
+		}
+
+		update_option( Settings::FIXER_OPTION, $mode );
+		echo 'MODE=' . $mode . "\n";
+	}
+);
+
+WP_CLI::add_command(
+	'iawmlf-e2e-fixer-mode cleanup',
+	function (): void {
+		iawmlf_e2e_fixer_mode_cleanup();
+		echo "CLEANED=1\n";
+	}
+);

--- a/e2e/specs/fixer-mode.spec.js
+++ b/e2e/specs/fixer-mode.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * The Fixer Option controls what the front-end checker does with a broken link:
+ *
+ *   - replace_link : rewrite the href to the archived version + add `iawmlf-broken-link`.
+ *   - check_only   : still check the link (records the result), but never touch the href.
+ *   - do_nothing   : don't even enqueue the checker; the link is left completely alone.
+ *
+ * One broken link (with an archived version) is seeded once, then the mode is toggled
+ * and the same page re-loaded to assert each contract.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+
+function wpCli( cmd ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- wp ${ cmd }`,
+		{ cwd: path.join( __dirname, '../..' ), encoding: 'utf8' }
+	);
+}
+
+function parse( output, key ) {
+	const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+	if ( ! m ) {
+		throw new Error( `Seeder did not print ${ key }. Output was:\n${ output }` );
+	}
+	return m[ 1 ].trim();
+}
+
+function seed() {
+	const output = wpCli( 'iawmlf-e2e-fixer-mode seed' );
+	return {
+		postUrl:     parse( output, 'POST_URL' ),
+		linkUrl:     parse( output, 'LINK_URL' ),
+		archivedUrl: parse( output, 'ARCHIVED_URL' ),
+	};
+}
+
+function setMode( mode ) {
+	wpCli( `iawmlf-e2e-fixer-mode mode ${ mode }` );
+}
+
+test.describe( 'fixer option modes', () => {
+	let seeded;
+
+	test.beforeAll( () => {
+		seeded = seed();
+	} );
+
+	test.afterAll( () => {
+		wpCli( 'iawmlf-e2e-fixer-mode cleanup' );
+	} );
+
+	test( 'replace_link rewrites the broken link to the archived version', async ( { page } ) => {
+		setMode( 'replace_link' );
+		await page.goto( seeded.postUrl );
+
+		const link = page.locator( 'a', { hasText: 'fixer mode link' } );
+		await expect( link ).toBeVisible();
+
+		// The checker ran and, in replace mode, swapped the href + flagged it broken.
+		// The plugin renders archived links on the web-wp.archive.org host, so match the
+		// archive path host-agnostically rather than a specific subdomain.
+		await expect( link ).toHaveAttribute( 'data-iawmlf-archived-url', /.+/ );
+		await expect( link ).toHaveClass( /iawmlf-broken-link/ );
+		await expect( link ).toHaveAttribute( 'href', /archive\.org\/web/ );
+	} );
+
+	test( 'check_only checks the link but leaves the href untouched', async ( { page } ) => {
+		setMode( 'check_only' );
+		await page.goto( seeded.postUrl );
+
+		const link = page.locator( 'a', { hasText: 'fixer mode link' } );
+		await expect( link ).toBeVisible();
+
+		// The checker still ran (proves the check is recorded)...
+		await expect( link ).toHaveAttribute( 'data-iawmlf-archived-url', /.+/ );
+
+		// ...but the visitor-facing link is unchanged: no class, original href.
+		await expect( link ).not.toHaveClass( /iawmlf-broken-link/ );
+		await expect( link ).toHaveAttribute( 'href', seeded.linkUrl );
+	} );
+
+	test( 'do_nothing does not enqueue the checker and leaves the link alone', async ( { page } ) => {
+		setMode( 'do_nothing' );
+		await page.goto( seeded.postUrl );
+
+		const link = page.locator( 'a', { hasText: 'fixer mode link' } );
+		await expect( link ).toBeVisible();
+
+		// The front-end checker script is never enqueued in this mode.
+		await expect(
+			page.locator( 'script#iawm-link-fixer-front-link-checker-js' )
+		).toHaveCount( 0 );
+
+		// So the link is completely untouched.
+		await expect( link ).not.toHaveClass( /iawmlf-broken-link/ );
+		await expect( link ).not.toHaveAttribute( 'data-iawmlf-archived-url', /.+/ );
+		await expect( link ).toHaveAttribute( 'href', seeded.linkUrl );
+	} );
+} );

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -1430,8 +1430,11 @@ class Settings_Page {
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_REPLACE_LINK ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_REPLACE_LINK ); ?>>
 				<?php esc_html_e( 'Redirect broken links to snapshots on the Wayback Machine', 'internet-archive-wayback-machine-link-fixer' ); ?>
 			</option>
+			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_CHECK_ONLY ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_CHECK_ONLY ); ?>>
+				<?php esc_html_e( 'Check broken links but do not redirect them', 'internet-archive-wayback-machine-link-fixer' ); ?>
+			</option>
 			<option value="<?php echo esc_attr( Settings::FIXER_OPTION_DO_NOTHING ); ?>" <?php selected( Settings::get_fixer_option(), Settings::FIXER_OPTION_DO_NOTHING ); ?>>
-				<?php esc_html_e( 'Do not redirect broken links', 'internet-archive-wayback-machine-link-fixer' ); ?>
+				<?php esc_html_e( 'Do not auto check links', 'internet-archive-wayback-machine-link-fixer' ); ?>
 			</option>
 		</select>
 		<p class="description">

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -57,6 +57,7 @@ class Settings {
 	// Fixer Options
 	public const FIXER_OPTION_DO_NOTHING   = 'do_nothing';
 	public const FIXER_OPTION_REPLACE_LINK = 'replace_link';
+	public const FIXER_OPTION_CHECK_ONLY   = 'check_only';
 
 	// Onboarding options.
 	public const ONBOARDING_COMPLETED_OPTION = self::SETTINGS_PREFIX . 'onboarding_completed';
@@ -488,12 +489,16 @@ class Settings {
 	/**
 	 * Checks if the HTML link output should be rendered in the frontend.
 	 *
+	 * True for both "replace link" and "check only" - the frontend checker is
+	 * needed in both cases to verify links and record the result. The check-only
+	 * mode simply skips the href swap (handled JS-side via the fixer option).
+	 *
 	 * @since 1.3.1
 	 *
 	 * @return boolean
 	 */
 	public static function should_render_html_link_output(): bool {
-		$allowed = in_array( self::get_fixer_option(), array( self::FIXER_OPTION_REPLACE_LINK ), true );
+		$allowed = in_array( self::get_fixer_option(), array( self::FIXER_OPTION_REPLACE_LINK, self::FIXER_OPTION_CHECK_ONLY ), true );
 
 		/**
 		 * Filter to allow or disallow the HTML link output in the frontend.

--- a/tests/Event/Test_Check_Snapshot_Status_Event.php
+++ b/tests/Event/Test_Check_Snapshot_Status_Event.php
@@ -49,6 +49,17 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		// Remove client mocks so they can't leak into later tests under random ordering.
+		remove_all_filters( 'iawmlf_snapshot_client' );
+		remove_all_filters( 'iawmlf_link_checker_client' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Set the snapshot client to return a mocked response.
 	 *
 	 * @param array $response The response to return.

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -32,6 +32,11 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		// Clear the actionscheduler_actions table.
 		$this->wpdb->query( "TRUNCATE TABLE {$this->wpdb->prefix}actionscheduler_actions" );
 
+		// Clear any snapshot / link-checker client mocks leaked from other tests (random order):
+		// this class mocks at the HTTP layer, so a stale injected client would leave links 'pending'.
+		remove_all_filters( 'iawmlf_snapshot_client' );
+		remove_all_filters( 'iawmlf_link_checker_client' );
+
 		parent::set_up();
 	}
 

--- a/tests/Report/Test_Report_Table_Actions.php
+++ b/tests/Report/Test_Report_Table_Actions.php
@@ -50,6 +50,17 @@ class Test_Report_Table_Actions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		// Remove client mocks so they can't leak into later tests under random ordering.
+		remove_all_filters( 'iawmlf_snapshot_client' );
+		remove_all_filters( 'iawmlf_link_checker_client' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Set the snapshot client to return a mocked response.
 	 *
 	 * @param array $response The response to return.

--- a/tests/Settings/Test_Settings.php
+++ b/tests/Settings/Test_Settings.php
@@ -363,6 +363,10 @@ class Test_Settings extends \WP_UnitTestCase {
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
 		$this->assertTrue( Settings::should_render_html_link_output() );
 
+		// Set the option to check only (checker still runs, so output is rendered).
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_CHECK_ONLY );
+		$this->assertTrue( Settings::should_render_html_link_output() );
+
 		// Set the option to do nothing.
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_DO_NOTHING );
 		$this->assertFalse( Settings::should_render_html_link_output() );

--- a/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
+++ b/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
@@ -56,6 +56,17 @@ class Test_Action_Scheduler_Garbage_Collection extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		// Remove client mocks so they can't leak into later tests under random ordering.
+		remove_all_filters( 'iawmlf_snapshot_client' );
+		remove_all_filters( 'iawmlf_link_checker_client' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Set the snapshot client to return a mocked response.
 	 *
 	 * @param array $response The response to return.

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -776,6 +776,85 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox When the check only option is selected, the HTML link output should still be rendered so links can be checked.
+	 *
+	 * @return void
+	 */
+	public function test_check_only_option_renders_html_link_output(): void {
+		// Set the option to check only.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_CHECK_ONLY );
+
+		$post_id = \WP_UnitTestCase_Base::factory()->post->create();
+
+		$content = 'This is a post with a link to <a href="https://from.post/content">example</a><br>And another link to <a href="https://from.post/content_twice">example</a>';
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+				'post_type'    => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// Render the block.
+		$rendered = do_blocks( $GLOBALS['post']->post_content );
+
+		// Check it still contains the link data script tag.
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * @testdox When the check only option is selected, the front end script should be enqueued with the fixer option passed as check only.
+	 *
+	 * @return void
+	 */
+	public function test_check_only_option_enqueues_script(): void {
+		// Clear the wp-scripts global.
+		wp_scripts()->registered = array();
+
+		// Set the option to check only.
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_CHECK_ONLY );
+
+		$post_id         = \WP_UnitTestCase_Base::factory()->post->create();
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$content = 'This is a post with a link to <a href="https://from.post/content">example</a>';
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+				'post_type'    => 'post',
+			)
+		);
+
+		$handler = new WP_Post_Controller();
+		$handler->on_save_post_process_post_links( $post_id, get_post( $post_id ), true );
+
+		// Enqueue the script.
+		$handler->enqueue_frontend_script();
+		do_action( 'wp_enqueue_scripts' );
+
+		// The script should be enqueued so links can be checked.
+		$this->assertTrue( wp_script_is( 'iawm-link-fixer-front-link-checker' ) );
+
+		// The localized fixer option should be check only.
+		$localized_data = wp_scripts()->get_data( 'iawm-link-fixer-front-link-checker', 'data' );
+
+		unset( $GLOBALS['post'] );
+
+		$matches = array();
+		preg_match( '/\{.*\}/', $localized_data, $matches );
+		$data = json_decode( $matches[0], true );
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'fixerOption', $data );
+		$this->assertEquals( Settings::FIXER_OPTION_CHECK_ONLY, $data['fixerOption'] );
+	}
+
+	/**
 	 * @testdox A post in the auto archiver excluded posts list should not be added to the wayback machine.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary
Adds a third **Fixer Option** — "Check broken links but do not redirect them"
(`FIXER_OPTION_CHECK_ONLY`). In this mode the front-end checker still runs and
records each link's status server-side, but it never rewrites the href or flags
the link — visitor-facing output is untouched. Also relabels the do-nothing
option to "Do not auto check links" (it was ambiguous next to the new mode).

## Changes
- **Settings:** new `FIXER_OPTION_CHECK_ONLY`; `should_render_html_link_output()`
  now true for check-only so the checker still enqueues and records results.
- **Front checker JS:** the href swap is gated to `replace_link` only.
- **Settings page:** third dropdown option + relabel of do-nothing.
- **README:** Fixer Option docs updated for all three modes.

## Testing
- `composer test:php` — 355 tests / 912 assertions pass (incl. 2 new check-only tests).
- `npm run test:e2e` — all specs pass, including a new `fixer-mode.spec.js` that
  drives all three modes in a real browser and asserts check-only records the
  check but leaves the href/class untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
