### PR TITLE
Manual, tag-driven wp.org deploy + ship root index.php

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -19,6 +19,9 @@ tests
 assets/css/src
 assets/js/src
 _docs
+.distignore
+README.md
+SECURITY.md
 # Agent context (development-only, do not deploy)
 AGENTS.md
 CLAUDE.md

--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -1,26 +1,18 @@
-name: Deploy to WordPress.org Dry Run
+name: Push Deploy from a Released Version (Dry Run)
 
-# Identical to push-deploy.yml but with dry-run enabled, so the SVN payload is
-# assembled and printed without ever running `svn commit`.
+# Same steps as push-deploy.yml with dry-run enabled. deploy.sh does everything
+# except `svn commit`, so you get the real `svn status` diff against live wp.org
+# trunk - additions, deletions and the tag copy - before anything is written.
 #
-# The resulting zip is attached to the GitHub release so you can inspect exactly
-# what would have shipped.
+# Nothing is published from this workflow. It does not touch the GitHub release.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Tag to deploy, e.g. 1.4.3 (must already exist and match the Stable tag in readme.txt)'
+        description: 'Tag to deploy, e.g. 1.4.3 (must have a release asset and match the Stable tag in readme.txt)'
         required: true
         type: string
-      source:
-        description: 'build = rebuild from the tag | release-asset = use the zip attached to the GitHub release'
-        required: true
-        default: build
-        type: choice
-        options:
-          - build
-          - release-asset
 
 jobs:
   deploy:
@@ -31,61 +23,44 @@ jobs:
         with:
           ref: refs/tags/${{ inputs.version }}
 
-      # Kept in the dry run too, so the guard itself gets exercised before a
-      # real deploy relies on it.
-      - name: Verify Stable tag matches the version being deployed
+      # Kept identical to push-deploy.yml so the dry run exercises the same
+      # guards the real deploy relies on.
+      - name: Download and verify release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          ASSET: internet-archive-wayback-machine-link-fixer.zip
         run: |
-          STABLE_TAG=$(sed -n 's/^Stable tag:[[:space:]]*//p' readme.txt | head -n1 | tr -d '[:space:]')
-          echo "readme.txt Stable tag: $STABLE_TAG"
-          echo "Deploying version:     ${{ inputs.version }}"
-          if [ "$STABLE_TAG" != "${{ inputs.version }}" ]; then
-            echo "::error::Stable tag '$STABLE_TAG' does not match '${{ inputs.version }}'. Refusing to deploy."
+          # RCs, betas and anything else suffixed must never reach SVN.
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "::error::'$VERSION' is not a stable release version. Refusing to deploy."
             exit 1
           fi
 
-      - name: Set up PHP
-        if: inputs.source == 'build'
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          tools: composer
+          gh release download "$VERSION" --pattern "$ASSET" --output plugin.zip --clobber
+          unzip -q plugin.zip -d svn-build
 
-      # Install DEV Deps, build i18n files
-      - name: Run i18n Build
-        if: inputs.source == 'build'
-        run: |
-          composer install --ignore-platform-reqs --no-interaction
-          composer internationalize
+          if [ ! -f "svn-build/internet-archive-wayback-machine-link-fixer.php" ]; then
+            echo "::error::No plugin bootstrap at the root of $ASSET. Refusing to deploy."
+            ls -A svn-build
+            exit 1
+          fi
 
-      # Install PROD Deps
-      - name: Install Composer Dependencies
-        if: inputs.source == 'build'
-        run: composer install --no-dev
+          ZIP_STABLE=$(sed -n 's/^Stable tag:[[:space:]]*//p' svn-build/readme.txt | head -n1 | tr -d '[:space:]')
+          echo "Stable tag in asset: $ZIP_STABLE"
+          echo "Deploying version:   $VERSION"
+          if [ "$ZIP_STABLE" != "$VERSION" ]; then
+            echo "::error::Stable tag '$ZIP_STABLE' does not match '$VERSION'. Refusing to deploy."
+            exit 1
+          fi
 
