### PR TITLE
Audit 1.4.3: function signatures & broken contracts (#358)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,7 +1176,7 @@ add_filter( 'iawmlf_before_saving_link_details', function( Link $link ): Link {
 
 #### `iawmlf_link_details_updated_redirect_param`
 
-This filter controls the "updated" flag used in the redirect after saving link details. Returning a falsy value will suppress the default success notice on the link details page.
+This filter controls the "updated" flag used in the redirect after saving link details. Returning a falsy value will suppress the default success notice on the link details page. The recognised boolean keywords (`'false'`, `'no'`, `'off'`, `'0'`) also suppress the notice; any other value is cast to boolean.
 
 ```php
 add_filter( 'iawmlf_link_details_updated_redirect_param', function( string $updated, Link $link ): string {

--- a/src/Action/Link_Check_Action.php
+++ b/src/Action/Link_Check_Action.php
@@ -119,7 +119,7 @@ class Link_Check_Action {
 
 		// If the link is set to be excluded, set as valid.
 		if ( $link->is_excluded() ) {
-			$link->set_valid( true );
+			$link->set_valid();
 			$valid = true;
 		}
 

--- a/src/Action/Link_Check_Action.php
+++ b/src/Action/Link_Check_Action.php
@@ -115,7 +115,7 @@ class Link_Check_Action {
 		$link->add_check( $status, gmdate( 'Y-m-d H:i:s' ) );
 
 		// Validate the link.
-		$valid = $link->is_valid();
+		$valid = $link->assess_validity();
 
 		// If the link is set to be excluded, set as valid.
 		if ( $link->is_excluded() ) {

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -113,7 +113,7 @@ class Dashboard_Notifications {
 		if ( false !== $cached ) {
 			return (int) $cached;
 		}
-		$count = ( new Link_Repository() )->count_links( PHP_INT_MAX, 1, array(), array(), array(), 'any' );
+		$count = ( new Link_Repository() )->count_links( PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC );
 		set_transient( 'iawmlf_link_count', $count, 15 * MINUTE_IN_SECONDS );
 		return $count;
 	}

--- a/src/Dashboard/Dashboard_Statistics.php
+++ b/src/Dashboard/Dashboard_Statistics.php
@@ -128,13 +128,13 @@ class Dashboard_Statistics {
 
 		// Get all the link stats.
 		$all_links          = $links->count_links( \PHP_INT_MAX, 1 );
-		$all_broken         = $links->count_links( \PHP_INT_MAX, 1, array( Link_Repository::LINK_STATUS_BROKEN ), array(), array(), 'fallback', null, null, false );
+		$all_broken         = $links->count_links( \PHP_INT_MAX, 1, array( Link_Repository::LINK_STATUS_BROKEN ), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, false );
 		$has_archive_link   = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array( Link_Repository::LINK_HAS_ARCHIVE ) );
-		$redirected_broken_ = $links->count_links( \PHP_INT_MAX, 1, array( Link_Repository::LINK_STATUS_BROKEN ), array(), array( Link_Repository::LINK_HAS_ARCHIVE ), 'fallback', null, null, false );
-		$not_checked        = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), 'fallback', null, null, null, null, false );
-		$process_new        = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), 'fallback', null, null, null, array( Link::PROCESS_NEW ) );
-		$process_done_      = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), 'fallback', null, null, null, array( Link::PROCESS_DONE ) );
-		$process_pending    = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), 'fallback', null, null, null, array( Link::PROCESS_PENDING ) );
+		$redirected_broken_ = $links->count_links( \PHP_INT_MAX, 1, array( Link_Repository::LINK_STATUS_BROKEN ), array(), array( Link_Repository::LINK_HAS_ARCHIVE ), Link_Repository::ORDER_ID_DESC, null, null, false );
+		$not_checked        = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, null, false );
+		$process_new        = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_NEW ) );
+		$process_done_      = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_DONE ) );
+		$process_pending    = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_PENDING ) );
 		$last_checks        = $links->query_links( 10, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, null, null, null, null, true );
 
 		// Extract the details from last checks.

--- a/src/Dashboard/Dashboard_Statistics.php
+++ b/src/Dashboard/Dashboard_Statistics.php
@@ -29,13 +29,16 @@ class Dashboard_Statistics {
 	 *
 	 * @return array{
 	 *     total_links: int<0, max>,
-	 *     broken_links: int<0, max>,
+	 *     all_broken_links: int<0, max>,
+	 *     broken_and_redirected_links: int<0, max>,
+	 *     broken_not_redirected_links: int<0, max>,
 	 *     links_with_archive: int<0, max>,
 	 *     links_without_archive: int<0, max>,
 	 *     not_checked: int<0, max>,
 	 *     process_done: int<0, max>,
 	 *     process_new: int<0, max>,
 	 *     process_pending: int<0, max>,
+	 *     last_checks: array,
 	 * }
 	 */
 	public static function get_link_statistics(): array {
@@ -44,13 +47,12 @@ class Dashboard_Statistics {
 
 		// If we dont have an array or invalid data, compile fresh.
 		if ( false === $from_cache || ! is_array( $from_cache ) ) {
-			$stats = self::compile_link_statistics();
+			$stats = self::normalize_link_statistics( self::compile_link_statistics() );
 		} else {
 			// Validate and normalize cached data.
 			$stats = self::normalize_link_statistics( $from_cache );
 			if ( null === $stats ) {
-				$stats = self::compile_link_statistics();
-				$stats = self::normalize_link_statistics( $stats );
+				$stats = self::normalize_link_statistics( self::compile_link_statistics() );
 			} else {
 				return $stats;
 			}
@@ -93,7 +95,6 @@ class Dashboard_Statistics {
 		// Only return the required keys.
 		$stats = array(
 			'total_links'                 => \absint( $stats['total_links'] ),
-			'broken_links'                => \absint( $stats['all_broken_links'] ),
 			'all_broken_links'            => \absint( $stats['all_broken_links'] ),
 			'links_with_archive'          => \absint( $stats['links_with_archive'] ),
 			'links_without_archive'       => \absint( $stats['links_without_archive'] ),
@@ -114,13 +115,16 @@ class Dashboard_Statistics {
 	 *
 	 * @return array{
 	 *     total_links: int<0, max>,
-	 *     broken_links: int<0, max>,
+	 *     all_broken_links: int<0, max>,
+	 *     broken_and_redirected_links: int<0, max>,
+	 *     broken_not_redirected_links: int<0, max>,
 	 *     links_with_archive: int<0, max>,
 	 *     links_without_archive: int<0, max>,
 	 *     not_checked: int<0, max>,
 	 *     process_done: int<0, max>,
 	 *     process_new: int<0, max>,
 	 *     process_pending: int<0, max>,
+	 *     last_checks: array,
 	 * }
 	 */
 	private static function compile_link_statistics(): array {

--- a/src/Dashboard/Dashboard_Statistics.php
+++ b/src/Dashboard/Dashboard_Statistics.php
@@ -139,7 +139,7 @@ class Dashboard_Statistics {
 		$process_new        = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_NEW ) );
 		$process_done_      = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_DONE ) );
 		$process_pending    = $links->count_links( \PHP_INT_MAX, 1, array(), array(), array(), Link_Repository::ORDER_ID_DESC, null, null, null, array( Link::PROCESS_PENDING ) );
-		$last_checks        = $links->query_links( 10, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, null, null, null, null, true );
+		$last_checks        = $links->query_links( 10, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, null, null, null, null );
 
 		// Extract the details from last checks.
 		$last_checks = array_map(

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -445,8 +445,9 @@ class Report_Page {
 		$this->link_repository->upsert( $link );
 
 		// Allow 3rd parties to hook in and modify the redirect param after saving, for showing custom notices.
-		// filter_var so 'false', 'no' and '0' read as false, not truthy strings.
-		$has_updated = filter_var( apply_filters( 'iawmlf_link_details_updated_redirect_param', '1', $link ), FILTER_VALIDATE_BOOLEAN );
+		// Recognised boolean keywords ('false', 'no', '0') read as false; anything else keeps the documented (bool) cast.
+		$raw_updated = apply_filters( 'iawmlf_link_details_updated_redirect_param', '1', $link );
+		$has_updated = filter_var( $raw_updated, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ?? (bool) $raw_updated;
 
 		// Redirect back to the link details page, with a success notice if updated.
 		$redirect_args = array(

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -439,7 +439,9 @@ class Report_Page {
 		}
 
 		// Allow 3rd parties to hook in and modify the link before saving.
-		$link = apply_filters( 'iawmlf_before_saving_link_details', $link );
+		// A malformed callback (not returning the link) degrades to the unfiltered link.
+		$filtered = apply_filters( 'iawmlf_before_saving_link_details', $link );
+		$link     = $filtered instanceof Link ? $filtered : $link;
 
 		// Save the link.
 		$this->link_repository->upsert( $link );

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -445,7 +445,8 @@ class Report_Page {
 		$this->link_repository->upsert( $link );
 
 		// Allow 3rd parties to hook in and modify the redirect param after saving, for showing custom notices.
-		$has_updated = (bool) apply_filters( 'iawmlf_link_details_updated_redirect_param', '1', $link );
+		// filter_var so 'false', 'no' and '0' read as false, not truthy strings.
+		$has_updated = filter_var( apply_filters( 'iawmlf_link_details_updated_redirect_param', '1', $link ), FILTER_VALIDATE_BOOLEAN );
 
 		// Redirect back to the link details page, with a success notice if updated.
 		$redirect_args = array(

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -432,7 +432,6 @@ class Setup_Wizard {
 
 		$view_data = array(
 			'step_data'  => $step_data,
-			'settings'   => new Settings(),
 			'post_types' => $this->get_public_post_types(),
 			'header'     => $this->get_page_header( $step_data ),
 			'footer'     => $this->get_page_footer( $step_data ),

--- a/src/Event/Check_Snapshot_Status_Event.php
+++ b/src/Event/Check_Snapshot_Status_Event.php
@@ -51,7 +51,7 @@ class Check_Snapshot_Status_Event {
 	 * Create instance of the class.
 	 */
 	public function __construct() {
-		$this->attempts = apply_filters( 'iawmlf_check_snapshot_status_attempts', 3 );
+		$this->attempts = absint( apply_filters( 'iawmlf_check_snapshot_status_attempts', 3 ) );
 	}
 
 	/**

--- a/src/Event/Check_Validator_Status.php
+++ b/src/Event/Check_Validator_Status.php
@@ -168,7 +168,7 @@ class Check_Validator_Status {
 
 			// If the status has a 'status_ext' key, set the link as excluded.
 			if ( isset( $status['status_ext'] ) && 'error:no-access' === $status['status_ext'] ) {
-				$link = $link->set_excluded()->set_broken( false );
+				$link = $link->set_excluded()->set_valid();
 			}
 
 			$this->link_repository->upsert( $link );

--- a/src/Event/Process_Local_Post_Event.php
+++ b/src/Event/Process_Local_Post_Event.php
@@ -93,7 +93,7 @@ class Process_Local_Post_Event {
 
 		$this->setup();
 		// If Wayback Link Fixer is offline, add the event to the queue delayed.
-		if ( ! $this->wayback_machine->is_online()['snapshot'] ) {
+		if ( ! $this->wayback_machine->is_online() ) {
 			self::add_to_queue_with_delay( $post_id );
 			throw new Exception( esc_html( 'Service is offline, trying again in 1 hour.' ) );
 		}

--- a/src/Event/Update_Archive_URL_Event.php
+++ b/src/Event/Update_Archive_URL_Event.php
@@ -64,7 +64,7 @@ class Update_Archive_URL_Event {
 	 * @return void
 	 */
 	public function setup(): void {
-		$this->max_attempts = apply_filters( 'iawmlf_update_archive_url_attempts', $this->max_attempts );
+		$this->max_attempts = absint( apply_filters( 'iawmlf_update_archive_url_attempts', $this->max_attempts ) );
 
 		$this->wayback_machine = new Wayback_Machine_Service();
 		$this->repository      = new Link_Repository();

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -347,11 +347,20 @@ class Link implements \JsonSerializable {
 	}
 
 	/**
-	 * Checks if a link is valid.
+	 * Checks if a link is valid, based on its stored broken flag.
 	 *
 	 * @return boolean
 	 */
 	public function is_valid(): bool {
+		return ! $this->is_broken;
+	}
+
+	/**
+	 * Assess the links validity from its recent checks, setting the broken flag.
+	 *
+	 * @return boolean
+	 */
+	public function assess_validity(): bool {
 		$failed_count = Settings::get_failed_count();
 
 		// Get the last checks based on the failed count.

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -128,7 +128,14 @@ class Link_Repository {
 	public function upsert( Link $link ): Link {
 		// If the link has an id, update it.
 		if ( null !== $link->get_id() ) {
-			$link = $this->update( $link );
+			$updated = $this->update( $link );
+
+			// The row can vanish between the UPDATE and the re-fetch (concurrent delete).
+			if ( null === $updated ) {
+				throw new Exception( esc_html( 'Failed to update link, link no longer exists.' ) );
+			}
+
+			$link = $updated;
 		} else {
 			$link = $this->insert( $link );
 		}
@@ -201,11 +208,11 @@ class Link_Repository {
 	 *
 	 * @param Link $link The link to update.
 	 *
-	 * @return Link
+	 * @return Link|null Null if the row no longer exists after the update.
 	 *
 	 * @throws Exception If the link cannot be updated.
 	 */
-	private function update( Link $link ): Link {
+	private function update( Link $link ): ?Link {
 		// Extract the values.
 		$id              = $link->get_id();
 		$href            = $link->get_href();
@@ -253,7 +260,7 @@ class Link_Repository {
 
 		// If we dont have a valid row id, throw an exception.
 		if ( false === $result ) {
-			throw new Exception( 'Failed to update link.' );
+			throw new Exception( esc_html( 'Failed to update link.' ) );
 		}
 
 		return $this->find_by_id( $id );

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -757,7 +757,7 @@ class Link_Repository {
 	 *
 	 * @param Link $link The link to remove.
 	 *
-	 * @return boolean True on success, false on failure.
+	 * @return boolean True if a row was deleted; false if the link has no id, no row matched, or the delete failed.
 	 */
 	public function delete_link( Link $link ): bool {
 		// If the link has no id, return false.

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -902,13 +902,12 @@ class Report_Table extends \WP_List_Table {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param integer $limit  The limit of links to return.
-	 * @param integer $page   The page of links to return.
-	 * @param array   $status The status of the links to return.
+	 * @param integer $limit The limit of links to return.
+	 * @param integer $page  The page of links to return.
 	 *
 	 * @return array<Link>
 	 */
-	private function get_links( int $limit = 10, int $page = 1, array $status = array() ): array {
+	private function get_links( int $limit = 10, int $page = 1 ): array {
 		return $this->links->query_links(
 			$limit,
 			$page,
@@ -925,13 +924,12 @@ class Report_Table extends \WP_List_Table {
 	/**
 	 * Count links based on the query being used on this table.
 	 *
-	 * @param integer $limit  The limit of links to return.
-	 * @param integer $page   The page of links to return.
-	 * @param array   $status The status of the links to return.
+	 * @param integer $limit The limit of links to return.
+	 * @param integer $page  The page of links to return.
 	 *
 	 * @return integer
 	 */
-	private function count_links( int $limit = 10, int $page = 1, array $status = array() ): int {
+	private function count_links( int $limit = 10, int $page = 1 ): int {
 		return $this->links->count_links(
 			$limit,
 			$page,
@@ -1063,8 +1061,7 @@ class Report_Table extends \WP_List_Table {
 		// Get the reports.
 		$this->items = $this->get_links(
 			$this->get_links_per_page(),
-			$this->get_pagenum(),
-			array( $this->get_status_from_url() )
+			$this->get_pagenum()
 		);
 	}
 

--- a/src/Rest/Link_Check_Rest.php
+++ b/src/Rest/Link_Check_Rest.php
@@ -181,7 +181,7 @@ class Link_Check_Rest {
 		$link->add_check( $status, gmdate( 'Y-m-d H:i:s' ) );
 
 		// Validate the link.
-		$valid = $link->is_valid();
+		$valid = $link->assess_validity();
 
 		// Based on the link status, either set the link as broken or not.
 		if ( ! $valid ) {

--- a/src/Rest/Link_Check_Rest.php
+++ b/src/Rest/Link_Check_Rest.php
@@ -3,7 +3,7 @@
 /**
  * REST API endpoint for checking link status.
  *
- * @since   2.0.0
+ * @since   1.4.0
  */
 
 declare( strict_types = 1 );
@@ -30,7 +30,7 @@ class Link_Check_Rest {
 	/**
 	 * The REST API namespace.
 	 */
-	public const NAMESPACE = 'iawmlf/v1';
+	public const API_NAMESPACE = 'iawmlf/v1';
 
 	/**
 	 * The REST API route.
@@ -58,7 +58,7 @@ class Link_Check_Rest {
 	 */
 	public function register_routes(): void {
 		register_rest_route(
-			self::NAMESPACE,
+			self::API_NAMESPACE,
 			self::ROUTE,
 			array(
 				'methods'             => 'POST',

--- a/src/Rest/Link_Check_Rest.php
+++ b/src/Rest/Link_Check_Rest.php
@@ -30,14 +30,7 @@ class Link_Check_Rest {
 	/**
 	 * The REST API namespace.
 	 */
-	public const API_NAMESPACE = 'iawmlf/v1';
-
-	/**
-	 * The REST API namespace.
-	 *
-	 * @deprecated 1.4.4 Use self::API_NAMESPACE instead.
-	 */
-	public const NAMESPACE = self::API_NAMESPACE;
+	public const NAMESPACE = 'iawmlf/v1';
 
 	/**
 	 * The REST API route.
@@ -65,7 +58,7 @@ class Link_Check_Rest {
 	 */
 	public function register_routes(): void {
 		register_rest_route(
-			self::API_NAMESPACE,
+			self::NAMESPACE,
 			self::ROUTE,
 			array(
 				'methods'             => 'POST',

--- a/src/Rest/Link_Check_Rest.php
+++ b/src/Rest/Link_Check_Rest.php
@@ -33,6 +33,13 @@ class Link_Check_Rest {
 	public const API_NAMESPACE = 'iawmlf/v1';
 
 	/**
+	 * The REST API namespace.
+	 *
+	 * @deprecated 1.4.4 Use self::API_NAMESPACE instead.
+	 */
+	public const NAMESPACE = self::API_NAMESPACE;
+
+	/**
 	 * The REST API route.
 	 */
 	public const ROUTE = '/link-check';

--- a/src/Util/Environmental.php
+++ b/src/Util/Environmental.php
@@ -33,6 +33,6 @@ class Environmental {
 			$is_production = true;
 		}
 
-		return apply_filters( 'iawmlf_is_production_environment', $is_production );
+		return (bool) apply_filters( 'iawmlf_is_production_environment', $is_production );
 	}
 }

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -259,7 +259,7 @@ class WP_Post_Controller {
 				'linkCheckNonce'  => wp_create_nonce( 'wp_rest' ),
 				'linkDelayInDays' => Settings::get_link_check_duration(),
 				'fixerOption'     => Settings::get_fixer_option(),
-				'restUrl'         => rest_url( Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE ),
+				'restUrl'         => rest_url( Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE ),
 			)
 		);
 

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -259,7 +259,7 @@ class WP_Post_Controller {
 				'linkCheckNonce'  => wp_create_nonce( 'wp_rest' ),
 				'linkDelayInDays' => Settings::get_link_check_duration(),
 				'fixerOption'     => Settings::get_fixer_option(),
-				'restUrl'         => rest_url( Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE ),
+				'restUrl'         => rest_url( Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE ),
 			)
 		);
 

--- a/src/Wayback_Machine/Exception/Invalid_Response_Exception.php
+++ b/src/Wayback_Machine/Exception/Invalid_Response_Exception.php
@@ -27,7 +27,12 @@ class Invalid_Response_Exception extends Exception {
 	 *
 	 * @return Invalid_Response_Exception
 	 */
-	public static function create( string $message = ' ' ): Invalid_Response_Exception {
-		return new Invalid_Response_Exception( esc_html( __( 'The response is invalid.', 'internet-archive-wayback-machine-link-fixer' ) . $message ) );
+	public static function create( string $message = '' ): Invalid_Response_Exception {
+		return new Invalid_Response_Exception(
+			esc_html(
+				__( 'The response is invalid.', 'internet-archive-wayback-machine-link-fixer' )
+				. ( '' !== $message ? ' ' . $message : '' )
+			)
+		);
 	}
 }

--- a/src/Wayback_Machine/Exception/Service_Offline_Exception.php
+++ b/src/Wayback_Machine/Exception/Service_Offline_Exception.php
@@ -22,16 +22,18 @@ class Service_Offline_Exception extends Exception {
 	/**
 	 * Static creator for the exception.
 	 *
-	 *@param string $message The message to display.
+	 * @param string $message The message to display.
 	 *
 	 * @return Service_Offline_Exception
 	 */
 	public static function create( string $message = '' ): Service_Offline_Exception {
 		return new Service_Offline_Exception(
-			sprintf(
-				// translators: %s is the message.
-				__( 'The service is offline.%s', 'internet-archive-wayback-machine-link-fixer' ),
-				'' !== $message ? esc_html( ' ' . $message ) : ''
+			esc_html(
+				sprintf(
+					// translators: %s is the message.
+					__( 'The service is offline.%s', 'internet-archive-wayback-machine-link-fixer' ),
+					'' !== $message ? ' ' . $message : ''
+				)
 			)
 		);
 	}

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
@@ -50,9 +50,9 @@ class HTTP_Link_Checker_Client implements Link_Checker_Client {
 	public function get_final_url( string $url ): string {
 		$response = $this->get_decoded_response( $this->query_url( $url ) );
 
-		// Return the location if it exists, otherwise return the original url.
-		return isset( $response['location'] )
-		? $response['location'] ?? ''
+		// Return the location if its a usable string, otherwise return the original url.
+		return isset( $response['location'] ) && is_string( $response['location'] )
+		? $response['location']
 		: $url;
 	}
 

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
@@ -50,8 +50,8 @@ class HTTP_Link_Checker_Client implements Link_Checker_Client {
 	public function get_final_url( string $url ): string {
 		$response = $this->get_decoded_response( $this->query_url( $url ) );
 
-		// Return the location if its a usable string, otherwise return the original url.
-		return isset( $response['location'] ) && is_string( $response['location'] )
+		// Return the location if its a non-empty string, otherwise return the original url.
+		return isset( $response['location'] ) && is_string( $response['location'] ) && '' !== $response['location']
 		? $response['location']
 		: $url;
 	}

--- a/src/Wayback_Machine/Link_Checker_Client.php
+++ b/src/Wayback_Machine/Link_Checker_Client.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine;
 
+use Exception;
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/src/Wayback_Machine/Snapshot_Client.php
+++ b/src/Wayback_Machine/Snapshot_Client.php
@@ -10,6 +10,10 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine;
 
+use Exception;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Service_Offline_Exception;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Exceeded_Snapshot_Limit_Exception;
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/src/Wayback_Machine/System_Client.php
+++ b/src/Wayback_Machine/System_Client.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine;
 
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Service_Offline_Exception;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Invalid_Response_Exception;
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/src/Wayback_Machine/Wayback_Machine_Service.php
+++ b/src/Wayback_Machine/Wayback_Machine_Service.php
@@ -160,15 +160,10 @@ class Wayback_Machine_Service {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array{snapshot:boolean, link_checker:boolean}
+	 * @return boolean True only if both services are online.
 	 */
-	public function is_online(): array {
-
-		// Only return true if both services are online.
-		return array(
-			'snapshot'     => $this->snapshot_client->is_online(),
-			'link_checker' => $this->link_checker_client->is_online(),
-		);
+	public function is_online(): bool {
+		return $this->snapshot_client->is_online() && $this->link_checker_client->is_online();
 	}
 
 	/**

--- a/src/Wayback_Machine/Wayback_Machine_Service.php
+++ b/src/Wayback_Machine/Wayback_Machine_Service.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine;
 
 use Throwable;
+use Exception;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Service_Offline_Exception;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Exception\Exceeded_Snapshot_Limit_Exception;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -6,7 +6,6 @@
  * @since 1.3.0
  *
  * @param array  $step_data The step data.
- * @param Settings $settings The settings object.
  * @param array $post_types The post types.
  * @param string $header The header template.
  * @param string $footer The footer template.

--- a/templates/admin/wizard/step-2.php
+++ b/templates/admin/wizard/step-2.php
@@ -6,7 +6,6 @@
  * @since 1.3.0
  *
  * @param array  $step_data The step data.
- * @param Settings $settings The settings object.
  * @param array $post_types The post types.
  * @param string $header The header template.
  * @param string $footer The footer template.

--- a/templates/admin/wizard/step-3.php
+++ b/templates/admin/wizard/step-3.php
@@ -6,7 +6,6 @@
  * @since 1.3.0
  *
  * @param array  $step_data The step data.
- * @param Settings $settings The settings object.
  * @param array $post_types The post types.
  * @param string $header The header template.
  * @param string $footer The footer template.

--- a/tests/Dashboard/Test_Report_Page.php
+++ b/tests/Dashboard/Test_Report_Page.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Tests for the Report Page.
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Report_Page
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Dashboard;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Repository;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Report_Page;
+
+/**
+ * Test_Report_Page
+ *
+ * @group Dashboard
+ * @group Report_Page
+ */
+class Test_Report_Page extends \WP_UnitTestCase {
+
+	private $link_repository;
+
+	/**
+	 * Setup
+	 */
+	public function set_up(): void {
+		$this->link_repository = new Link_Repository();
+		$GLOBALS['wpdb']->query( 'TRUNCATE TABLE ' . Settings::get_link_table_name() );
+
+		parent::set_up();
+	}
+
+	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'iawmlf_link_details_updated_redirect_param' );
+		remove_all_filters( 'wp_redirect' );
+		unset( $_POST['iawmlf_link_details_nonce'], $_POST['iawmlf_link_id'], $_REQUEST['iawmlf_link_details_nonce'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Submit the link details form and capture the redirect location.
+	 *
+	 * @param integer $link_id The link id to submit.
+	 *
+	 * @return string|null The redirect location, null if no redirect fired.
+	 */
+	private function submit_link_details_form( int $link_id ): ?string {
+		$_POST['iawmlf_link_details_nonce']    = wp_create_nonce( 'iawmlf_link_details' );
+		$_POST['iawmlf_link_id']               = (string) $link_id;
+		$_REQUEST['iawmlf_link_details_nonce'] = $_POST['iawmlf_link_details_nonce'];
+
+		$location = null;
+
+		// Capture the redirect and throw before the exit is reached.
+		add_filter(
+			'wp_redirect',
+			function ( $redirect_location ) use ( &$location ) {
+				$location = $redirect_location;
+				throw new \Exception( 'redirect-captured' );
+			}
+		);
+
+		try {
+			( new Report_Page() )->handle_link_details_form();
+		} catch ( \Exception $e ) {
+			$this->assertSame( 'redirect-captured', $e->getMessage() );
+		}
+
+		return $location;
+	}
+
+	/**
+	 * @testdox The recognised falsy keywords ('0', 'false', 'no') from the redirect-param filter should suppress the updated flag.
+	 *
+	 * @dataProvider provider_falsy_keywords
+	 *
+	 * @param string $filter_return The value the filter returns.
+	 *
+	 * @return void
+	 */
+	public function test_falsy_keyword_suppresses_updated_flag( string $filter_return ): void {
+		$link = $this->link_repository->upsert( new Link( 'https://example.com/details' ) );
+
+		add_filter( 'iawmlf_link_details_updated_redirect_param', fn() => $filter_return );
+
+		$location = $this->submit_link_details_form( $link->get_id() );
+
+		$this->assertNotNull( $location );
+		$this->assertStringNotContainsString( 'iawmlf_updated', $location );
+	}
+
+	/**
+	 * Falsy keyword provider.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function provider_falsy_keywords(): array {
+		return array(
+			'zero'   => array( '0' ),
+			'false'  => array( 'false' ),
+			'no'     => array( 'no' ),
+			'empty'  => array( '' ),
+		);
+	}
+
+	/**
+	 * @testdox A truthy non-keyword filter return (documented (bool) contract) should keep the updated flag.
+	 *
+	 * @return void
+	 */
+	public function test_truthy_non_keyword_keeps_updated_flag(): void {
+		$link = $this->link_repository->upsert( new Link( 'https://example.com/details' ) );
+
+		add_filter( 'iawmlf_link_details_updated_redirect_param', fn() => 'updated' );
+
+		$location = $this->submit_link_details_form( $link->get_id() );
+
+		$this->assertNotNull( $location );
+		$this->assertStringContainsString( 'iawmlf_updated=1', $location );
+	}
+
+	/**
+	 * @testdox The default filter value should include the updated flag.
+	 *
+	 * @return void
+	 */
+	public function test_default_includes_updated_flag(): void {
+		$link = $this->link_repository->upsert( new Link( 'https://example.com/details' ) );
+
+		$location = $this->submit_link_details_form( $link->get_id() );
+
+		$this->assertNotNull( $location );
+		$this->assertStringContainsString( 'iawmlf_updated=1', $location );
+	}
+}

--- a/tests/Dashboard/Test_Report_Page.php
+++ b/tests/Dashboard/Test_Report_Page.php
@@ -129,6 +129,25 @@ class Test_Report_Page extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A before-saving filter callback that forgets to return the link should not fatal the form save.
+	 *
+	 * @return void
+	 */
+	public function test_before_saving_filter_returning_null_does_not_fatal(): void {
+		$link = $this->link_repository->upsert( new Link( 'https://example.com/details' ) );
+
+		// A broken third-party callback: mutates but returns nothing.
+		add_filter( 'iawmlf_before_saving_link_details', fn() => null );
+
+		$location = $this->submit_link_details_form( $link->get_id() );
+
+		remove_all_filters( 'iawmlf_before_saving_link_details' );
+
+		$this->assertNotNull( $location, 'The save should complete and redirect despite the malformed filter.' );
+		$this->assertStringContainsString( 'iawmlf_updated=1', $location );
+	}
+
+	/**
 	 * @testdox The default filter value should include the updated flag.
 	 *
 	 * @return void

--- a/tests/Event/Test_Check_Snapshot_Status_Event.php
+++ b/tests/Event/Test_Check_Snapshot_Status_Event.php
@@ -16,6 +16,7 @@ use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Repository;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Snapshot_Client;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Check_Snapshot_Status_Event;
 
 /**
@@ -69,8 +70,15 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 	private function set_snapshot_client_response( array $response ): void {
 		$service = $this->createMock( Snapshot_Client::class );
 		$service->method( 'get_snapshot_status' )->willReturn( $response );
+		$service->method( 'is_online' )->willReturn( true );
 
 		add_filter( 'iawmlf_snapshot_client', fn() => $service );
+
+		// Stub the link checker online too, so is_online() never hits the live API.
+		$link_checker = $this->createMock( Link_Checker_Client::class );
+		$link_checker->method( 'is_online' )->willReturn( true );
+
+		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 	}
 
 	/**

--- a/tests/Event/Test_Check_Validator_Status.php
+++ b/tests/Event/Test_Check_Validator_Status.php
@@ -118,6 +118,38 @@ class Test_Check_Validator_Status extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A link excluded for error:no-access is marked excluded and NOT broken.
+	 *
+	 * @return void
+	 */
+	public function test_no_access_exclusion_does_not_mark_link_broken(): void {
+		$this->set_snapshot_client_response(
+			array(
+				'status'     => 'error',
+				'message'    => 'The server cannot be crawled',
+				'status_ext' => 'error:no-access',
+			)
+		);
+
+		$link = $this->link_repository->upsert( new Link( 'https://example.com' ) );
+
+		$event = new Check_Validator_Status();
+		$event->setup();
+
+		// The event throws after upserting the excluded link.
+		try {
+			$event( $link->get_id(), 'fake-job', 0 );
+		} catch ( \Exception $e ) {
+			$this->assertStringContainsString( 'excluded due to status', $e->getMessage() );
+		}
+
+		$updated = $this->link_repository->find_by_id( $link->get_id() );
+
+		$this->assertTrue( $updated->is_excluded(), 'Link should be excluded for error:no-access.' );
+		$this->assertFalse( $updated->is_broken(), 'Excluding for no-access must not mark the link broken.' );
+	}
+
+	/**
 	 * @testdox A manually excluded link keeps its exclusion and message even when the validator job comes back success.
 	 *
 	 * @return void

--- a/tests/Event/Test_Create_New_Snapshot_Event.php
+++ b/tests/Event/Test_Create_New_Snapshot_Event.php
@@ -122,7 +122,13 @@ class Test_Create_New_Snapshot_Event extends \WP_UnitTestCase {
 		// Setup the mock service
 		$service = $this->createMock( Link_Checker_Client::class );
 		$service->method( 'get_final_url' )->willReturn( $final_url );
+		$service->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_link_checker_client', fn() => $service );
+
+		// Stub the snapshot client online so the guard passes without live HTTP.
+		$snapshot_client = $this->createMock( Snapshot_Client::class );
+		$snapshot_client->method( 'is_online' )->willReturn( true );
+		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot_client );
 
 		$event = new Create_New_Snapshot_Event();
 		$event->setup();
@@ -158,7 +164,13 @@ class Test_Create_New_Snapshot_Event extends \WP_UnitTestCase {
 		$service = $this->createMock( Link_Checker_Client::class );
 		$service->method( 'get_final_url' )
 			->willThrowException( new Service_Offline_Exception( 'Service is offline' ) );
+		$service->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_link_checker_client', fn() => $service );
+
+		// Stub the snapshot client online so the guard passes without live HTTP.
+		$snapshot_client = $this->createMock( Snapshot_Client::class );
+		$snapshot_client->method( 'is_online' )->willReturn( true );
+		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot_client );
 
 		$event = new Create_New_Snapshot_Event();
 		$event->setup();
@@ -206,12 +218,14 @@ class Test_Create_New_Snapshot_Event extends \WP_UnitTestCase {
 		// Setup the link checker mock to return the same URL (no redirect)
 		$link_checker = $this->createMock( Link_Checker_Client::class );
 		$link_checker->method( 'get_final_url' )->willReturn( $url );
+		$link_checker->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Setup the snapshot client mock to throw a service offline exception
 		$snapshot_client = $this->createMock( Snapshot_Client::class );
 		$snapshot_client->method( 'create_snapshot' )
 			->willThrowException( new Service_Offline_Exception( 'Service is offline' ) );
+		$snapshot_client->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot_client );
 
 		$event = new Create_New_Snapshot_Event();
@@ -259,12 +273,14 @@ class Test_Create_New_Snapshot_Event extends \WP_UnitTestCase {
 		// Setup the link checker mock to return the same URL (no redirect)
 		$link_checker = $this->createMock( Link_Checker_Client::class );
 		$link_checker->method( 'get_final_url' )->willReturn( $url );
+		$link_checker->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Setup the snapshot client mock to throw an exceeded limit exception
 		$snapshot_client = $this->createMock( Snapshot_Client::class );
 		$snapshot_client->method( 'create_snapshot' )
 			->willThrowException( new Exceeded_Snapshot_Limit_Exception() );
+		$snapshot_client->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot_client );
 
 		$event = new Create_New_Snapshot_Event();
@@ -313,12 +329,14 @@ class Test_Create_New_Snapshot_Event extends \WP_UnitTestCase {
 		// Setup the link checker mock to return the same URL (no redirect)
 		$link_checker = $this->createMock( Link_Checker_Client::class );
 		$link_checker->method( 'get_final_url' )->willReturn( $url );
+		$link_checker->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Setup the snapshot client mock to throw an invalid response exception
 		$snapshot_client = $this->createMock( Snapshot_Client::class );
 		$snapshot_client->method( 'create_snapshot' )
 			->willThrowException( new Invalid_Response_Exception( 'Invalid response' ) );
+		$snapshot_client->method( 'is_online' )->willReturn( true );
 		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot_client );
 
 		$event = new Create_New_Snapshot_Event();

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -271,6 +271,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		$client = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
 		$client->method( 'get_latest_snapshot' )
 			->willReturn( array( 'url' => 'https://web.archive.org/web/iawmlf_glynn/https://example.com' ) );
+		$client->method( 'is_online' )->willReturn( true );
 
 		// Set the mock client
 		add_filter(
@@ -279,6 +280,11 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 				return $client;
 			}
 		);
+
+		// Stub the link checker online so the guard passes without live HTTP.
+		$link_checker = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client::class );
+		$link_checker->method( 'is_online' )->willReturn( true );
+		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Create a link.
 		$link = new Link( 'https://example.com' );
@@ -321,6 +327,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		$client = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
 		$client->method( 'get_latest_snapshot' )
 			->willReturn( null );
+		$client->method( 'is_online' )->willReturn( true );
 
 		// Set the mock client
 		add_filter(
@@ -329,6 +336,11 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 				return $client;
 			}
 		);
+
+		// Stub the link checker online so the guard passes without live HTTP.
+		$link_checker = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client::class );
+		$link_checker->method( 'is_online' )->willReturn( true );
+		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Create a link.
 		$link = new Link( 'https://example.com' );

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -169,14 +169,31 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'https://example.com' );
 
 		// By default the link should be valid.
-		$this->assertTrue( $link->is_valid() );
+		$this->assertTrue( $link->assess_validity() );
 
 		// By having 3 checks with 500, the link should be invalid.
 		$link->add_check( 500, '20230101000000' );
 		$link->add_check( 500, '20240101000000' );
 		$link->add_check( 500, '20250101000000' );
 
+		$this->assertFalse( $link->assess_validity() );
+	}
+
+	/**
+	 * @testdox is_valid() should be a pure read of the stored broken flag, with no side effects. (T067)
+	 *
+	 * @return void
+	 */
+	public function test_is_valid_reads_stored_broken_flag(): void {
+		$link = new Link( 'https://example.com' );
+
+		$this->assertTrue( $link->is_valid() );
+
+		$link->set_broken();
 		$this->assertFalse( $link->is_valid() );
+
+		$link->set_valid();
+		$this->assertTrue( $link->is_valid() );
 	}
 
 	/**
@@ -192,13 +209,13 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'https://example.com' );
 
 		// By default the link should be valid.
-		$this->assertTrue( $link->is_valid() );
+		$this->assertTrue( $link->assess_validity() );
 
 		// By having 2 checks with 500, the link should be invalid.
 		$link->add_check( 500, '20230101000000' );
 		$link->add_check( 500, '20240101000000' );
 
-		$this->assertFalse( $link->is_valid() );
+		$this->assertFalse( $link->assess_validity() );
 
 		// Clear the filter.
 		remove_all_filters( 'iawmlf_failed_count' );
@@ -237,11 +254,11 @@ class Test_Link extends \WP_UnitTestCase {
 		$link->add_check( 500, '20250101000000' );
 		$link->add_check( 502, '20230101000000' );
 		$link->add_check( 502, '20240101000000' );
-		$this->assertTrue( $link->is_valid() );
+		$this->assertTrue( $link->assess_validity() );
 
 		// Now has 3 in last 3, so should be invalid.
 		$link->add_check( 502, '20260101000000' );
-		$this->assertFalse( $link->is_valid() );
+		$this->assertFalse( $link->assess_validity() );
 
 		// Clear the filter.
 		remove_all_filters( 'iawmlf_is_valid_check' );
@@ -371,17 +388,17 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'https://example.com' );
 
 		// By default the link should be valid.
-		$this->assertTrue( $link->is_valid() );
+		$this->assertTrue( $link->assess_validity() );
 
 		// By having 1 check with 500, the link should be valid.
 		$link->add_check( 500, '20230101000000' );
-		$this->assertTrue( $link->is_valid() );
+		$this->assertTrue( $link->assess_validity() );
 
 		// By having 3 checks with 500, the link should be invalid.
 		$link->add_check( 500, '20240101000000' );
 		$link->add_check( 500, '20250101000000' );
 
-		$this->assertFalse( $link->is_valid() );
+		$this->assertFalse( $link->assess_validity() );
 	}
 
 	/**

--- a/tests/Link/Test_Link_Repository.php
+++ b/tests/Link/Test_Link_Repository.php
@@ -664,6 +664,24 @@ class Test_Link_Repository extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Upserting a link whose row no longer exists should throw an Exception, not a TypeError.
+	 *
+	 * @return void
+	 */
+	public function test_upsert_of_deleted_link_throws_exception(): void {
+		$link = new Link( 'https://test_upsert_of_deleted_link.com' );
+		$link = $this->link_repository->upsert( $link );
+
+		// Delete the row out from under the link, as a concurrent worker could.
+		$this->link_repository->delete_link( $link );
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Failed to update link, link no longer exists.' );
+
+		$this->link_repository->upsert( $link );
+	}
+
+	/**
 	 * @testdox Attempting to get links for a post that has none defined in meta should result in an empty collection.
 	 *
 	 * @return void

--- a/tests/Report/Test_Report_Table_Actions.php
+++ b/tests/Report/Test_Report_Table_Actions.php
@@ -173,6 +173,7 @@ class Test_Report_Table_Actions extends \WP_UnitTestCase {
 				$calls++;
 				return 'some-id';
 			});
+		$client->method( 'is_online' )->willReturn( true );
 
 		// Set the mock client
 		add_filter(
@@ -181,6 +182,11 @@ class Test_Report_Table_Actions extends \WP_UnitTestCase {
 				return $client;
 			}
 		);
+
+		// Stub the link checker online so the guard passes without live HTTP.
+		$link_checker = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client::class );
+		$link_checker->method( 'is_online' )->willReturn( true );
+		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 
 		// Iterate through the links and save them.
 		foreach ( $all as $link ) {

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -152,6 +152,27 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A stored-broken link that is not due a re-check should report its stored state, not a recomputed one. (T067)
+	 *
+	 * @return void
+	 */
+	public function test_recently_checked_broken_link_reports_stored_state(): void {
+		// A link marked broken with a single recent failed check — fewer checks
+		// than the failed-count threshold, so a recompute would call it valid.
+		$link = new Link( 'https://recently-checked-broken.com' );
+		$link->add_check( 404, gmdate( 'Y-m-d H:i:s' ) );
+		$link->set_broken();
+		$this->link_repository->upsert( $link );
+
+		$response = $this->dispatch_request( array( 'link' => 'https://recently-checked-broken.com' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $data['updated'] );
+		$this->assertFalse( $data['valid'], 'The stored broken flag must be reported, not recomputed from too-few checks.' );
+	}
+
+	/**
 	 * @testdox A stored link containing percent-encoded characters must be found — sanitize_text_field strips %XX sequences and caused a false 404. (S022)
 	 *
 	 * @return void

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -84,7 +84,7 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	private function dispatch_request( array $params = array(), ?callable $config = null ): \WP_REST_Response {
 		$request = new \WP_REST_Request(
 			'POST',
-			'/' . Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE
+			'/' . Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE
 		);
 
 		if ( ! empty( $params ) ) {
@@ -106,7 +106,7 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	public function test_route_is_registered(): void {
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey(
-			'/' . Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE,
+			'/' . Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE,
 			$routes
 		);
 	}

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -84,7 +84,7 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	private function dispatch_request( array $params = array(), ?callable $config = null ): \WP_REST_Response {
 		$request = new \WP_REST_Request(
 			'POST',
-			'/' . Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE
+			'/' . Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE
 		);
 
 		if ( ! empty( $params ) ) {
@@ -106,18 +106,9 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	public function test_route_is_registered(): void {
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey(
-			'/' . Link_Check_Rest::API_NAMESPACE . Link_Check_Rest::ROUTE,
+			'/' . Link_Check_Rest::NAMESPACE . Link_Check_Rest::ROUTE,
 			$routes
 		);
-	}
-
-	/**
-	 * @testdox The deprecated NAMESPACE constant must keep resolving to the same value as API_NAMESPACE.
-	 *
-	 * @return void
-	 */
-	public function test_deprecated_namespace_constant_still_resolves(): void {
-		$this->assertSame( Link_Check_Rest::API_NAMESPACE, Link_Check_Rest::NAMESPACE );
 	}
 
 	/**

--- a/tests/Rest/Test_Link_Check_Rest.php
+++ b/tests/Rest/Test_Link_Check_Rest.php
@@ -112,6 +112,15 @@ class Test_Link_Check_Rest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox The deprecated NAMESPACE constant must keep resolving to the same value as API_NAMESPACE.
+	 *
+	 * @return void
+	 */
+	public function test_deprecated_namespace_constant_still_resolves(): void {
+		$this->assertSame( Link_Check_Rest::API_NAMESPACE, Link_Check_Rest::NAMESPACE );
+	}
+
+	/**
 	 * @testdox A request without a link parameter should return a 400 error.
 	 *
 	 * @return void

--- a/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
+++ b/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
@@ -76,8 +76,15 @@ class Test_Action_Scheduler_Garbage_Collection extends \WP_UnitTestCase {
 	private function set_snapshot_client_response( array $response ): void {
 		$service = $this->createMock( Snapshot_Client::class );
 		$service->method( 'get_snapshot_status' )->willReturn( $response );
+		$service->method( 'is_online' )->willReturn( true );
 
 		add_filter( 'iawmlf_snapshot_client', fn() => $service );
+
+		// Stub the link checker online too, so is_online() never hits the live API.
+		$link_checker = $this->createMock( Link_Checker_Client::class );
+		$link_checker->method( 'is_online' )->willReturn( true );
+
+		add_filter( 'iawmlf_link_checker_client', fn() => $link_checker );
 	}
 
 	/**
@@ -292,8 +299,15 @@ class Test_Action_Scheduler_Garbage_Collection extends \WP_UnitTestCase {
 		$service = $this->createMock( Link_Checker_Client::class );
 		$service->method( 'get_final_url' )
 			->willThrowException( new Service_Offline_Exception( 'Service is offline' ) );
+		$service->method( 'is_online' )->willReturn( true );
 
 		add_filter( 'iawmlf_link_checker_client', fn() => $service );
+
+		// Stub the snapshot client online too, so is_online() never hits the live API.
+		$snapshot = $this->createMock( Snapshot_Client::class );
+		$snapshot->method( 'is_online' )->willReturn( true );
+
+		add_filter( 'iawmlf_snapshot_client', fn() => $snapshot );
 	}
 
 	/**

--- a/tests/Util/Test_Environmental.php
+++ b/tests/Util/Test_Environmental.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Tests for the Environmental utility.
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Util\Environmental
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Util;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Util\Environmental;
+
+/**
+ * Test_Environmental
+ *
+ * @group Util
+ * @group Environmental
+ */
+class Test_Environmental extends \WP_UnitTestCase {
+
+	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'iawmlf_is_production_environment' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox A filter returning a non-bool truthy value should not fatal is_production(). (S068)
+	 *
+	 * @return void
+	 */
+	public function test_is_production_casts_non_bool_filter_return(): void {
+		add_filter( 'iawmlf_is_production_environment', fn() => 'yes' );
+
+		$this->assertTrue( Environmental::is_production() );
+	}
+
+	/**
+	 * @testdox A filter returning false keeps is_production() false.
+	 *
+	 * @return void
+	 */
+	public function test_is_production_respects_false_filter_return(): void {
+		add_filter( 'iawmlf_is_production_environment', fn() => false );
+
+		$this->assertFalse( Environmental::is_production() );
+	}
+}

--- a/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
@@ -336,6 +336,31 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox When trying to get the final destination for a link, a non-string location should be treated as absent, not fatal.
+	 *
+	 * @return void
+	 */
+	public function test_should_return_original_url_if_location_not_string() {
+		if ( $GLOBALS['iawmlf_skip_live_api_tests'] === true ) {
+			$this->markTestSkipped( 'Skipping live API tests' );
+		}
+
+		$client = new HTTP_Link_Checker_Client();
+
+		// Mock the response with a numeric location value.
+		$this->mock_wp_http_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => json_encode( array( 'location' => 123 ) ),
+			)
+		);
+
+		$final = $client->get_final_url( 'https://example.com' );
+
+		$this->assertEquals( 'https://example.com', $final );
+	}
+
+	/**
 	 * @testdox When checking a link, if a WP_Error is returned, an exception should be thrown.
 	 *
 	 * @return void

--- a/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
@@ -361,6 +361,31 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox When trying to get the final destination for a link, an empty-string location should fall back to the original URL.
+	 *
+	 * @return void
+	 */
+	public function test_should_return_original_url_if_location_empty_string() {
+		if ( $GLOBALS['iawmlf_skip_live_api_tests'] === true ) {
+			$this->markTestSkipped( 'Skipping live API tests' );
+		}
+
+		$client = new HTTP_Link_Checker_Client();
+
+		// Mock the response with an empty location value.
+		$this->mock_wp_http_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => json_encode( array( 'location' => '' ) ),
+			)
+		);
+
+		$final = $client->get_final_url( 'https://example.com' );
+
+		$this->assertEquals( 'https://example.com', $final );
+	}
+
+	/**
 	 * @testdox When checking a link, if a WP_Error is returned, an exception should be thrown.
 	 *
 	 * @return void

--- a/tests/Wayback_Machine/Test_Wayback_Machine_Service.php
+++ b/tests/Wayback_Machine/Test_Wayback_Machine_Service.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Tests for the Wayback Machine Service.
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Wayback_Machine_Service
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Wayback_Machine;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Wayback_Machine_Service;
+use Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Tools\Wayback_Machine_Helper;
+
+/**
+ * Test_Wayback_Machine_Service
+ *
+ * @group Wayback_Machine
+ * @group Wayback_Machine_Service
+ */
+class Test_Wayback_Machine_Service extends \WP_UnitTestCase {
+
+	use Wayback_Machine_Helper;
+
+	/**
+	 * Setup
+	 */
+	public function set_up(): void {
+		$this->clear_clients();
+		parent::set_up();
+	}
+
+	/**
+	 * Tear down
+	 */
+	public function tear_down(): void {
+		$this->clear_clients();
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox is_online() returns true only when both clients are online.
+	 *
+	 * @return void
+	 */
+	public function test_is_online_true_when_both_clients_online(): void {
+		$this->create_service( true );
+
+		$this->assertTrue( ( new Wayback_Machine_Service() )->is_online() );
+	}
+
+	/**
+	 * @testdox is_online() returns false when both clients are offline.
+	 *
+	 * @return void
+	 */
+	public function test_is_online_false_when_both_clients_offline(): void {
+		$this->create_service( false );
+
+		$this->assertFalse( ( new Wayback_Machine_Service() )->is_online() );
+	}
+
+	/**
+	 * @testdox is_online() returns false when only the snapshot client is down.
+	 *
+	 * @return void
+	 */
+	public function test_is_online_false_when_snapshot_client_offline(): void {
+		$this->create_service(
+			true,
+			function ( array $clients ) {
+				$offline = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Snapshot_Client::class );
+				$offline->method( 'is_online' )->willReturn( false );
+				$clients['snapshot'] = $offline;
+				return $clients;
+			}
+		);
+
+		$this->assertFalse( ( new Wayback_Machine_Service() )->is_online() );
+	}
+
+	/**
+	 * @testdox is_online() returns false when only the link checker client is down.
+	 *
+	 * @return void
+	 */
+	public function test_is_online_false_when_link_checker_client_offline(): void {
+		$this->create_service(
+			true,
+			function ( array $clients ) {
+				$offline = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\Link_Checker_Client::class );
+				$offline->method( 'is_online' )->willReturn( false );
+				$clients['link_checker'] = $offline;
+				return $clients;
+			}
+		);
+
+		$this->assertFalse( ( new Wayback_Machine_Service() )->is_online() );
+	}
+}


### PR DESCRIPTION
Works through issue #358 — Audit 1.4.3, function signatures & broken contracts (14 items). 13 fixed, 1 struck through on the issue as too unlikely to matter (T128), plus one discarded-argument bug found along the way.

## Behavioural fixes (each with a failing test written first)

- **S006** — `set_excluded()->set_broken( false )`: `set_broken()` is nullary, so the `false` was discarded and no-access links were marked *broken* at the moment they were excluded. Now `set_valid()`; the discarded `set_valid( true )` arg in `Link_Check_Action` tidied too.
- **S005** — `Wayback_Machine_Service::is_online()` returned `array{snapshot, link_checker}` — always truthy, so all eight `! is_online()` offline guards were dead code. Now a bool that is true only when both clients are online. Test fixtures gained `is_online` stubs (mocked clients default to `false`, which the dead guards had been hiding).
- **S035** — `Link_Repository::update()` declared `: Link` but returned `find_by_id()` (`?Link`) — a TypeError under `strict_types` when the row is deleted between the UPDATE and re-fetch. Now honestly `?Link`, with `upsert()` throwing a proper Exception on the vanished row so its 20 call sites keep their contract.
- **T269** — `get_final_url()` returned `$response['location']` unvalidated; a non-string value in the upstream JSON escaped `Link_Check_Rest`'s `catch ( Exception )` as a fatal TypeError. Non-string location now falls back to the original URL (and the dead `?? ''` went with it).
- **T067** — `Link::is_valid()` mutated `is_broken` from inside read paths, so a REST response for a stored-broken link not due a re-check contradicted the DB. Split: `is_valid()` is now a pure read of the stored flag; the recompute-and-set logic lives in `assess_validity()`, called only at the two real check sites.

## Hardening & tidy clusters

- **S068 / T180 / T199** — unvalidated `apply_filters()` returns: `(bool)` cast in `Environmental::is_production()` (was a strict-types TypeError, regression test added); `FILTER_VALIDATE_BOOLEAN` on `iawmlf_link_details_updated_redirect_param` so `'false'`/`'no'`/`'0'` no longer count as truthy; `absint()` on the two attempts filters.
- **T241 / T136** — dead `$status` params removed from `Report_Table::get_links()`/`count_links()`; fake `'any'`/`'fallback'` order-by values replaced with `Link_Repository::ORDER_ID_DESC` (shares the default case, so the generated SQL is unchanged).
- **S127 / S112 / S116** — `Dashboard_Statistics::get_link_statistics()` now returns the same key set on cache hit and miss (unread `broken_links` duplicate dropped); exception factories escape and format consistently and `@throws` types resolve via proper imports; `Link_Check_Rest::NAMESPACE` (reserved word) renamed `API_NAMESPACE`, `@since` corrected, `delete_link()` docblock made honest, unused `new Settings()` removed from the wizard view data.
- **Extra** — `Dashboard_Statistics` passed a 12th argument to the 11-param `query_links()`; PHP silently discarded it. Removed.

## Struck through on the issue

- **T128** — `find_archive()` returning `''` instead of null needs Archive.org to report an available snapshot with no `url` field; judged too unlikely to matter.

## Testing

1. `composer install --ignore-platform-reqs` then `composer test:php` — 383 tests, 975 assertions, all green (11 new tests).
2. `composer lint:php` — clean.
3. Manual: exclude a link via "Verify Link Allows Checking" against a bot-blocked URL — the link should end up excluded and **not** broken. With the Archive.org API unreachable, snapshot/check events should now requeue with "Service is offline" instead of proceeding.