-      # Install Node Modules and Build Assets
-      - name: Install Node Modules and Build Assets
-        if: inputs.source == 'build'
-        run: |
-          npm install
-          npm run build
-
-      # Unpack the already-published zip instead of rebuilding.
-      - name: Download release asset
-        if: inputs.source == 'release-asset'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p svn-build
-          gh release download "${{ inputs.version }}" --pattern '*.zip' --dir .
-          unzip -q ./*.zip -d svn-build
-          echo "Unpacked release asset:"
+          echo "Verified payload:"
           ls -A svn-build
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         with:
           dry-run: true
-          generate-zip: true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
@@ -94,13 +69,6 @@ jobs:
           # a dispatch from a branch would produce a tag like
           # "tags/refs/heads/my-branch".
           VERSION: ${{ inputs.version }}
-          # Only set for release-asset; empty makes deploy.sh use .distignore.
-          BUILD_DIR: ${{ inputs.source == 'release-asset' && 'svn-build' || '' }}
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.version }}
-          files: internet-archive-wayback-machine-link-fixer.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ships the verified zip as-is. Without this deploy.sh would filter
+          # the checkout through .distignore instead.
+          BUILD_DIR: svn-build

--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -1,4 +1,4 @@
-name: Push Deploy from a Released Version (Dry Run)
+name: Preview Release Deploy (no changes)
 
 # Same steps as push-deploy.yml with dry-run enabled. deploy.sh does everything
 # except `svn commit`, so you get the real `svn status` diff against live wp.org

--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -1,30 +1,85 @@
 name: Deploy to WordPress.org Dry Run
 
+# Identical to push-deploy.yml but with dry-run enabled, so the SVN payload is
+# assembled and printed without ever running `svn commit`.
+#
+# The resulting zip is attached to the GitHub release so you can inspect exactly
+# what would have shipped.
+
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to deploy, e.g. 1.4.3 (must already exist and match the Stable tag in readme.txt)'
+        required: true
+        type: string
+      source:
+        description: 'build = rebuild from the tag | release-asset = use the zip attached to the GitHub release'
+        required: true
+        default: build
+        type: choice
+        options:
+          - build
+          - release-asset
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout tag
         uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.version }}
+
+      # Kept in the dry run too, so the guard itself gets exercised before a
+      # real deploy relies on it.
+      - name: Verify Stable tag matches the version being deployed
+        run: |
+          STABLE_TAG=$(sed -n 's/^Stable tag:[[:space:]]*//p' readme.txt | head -n1 | tr -d '[:space:]')
+          echo "readme.txt Stable tag: $STABLE_TAG"
+          echo "Deploying version:     ${{ inputs.version }}"
+          if [ "$STABLE_TAG" != "${{ inputs.version }}" ]; then
+            echo "::error::Stable tag '$STABLE_TAG' does not match '${{ inputs.version }}'. Refusing to deploy."
+            exit 1
+          fi
+
+      - name: Set up PHP
+        if: inputs.source == 'build'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer
 
       # Install DEV Deps, build i18n files
       - name: Run i18n Build
+        if: inputs.source == 'build'
         run: |
           composer install --ignore-platform-reqs --no-interaction
           composer internationalize
 
       # Install PROD Deps
       - name: Install Composer Dependencies
+        if: inputs.source == 'build'
         run: composer install --no-dev
 
       # Install Node Modules and Build Assets
       - name: Install Node Modules and Build Assets
+        if: inputs.source == 'build'
         run: |
           npm install
           npm run build
+
+      # Unpack the already-published zip instead of rebuilding.
+      - name: Download release asset
+        if: inputs.source == 'release-asset'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p svn-build
+          gh release download "${{ inputs.version }}" --pattern '*.zip' --dir .
+          unzip -q ./*.zip -d svn-build
+          echo "Unpacked release asset:"
+          ls -A svn-build
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
@@ -35,10 +90,17 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: internet-archive-wayback-machine-link-fixer
+          # Set explicitly. Left unset, deploy.sh derives it from GITHUB_REF and
+          # a dispatch from a branch would produce a tag like
+          # "tags/refs/heads/my-branch".
+          VERSION: ${{ inputs.version }}
+          # Only set for release-asset; empty makes deploy.sh use .distignore.
+          BUILD_DIR: ${{ inputs.source == 'release-asset' && 'svn-build' || '' }}
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          files: SVN-${{ github.event.repository.name }}.zip
+          tag_name: ${{ inputs.version }}
+          files: internet-archive-wayback-machine-link-fixer.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -2,24 +2,20 @@ name: Deploy to WordPress.org
 
 # Manual only. Nothing here runs on push, tag or release.
 #
-# You name the tag to ship, and choose whether the files are rebuilt from that
-# tag or taken from the zip already attached to its GitHub release.
+# Deploys the zip already attached to a tag's GitHub release - the artifact
+# release.yml built and you tested. Nothing is rebuilt here, so the bytes that
+# reach wp.org are the bytes you signed off.
+#
+# Note: deploy.sh exits 0 without committing if tags/<version> already exists in
+# SVN. Re-dispatching a published version to correct trunk is a silent no-op.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Tag to deploy, e.g. 1.4.3 (must already exist and match the Stable tag in readme.txt)'
+        description: 'Tag to deploy, e.g. 1.4.3 (must have a release asset and match the Stable tag in readme.txt)'
         required: true
         type: string
-      source:
-        description: 'build = rebuild from the tag | release-asset = use the zip attached to the GitHub release'
-        required: true
-        default: build
-        type: choice
-        options:
-          - build
-          - release-asset
 
 jobs:
   deploy:
@@ -30,60 +26,43 @@ jobs:
         with:
           ref: refs/tags/${{ inputs.version }}
 
-      # wp.org serves whatever the Stable tag in trunk points at, so a mismatch
-      # here is how an RC reaches every user. Fail before anything touches SVN.
-      - name: Verify Stable tag matches the version being deployed
+      # This tree is rsynced into SVN trunk with --delete, so it is checked
+      # before use. wp.org serves whatever the Stable tag in trunk points at,
+      # which is how an RC would reach every user.
+      - name: Download and verify release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          ASSET: internet-archive-wayback-machine-link-fixer.zip
         run: |
-          STABLE_TAG=$(sed -n 's/^Stable tag:[[:space:]]*//p' readme.txt | head -n1 | tr -d '[:space:]')
-          echo "readme.txt Stable tag: $STABLE_TAG"
-          echo "Deploying version:     ${{ inputs.version }}"
-          if [ "$STABLE_TAG" != "${{ inputs.version }}" ]; then
-            echo "::error::Stable tag '$STABLE_TAG' does not match '${{ inputs.version }}'. Refusing to deploy."
+          # RCs, betas and anything else suffixed must never reach SVN.
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "::error::'$VERSION' is not a stable release version. Refusing to deploy."
             exit 1
           fi
 
-      - name: Set up PHP
-        if: inputs.source == 'build'
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          tools: composer
+          gh release download "$VERSION" --pattern "$ASSET" --output plugin.zip --clobber
+          unzip -q plugin.zip -d svn-build
 
-      # Install DEV Deps, build i18n files
-      - name: Run i18n Build
-        if: inputs.source == 'build'
-        run: |
-          composer install --ignore-platform-reqs --no-interaction
-          composer internationalize
+          if [ ! -f "svn-build/internet-archive-wayback-machine-link-fixer.php" ]; then
+            echo "::error::No plugin bootstrap at the root of $ASSET. Refusing to deploy."
+            ls -A svn-build
+            exit 1
+          fi
 
-      # Install PROD Deps
-      - name: Install Composer Dependencies
-        if: inputs.source == 'build'
-        run: composer install --no-dev
+          ZIP_STABLE=$(sed -n 's/^Stable tag:[[:space:]]*//p' svn-build/readme.txt | head -n1 | tr -d '[:space:]')
+          echo "Stable tag in asset: $ZIP_STABLE"
+          echo "Deploying version:   $VERSION"
+          if [ "$ZIP_STABLE" != "$VERSION" ]; then
+            echo "::error::Stable tag '$ZIP_STABLE' does not match '$VERSION'. Refusing to deploy."
+            exit 1
+          fi
 
-      # Install Node Modules and Build Assets
-      - name: Install Node Modules and Build Assets
-        if: inputs.source == 'build'
-        run: |
-          npm install
-          npm run build
-
-      # Unpack the already-published zip instead of rebuilding.
-      - name: Download release asset
-        if: inputs.source == 'release-asset'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p svn-build
-          gh release download "${{ inputs.version }}" --pattern '*.zip' --dir .
-          unzip -q ./*.zip -d svn-build
-          echo "Unpacked release asset:"
+          echo "Verified payload:"
           ls -A svn-build
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
-        with:
-          generate-zip: true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
@@ -92,5 +71,6 @@ jobs:
           # a dispatch from a branch would produce a tag like
           # "tags/refs/heads/my-branch".
           VERSION: ${{ inputs.version }}
-          # Only set for release-asset; empty makes deploy.sh use .distignore.
-          BUILD_DIR: ${{ inputs.source == 'release-asset' && 'svn-build' || '' }}
+          # Ships the verified zip as-is. Without this deploy.sh would filter
+          # the checkout through .distignore instead.
+          BUILD_DIR: svn-build

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to WordPress.org
+name: Publish Release to WordPress.org
 
 # Manual only. Nothing here runs on push, tag or release.
 #

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,30 +1,84 @@
 name: Deploy to WordPress.org
 
+# Manual only. Nothing here runs on push, tag or release.
+#
+# You name the tag to ship, and choose whether the files are rebuilt from that
+# tag or taken from the zip already attached to its GitHub release.
+
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to deploy, e.g. 1.4.3 (must already exist and match the Stable tag in readme.txt)'
+        required: true
+        type: string
+      source:
+        description: 'build = rebuild from the tag | release-asset = use the zip attached to the GitHub release'
+        required: true
+        default: build
+        type: choice
+        options:
+          - build
+          - release-asset
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout tag
         uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.version }}
+
+      # wp.org serves whatever the Stable tag in trunk points at, so a mismatch
+      # here is how an RC reaches every user. Fail before anything touches SVN.
+      - name: Verify Stable tag matches the version being deployed
+        run: |
+          STABLE_TAG=$(sed -n 's/^Stable tag:[[:space:]]*//p' readme.txt | head -n1 | tr -d '[:space:]')
+          echo "readme.txt Stable tag: $STABLE_TAG"
+          echo "Deploying version:     ${{ inputs.version }}"
+          if [ "$STABLE_TAG" != "${{ inputs.version }}" ]; then
+            echo "::error::Stable tag '$STABLE_TAG' does not match '${{ inputs.version }}'. Refusing to deploy."
+            exit 1
+          fi
+
+      - name: Set up PHP
+        if: inputs.source == 'build'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer
 
       # Install DEV Deps, build i18n files
       - name: Run i18n Build
+        if: inputs.source == 'build'
         run: |
           composer install --ignore-platform-reqs --no-interaction
           composer internationalize
 
       # Install PROD Deps
       - name: Install Composer Dependencies
+        if: inputs.source == 'build'
         run: composer install --no-dev
 
       # Install Node Modules and Build Assets
       - name: Install Node Modules and Build Assets
+        if: inputs.source == 'build'
         run: |
           npm install
           npm run build
+
+      # Unpack the already-published zip instead of rebuilding.
+      - name: Download release asset
+        if: inputs.source == 'release-asset'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p svn-build
+          gh release download "${{ inputs.version }}" --pattern '*.zip' --dir .
+          unzip -q ./*.zip -d svn-build
+          echo "Unpacked release asset:"
+          ls -A svn-build
 
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
@@ -34,3 +88,9 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: internet-archive-wayback-machine-link-fixer
+          # Set explicitly. Left unset, deploy.sh derives it from GITHUB_REF and
+          # a dispatch from a branch would produce a tag like
+          # "tags/refs/heads/my-branch".
+          VERSION: ${{ inputs.version }}
+          # Only set for release-asset; empty makes deploy.sh use .distignore.
+          BUILD_DIR: ${{ inputs.source == 'release-asset' && 'svn-build' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
             ".github/*" \
             ".gitignore" \
             ".distignore" \
-            "index.php" \
             "node_modules/*" \
             "models/*" \
             "package.json" \


### PR DESCRIPTION
## What

Makes deploying to the WordPress.org SVN repository an explicit, manual, tag-driven process, and fixes one defect in the release zip.

Nothing here deploys automatically. Both workflows remain `workflow_dispatch` only.

## Why

`deploy.sh` in `10up/action-wordpress-plugin-deploy` derives the SVN tag from the git ref:

```bash
VERSION="${GITHUB_REF#refs/tags/}"
```

Our workflows are `workflow_dispatch`, and the ref picker lets you select a branch. Dispatching from a branch leaves `VERSION` as the literal `refs/heads/release/1.4.3`, which becomes `svn cp trunk "tags/refs/heads/release/1.4.3"` and commits trunk with a matching message.

Separately, wp.org serves whatever `Stable tag:` in the readme.txt in SVN trunk points at. Deploying a commit whose readme still says `1.4.3-RC1` would put an RC in front of every user. Nothing guarded that.

## Changes

**`push-deploy.yml` / `push-deploy-dryrun.yml`**

- `version` input — the tag to deploy. Checked out explicitly as `refs/tags/<version>`.
- `VERSION` passed to the action as env, so the ref is never used to derive it.
- Hard fail before SVN is touched if `readme.txt`'s `Stable tag` does not match the version being deployed.
- `source` input:
  - `build` — rebuild from the tag (current behaviour)
  - `release-asset` — download the zip attached to that tag's GitHub release and deploy those exact bytes via `BUILD_DIR`

**`release.yml`**

- Stop excluding root `index.php` from the zip. `assets/index.php` and `src/index.php` were already shipping while the plugin root was not. Verified by unpacking the published 1.4.3 asset.

## Verification done

- Read `deploy.sh` and `action.yml` from `10up/action-wordpress-plugin-deploy` to confirm `VERSION`, `BUILD_DIR`, `ASSETS_DIR` are env-driven and that `generate-zip` / `dry-run` are the only `with:` inputs.
- Confirmed `.distignore` is only used when `BUILD_DIR` is unset; with a build dir the action rsyncs that directory as-is.
- Downloaded and unpacked the published `1.4.3` release asset (264 entries): `vendor/` contains only `woocommerce/action-scheduler` plus autoload; no dev packages, tests, coverage or node_modules; asset `src` directories correctly stripped; root `index.php` confirmed missing.

## Not verified

- The workflows have not been executed. The `source: release-asset` path and the `BUILD_DIR` expression are unproven until a dry run is dispatched.
- Whether `dependencies/` (php-scoper output) should be in the release zip. It is currently absent.

## Testing instructions

1. Run **Deploy to WordPress.org Dry Run** against tag `1.4.3` with `source: release-asset`.
2. Confirm the Stable tag check passes and `svn status` shows the expected diff, including any deletions.
3. Re-run with a deliberately wrong `version` and confirm it fails before reaching SVN.
