### PR TITLE
Audit 1.4.3 - performance, queries & caching (issue #359)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,11 +12,12 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php: [ '8.1', '8.2', '8.3', '8.4']
+        database: [ 'mysql:5.7', 'mariadb:10.6' ]
     runs-on: ${{ matrix.operating-system }}
     services:
-      # Setup MYSQL
+      # Setup MYSQL/MariaDB
       mysql-service:
-        image: 'mysql:5.7'
+        image: ${{ matrix.database }}
         env:
           MYSQL_ROOT_PASSWORD: 'poetry'
           MYSQL_DATABASE: wlf_tests

--- a/README.md
+++ b/README.md
@@ -1129,11 +1129,11 @@ add_filter( 'iawmlf_create_snapshot_url', function( string $url ): string {
 
 #### `iawmlf_create_snapshot_timeout`
 
-This is used to set the timeout for creating a new snapshot. The default is 1000 seconds (16.7 minutes).
+This is used to set the timeout for creating a new snapshot. The default is 5000ms (5 seconds).
 
 ```php
 add_filter( 'iawmlf_create_snapshot_timeout', function( int $timeout ): int {
-	return 2000; // 33+ minutes
+	return 10000; // 10 seconds
 });
 ```
 

--- a/assets/js/src/admin_settings.js
+++ b/assets/js/src/admin_settings.js
@@ -214,6 +214,15 @@
 		}
 
 		/**
+		 * Build the "Show more" sentinel row.
+		 *
+		 * @return {string} The row HTML.
+		 */
+		function moreRowHtml() {
+			return '<div class="iawmlf-post-search__item iawmlf-post-search__more">' + escapeHTML(__('Show more…', 'internet-archive-wayback-machine-link-fixer')) + '</div>';
+		}
+
+		/**
 		 * Render the search results in the dropdown.
 		 *
 		 * @param {Array}   results - Array of result objects.
@@ -221,22 +230,30 @@
 		 * @param {boolean} append  - Append to the current results rather than replacing them.
 		 */
 		function renderResults(results, search, append) {
+			const startIndex = append ? currentResults.length : 0;
 			currentResults = append ? currentResults.concat(results) : results;
-			activeIndex = -1;
 
 			let html = '';
-			currentResults.forEach(function (result, i) {
-				html += '<div class="iawmlf-post-search__item" data-index="' + i + '">';
+			results.forEach(function (result, i) {
+				html += '<div class="iawmlf-post-search__item" data-index="' + (startIndex + i) + '">';
 				html += '<div class="iawmlf-post-search__item-title">' + highlight(escapeHTML(result.title), search) + '</div>';
 				html += '<div class="iawmlf-post-search__item-meta">' + escapeHTML(result.post_type) + ' &middot; ID: ' + escapeHTML(String(result.id)) + ' &middot; /' + highlight(escapeHTML(result.slug), search) + '</div>';
 				html += '</div>';
 			});
 
-			if (hasMore) {
-				html += '<div class="iawmlf-post-search__item iawmlf-post-search__more">' + escapeHTML(__('Show more…', 'internet-archive-wayback-machine-link-fixer')) + '</div>';
+			if (append) {
+				// Append in place - a full innerHTML rewrite would reset the scroll position and keyboard state.
+				const moreRow = dropdown.querySelector('.iawmlf-post-search__more');
+				if (moreRow) {
+					moreRow.remove();
+				}
+				dropdown.insertAdjacentHTML('beforeend', html + (hasMore ? moreRowHtml() : ''));
+				show();
+				return;
 			}
 
-			dropdown.innerHTML = html;
+			activeIndex = -1;
+			dropdown.innerHTML = html + (hasMore ? moreRowHtml() : '');
 			show();
 		}
 
@@ -272,7 +289,6 @@
 			abortCtrl = new AbortController();
 
 			currentSearch = search;
-			currentPage = page;
 			loadingMore = !!append;
 
 			if (!append) {
@@ -300,6 +316,8 @@
 					const payload = data.success && data.data ? data.data : null;
 					const results = payload && payload.results ? payload.results : [];
 					hasMore = !!(payload && payload.has_more);
+					// Only advance the page on success, so a failed append can be retried rather than skipped.
+					currentPage = page;
 
 					var filtered = results.filter(function (result) {
 						return !isExcluded(result);

--- a/assets/js/src/admin_settings.js
+++ b/assets/js/src/admin_settings.js
@@ -292,6 +292,11 @@
 			loadingMore = !!append;
 
 			if (!append) {
+				// A fresh search resets the paging state - stale hasMore/currentPage would let the
+				// scroll event fired by the collapsing dropdown trigger a bogus loadMore of the old search.
+				currentPage = 1;
+				hasMore = false;
+				currentResults = [];
 				showLoading();
 			}
 

--- a/assets/js/src/admin_settings.js
+++ b/assets/js/src/admin_settings.js
@@ -152,6 +152,10 @@
 		let abortCtrl      = null;
 		let activeIndex    = -1;
 		let currentResults = [];
+		let currentSearch  = '';
+		let currentPage    = 1;
+		let hasMore        = false;
+		let loadingMore    = false;
 
 		/**
 		 * Highlight search term in text using <mark> tags.
@@ -183,6 +187,8 @@
 			dropdown.style.display = 'none';
 			activeIndex = -1;
 			currentResults = [];
+			currentPage = 1;
+			hasMore = false;
 		}
 
 		/**
@@ -210,20 +216,25 @@
 		/**
 		 * Render the search results in the dropdown.
 		 *
-		 * @param {Array}  results - Array of result objects.
-		 * @param {string} search  - The search term for highlighting.
+		 * @param {Array}   results - Array of result objects.
+		 * @param {string}  search  - The search term for highlighting.
+		 * @param {boolean} append  - Append to the current results rather than replacing them.
 		 */
-		function renderResults(results, search) {
-			currentResults = results;
+		function renderResults(results, search, append) {
+			currentResults = append ? currentResults.concat(results) : results;
 			activeIndex = -1;
 
 			let html = '';
-			results.forEach(function (result, i) {
+			currentResults.forEach(function (result, i) {
 				html += '<div class="iawmlf-post-search__item" data-index="' + i + '">';
 				html += '<div class="iawmlf-post-search__item-title">' + highlight(escapeHTML(result.title), search) + '</div>';
 				html += '<div class="iawmlf-post-search__item-meta">' + escapeHTML(result.post_type) + ' &middot; ID: ' + escapeHTML(String(result.id)) + ' &middot; /' + highlight(escapeHTML(result.slug), search) + '</div>';
 				html += '</div>';
 			});
+
+			if (hasMore) {
+				html += '<div class="iawmlf-post-search__item iawmlf-post-search__more">' + escapeHTML(__('Show more…', 'internet-archive-wayback-machine-link-fixer')) + '</div>';
+			}
 
 			dropdown.innerHTML = html;
 			show();
@@ -247,21 +258,32 @@
 		/**
 		 * Perform the AJAX search.
 		 *
-		 * @param {string} search - The search term.
+		 * @param {string}  search - The search term.
+		 * @param {number}  page   - The page of results to fetch.
+		 * @param {boolean} append - Append the results rather than replacing the list.
 		 */
-		function doSearch(search) {
+		function doSearch(search, page, append) {
+			page = page || 1;
+
 			// Abort any in-flight request.
 			if (abortCtrl) {
 				abortCtrl.abort();
 			}
 			abortCtrl = new AbortController();
 
-			showLoading();
+			currentSearch = search;
+			currentPage = page;
+			loadingMore = !!append;
+
+			if (!append) {
+				showLoading();
+			}
 
 			const formData = new FormData();
 			formData.append('action', action);
 			formData.append('nonce', nonce);
 			formData.append('search', search);
+			formData.append('page', page);
 			if (context) {
 				formData.append('context', context);
 			}
@@ -275,24 +297,38 @@
 					return response.json();
 				})
 				.then(function (data) {
-					if (data.success && data.data && data.data.length > 0) {
-						var filtered = data.data.filter(function (result) {
-							return !isExcluded(result);
-						});
-						if (filtered.length > 0) {
-							renderResults(filtered, search);
-						} else {
-							showNoResults();
-						}
-					} else {
+					const payload = data.success && data.data ? data.data : null;
+					const results = payload && payload.results ? payload.results : [];
+					hasMore = !!(payload && payload.has_more);
+
+					var filtered = results.filter(function (result) {
+						return !isExcluded(result);
+					});
+
+					if (filtered.length === 0 && !append) {
+						showNoResults();
+						return;
+					}
+
+					renderResults(filtered, search, append);
+				})
+				.catch(function (err) {
+					if (err.name !== 'AbortError' && !append) {
 						showNoResults();
 					}
 				})
-				.catch(function (err) {
-					if (err.name !== 'AbortError') {
-						showNoResults();
-					}
+				.finally(function () {
+					loadingMore = false;
 				});
+		}
+
+		/**
+		 * Load the next page of results, appending to the list.
+		 */
+		function loadMore() {
+			if (hasMore && !loadingMore) {
+				doSearch(currentSearch, currentPage + 1, true);
+			}
 		}
 
 		// Debounced input listener.
@@ -344,6 +380,11 @@
 
 		// Click on result.
 		dropdown.addEventListener('click', function (e) {
+			if (e.target.closest('.iawmlf-post-search__more')) {
+				loadMore();
+				return;
+			}
+
 			const item = e.target.closest('.iawmlf-post-search__item');
 			if (item) {
 				const idx = parseInt(item.dataset.index, 10);
@@ -352,6 +393,13 @@
 					input.value = '';
 					close();
 				}
+			}
+		});
+
+		// Load the next page when scrolled to the bottom of the list.
+		dropdown.addEventListener('scroll', function () {
+			if (dropdown.scrollTop + dropdown.clientHeight >= dropdown.scrollHeight - 4) {
+				loadMore();
 			}
 		});
 

--- a/functions.php
+++ b/functions.php
@@ -515,17 +515,17 @@ function iawmlf_get_admin_post_type_link( string $post_type, string $target = '_
  * @return boolean
  */
 function iawmlf_is_archive_api_online( bool $force = false ): bool {
-	// Try to get from transient.
+	// Try to get from transient. Stored as yes/no as a cached false would look like a missing transient.
 	$online = get_transient( 'iawmlf_archive_api_online' );
-	if ( false !== (bool) $online && false === $force ) {
-		return (bool) $online;
+	if ( false !== $online && false === $force ) {
+		return 'yes' === $online;
 	}
 
 	// Check if the system client is online.
 	$online = iawmlf_get_system_client()->is_online();
 	// Set the transient
 	$duration = apply_filters( 'iawmlf_archive_api_status_duration', \HOUR_IN_SECONDS );
-	set_transient( 'iawmlf_archive_api_online', $online, $duration );
+	set_transient( 'iawmlf_archive_api_online', $online ? 'yes' : 'no', $duration );
 	return (bool) $online;
 }
 

--- a/functions.php
+++ b/functions.php
@@ -518,7 +518,8 @@ function iawmlf_is_archive_api_online( bool $force = false ): bool {
 	// Try to get from transient. Stored as yes/no as a cached false would look like a missing transient.
 	$online = get_transient( 'iawmlf_archive_api_online' );
 	if ( false !== $online && false === $force ) {
-		return 'yes' === $online;
+		// Only an explicit 'no' is offline - a legacy boolean true (pre yes/no format) still reads as online.
+		return 'no' !== $online;
 	}
 
 	// Check if the system client is online.

--- a/functions.php
+++ b/functions.php
@@ -518,8 +518,8 @@ function iawmlf_is_archive_api_online( bool $force = false ): bool {
 	// Try to get from transient. Stored as yes/no as a cached false would look like a missing transient.
 	$online = get_transient( 'iawmlf_archive_api_online' );
 	if ( false !== $online && false === $force ) {
-		// Only an explicit 'no' is offline - a legacy boolean true (pre yes/no format) still reads as online.
-		return 'no' !== $online;
+		// A cached 'yes', or a legacy truthy value (the pre yes/no format), reads as online.
+		return in_array( $online, array( 'yes', '1', true ), true );
 	}
 
 	// Check if the system client is online.

--- a/src/Ajax/Post_Search_Ajax.php
+++ b/src/Ajax/Post_Search_Ajax.php
@@ -39,6 +39,11 @@ class Post_Search_Ajax {
 	private const MIN_CHARS = 2;
 
 	/**
+	 * The number of results returned per page.
+	 */
+	private const PER_PAGE = 100;
+
+	/**
 	 * Register the ajax action.
 	 *
 	 * @return void
@@ -76,8 +81,11 @@ class Post_Search_Ajax {
 			$excluded_ids = Settings::get_link_fixer_excluded_posts();
 		}
 
+		// Get the requested page of results.
+		$page = isset( $_POST['page'] ) ? max( 1, absint( wp_unslash( $_POST['page'] ) ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Missing, Checked above.
+
 		// Get the results.
-		$results = $this->search_posts( $search, $post_types, $excluded_ids );
+		$results = $this->search_posts( $search, $post_types, $excluded_ids, $page );
 
 		$this->send_success( $results );
 	}
@@ -90,15 +98,16 @@ class Post_Search_Ajax {
 	 * @param string   $search       The search term.
 	 * @param string[] $post_types   The post types to search within.
 	 * @param int[]    $excluded_ids Post IDs to exclude from results.
+	 * @param integer  $page         The page of results to return.
 	 *
-	 * @return array
+	 * @return array{results: array, has_more: bool}
 	 */
-	private function search_posts( string $search, array $post_types, array $excluded_ids = array() ): array {
+	private function search_posts( string $search, array $post_types, array $excluded_ids = array(), int $page = 1 ): array {
 		$found_ids = array();
 		$results   = array();
 
-		// If numeric, try exact ID match first.
-		if ( is_numeric( $search ) ) {
+		// If numeric, try exact ID match first (first page only).
+		if ( 1 === $page && is_numeric( $search ) ) {
 			$post_id = absint( $search );
 			if ( $post_id > 0 ) {
 				$id_query = new \WP_Query(
@@ -127,7 +136,9 @@ class Post_Search_Ajax {
 			array(
 				'post_type'                => $post_types,
 				'post_status'              => 'publish',
-				'posts_per_page'           => -1,
+				'posts_per_page'           => self::PER_PAGE + 1,
+				'offset'                   => ( $page - 1 ) * self::PER_PAGE,
+				'no_found_rows'            => true,
 				'orderby'                  => 'title',
 				'order'                    => 'ASC',
 				'suppress_filters'         => false,
@@ -138,14 +149,20 @@ class Post_Search_Ajax {
 
 		remove_filter( 'posts_where', $where_filter, 10 );
 
-		foreach ( $search_query->posts as $post ) {
+		// An extra row is fetched purely to detect a further page.
+		$has_more = count( $search_query->posts ) > self::PER_PAGE;
+
+		foreach ( array_slice( $search_query->posts, 0, self::PER_PAGE ) as $post ) {
 			if ( ! in_array( $post->ID, $found_ids, true ) ) {
 				$found_ids[] = $post->ID;
 				$results[]   = $this->format_result_from_post( $post );
 			}
 		}
 
-		return $results;
+		return array(
+			'results'  => $results,
+			'has_more' => $has_more,
+		);
 	}
 
 	/**

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -126,7 +126,8 @@ class Dashboard_Notifications {
 	public static function get_account_details(): ?array {
 		$cached = get_transient( 'iawmlf_account_details' );
 		if ( false !== $cached ) {
-			return 'NO DATA' === $cached ? null : $cached;
+			// Normalised on read, so raw payloads cached before normalisation render safely. 'NO DATA' is the cached failure.
+			return is_array( $cached ) ? self::normalize_account_details( $cached ) : null;
 		}
 		try {
 			$details = \iawmlf_get_system_client()->get_user_stats(
@@ -136,12 +137,7 @@ class Dashboard_Notifications {
 
 			if ( is_array( $details ) ) {
 				set_transient( 'iawmlf_account_details', $details, HOUR_IN_SECONDS );
-				return array(
-					'available'            => isset( $details['available'] ) ? (int) $details['available'] : 0,
-					'daily_captures'       => isset( $details['daily_captures'] ) ? (int) $details['daily_captures'] : 0,
-					'daily_captures_limit' => isset( $details['daily_captures_limit'] ) ? (int) $details['daily_captures_limit'] : 0,
-					'processing'           => isset( $details['processing'] ) ? (int) $details['processing'] : 0,
-				);
+				return self::normalize_account_details( $details );
 			}
 		} catch ( \Exception $e ) {
 			// Cache the failure so its not retried on every call.
@@ -152,5 +148,21 @@ class Dashboard_Notifications {
 		// Cache the failure so its not retried on every call.
 		set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
 		return null;
+	}
+
+	/**
+	 * Normalize an account details payload to the documented shape.
+	 *
+	 * @param array $details The raw payload.
+	 *
+	 * @return array{available:int, daily_captures:int, daily_captures_limit:int, processing:int}
+	 */
+	private static function normalize_account_details( array $details ): array {
+		return array(
+			'available'            => isset( $details['available'] ) ? (int) $details['available'] : 0,
+			'daily_captures'       => isset( $details['daily_captures'] ) ? (int) $details['daily_captures'] : 0,
+			'daily_captures_limit' => isset( $details['daily_captures_limit'] ) ? (int) $details['daily_captures_limit'] : 0,
+			'processing'           => isset( $details['processing'] ) ? (int) $details['processing'] : 0,
+		);
 	}
 }

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -126,7 +126,7 @@ class Dashboard_Notifications {
 	public static function get_account_details(): ?array {
 		$cached = get_transient( 'iawmlf_account_details' );
 		if ( false !== $cached ) {
-			return $cached;
+			return 'NO DATA' === $cached ? null : $cached;
 		}
 		try {
 			$details = \iawmlf_get_system_client()->get_user_stats(
@@ -144,9 +144,13 @@ class Dashboard_Notifications {
 				);
 			}
 		} catch ( \Exception $e ) {
+			// Cache the failure so its not retried on every call.
+			set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
 			return null;
 		}
 
+		// Cache the failure so its not retried on every call.
+		set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
 		return null;
 	}
 }

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -51,6 +51,21 @@ class Settings_Page {
 		add_action( 'admin_menu', array( $this, 'register_page' ), 20, 0 );
 		add_action( 'admin_init', array( $this, 'validate_archive_org_keys' ), 1 );
 		add_action( 'wp_ajax_iawmlf_dismiss_donation_cta', array( $this, 'dismiss_donation_cta' ) );
+
+		// Saving either archive.org key invalidates the cached account details.
+		add_action( 'add_option_' . Settings::ARCHIVE_ORG_ACCESS_KEY, array( $this, 'clear_account_details_cache' ) );
+		add_action( 'update_option_' . Settings::ARCHIVE_ORG_ACCESS_KEY, array( $this, 'clear_account_details_cache' ) );
+		add_action( 'add_option_' . Settings::ARCHIVE_ORG_SECRET_KEY, array( $this, 'clear_account_details_cache' ) );
+		add_action( 'update_option_' . Settings::ARCHIVE_ORG_SECRET_KEY, array( $this, 'clear_account_details_cache' ) );
+	}
+
+	/**
+	 * Clears the cached account details when the archive.org keys change.
+	 *
+	 * @return void
+	 */
+	public function clear_account_details_cache(): void {
+		delete_transient( 'iawmlf_account_details' );
 	}
 
 	/**

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -73,6 +73,14 @@ class Settings_Page {
 	 * @return  void
 	 */
 	public function register_fields(): void {
+		global $pagenow;
+
+		// Only needed when rendering the settings screen, or saving it via options.php.
+		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Read only page check.
+		if ( 'options.php' !== $pagenow && self::PAGE_SLUG !== $current_page ) {
+			return;
+		}
+
 		// Register the settings fields.
 		$this->register_settings_fields();
 		$this->add_settings_fields();

--- a/src/Event/Event_Controller.php
+++ b/src/Event/Event_Controller.php
@@ -37,9 +37,12 @@ class Event_Controller {
 		add_action( Scan_Own_Posts_Event::HANDLE, new Scan_Own_Posts_Event(), 10, 0 );
 		add_action( Failed_Event_Garbage_Collection_Event::HANDLE, new Failed_Event_Garbage_Collection_Event(), 10, 0 );
 
-		// Ensure the post scan event is added to the action scheduler.
-		add_action( 'init', array( Scan_Posts_Event::class, 'add_to_action_scheduler' ) );
-		add_action( 'init', array( Scan_Own_Posts_Event::class, 'add_to_action_scheduler' ) );
-		add_action( 'init', array( Failed_Event_Garbage_Collection_Event::class, 'add_to_action_scheduler' ) );
+		// Ensure the events are added to the action scheduler. Admin and cron only - front
+		// end traffic should not pay for the schedule self-check, cron re-heals it within minutes.
+		if ( is_admin() || wp_doing_cron() ) {
+			add_action( 'init', array( Scan_Posts_Event::class, 'add_to_action_scheduler' ) );
+			add_action( 'init', array( Scan_Own_Posts_Event::class, 'add_to_action_scheduler' ) );
+			add_action( 'init', array( Failed_Event_Garbage_Collection_Event::class, 'add_to_action_scheduler' ) );
+		}
 	}
 }

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -521,7 +521,7 @@ class Link implements \JsonSerializable {
 			'href'          => $this->href,
 			'archived_href' => $this->get_archived_href(),
 			'redirect_href' => $this->redirect_href,
-			'checks'        => $this->checks,
+			'checks'        => array_slice( $this->checks, -3 ), // Newest 3 only, the full history is not needed client side.
 			'broken'        => $this->is_broken,
 			'last_checked'  => $this->get_last_check(),
 			'process'       => $this->archive_process,

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -557,11 +557,13 @@ class Link_Repository {
 		}
 
 		// If we have a date, add to the query getting the last date from json column.
+		// The CASE guards the empty checks array - it would build the invalid path $[-1], which MySQL rejects.
 		if ( $date ) {
 			$date_range = $this->get_date_range( $date );
 			$query     .= true === $where ? ' AND' : ' WHERE';
-			$query     .= ' STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`checks`, CONCAT("$[", JSON_LENGTH(`checks`) - 1, "].date"))), \'%Y-%m-%d %H:%i:%s\')'; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
+			$query     .= ' CASE WHEN JSON_LENGTH(`checks`) = 0 THEN 0 ELSE STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`checks`, CONCAT("$[", JSON_LENGTH(`checks`) - 1, "].date"))), \'%Y-%m-%d %H:%i:%s\')'; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, Compiled in parts, very hard to escape
 			$query     .= $this->wpdb->prepare( ' BETWEEN %s AND %s', $date_range['start'], $date_range['end'] );
+			$query     .= ' END';
 			$where      = true;
 		}
 
@@ -652,9 +654,9 @@ class Link_Repository {
 		$order_by = sanitize_text_field( $order_by );
 		switch ( $order_by ) {
 			case self::ORDER_DATE_ASC:
-				// Here we check we have a date as the last entry of checks, if not use a late for last in results.
+				// Guard on the length first - an empty checks array would build the invalid path $[-1], which MySQL rejects.
 				return ' ORDER BY
-  CASE WHEN JSON_EXTRACT(`checks`, CONCAT("$[", JSON_LENGTH(`checks`) - 1, "].date")) IS NULL
+  CASE WHEN JSON_LENGTH(`checks`) = 0
        THEN \'9999-12-31\'
        ELSE JSON_EXTRACT(`checks`, CONCAT("$[", JSON_LENGTH(`checks`) - 1, "].date"))
   END ASC';

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
@@ -83,14 +83,33 @@ class HTTP_Link_Checker_Client implements Link_Checker_Client {
 			'WP-Wayback-Link-Fixer' => IAWMLF_VERSION,
 		);
 
-		// Get the response.
-		$response = wp_safe_remote_get(
-			$query_url,
+		// Memoized for the current request only, so repeat calls for the same url skip the HTTP round trip.
+		static $cache = array();
+
+		$key = wp_json_encode(
 			array(
-				'timeout' => $this->timeout / 1000, // Setting is in ms, WP_Http expects seconds.
+				'url'     => $url,
+				'params'  => $additional_params,
 				'headers' => $headers,
 			)
 		);
+
+		// If key exists in cache, get from cache.
+		if ( isset( $cache[ $key ] ) ) {
+			$response = $cache[ $key ];
+		} else {
+			// Get the response.
+			$response = wp_safe_remote_get(
+				$query_url,
+				array(
+					'timeout' => $this->timeout / 1000, // Setting is in ms, WP_Http expects seconds.
+					'headers' => $headers,
+				)
+			);
+
+			// Set the response in cache.
+			$cache[ $key ] = $response;
+		}
 
 		// If we dont have a valid response, throw exception
 		if ( is_wp_error( $response ) ) {

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Link_Checker_Client.php
@@ -87,7 +87,7 @@ class HTTP_Link_Checker_Client implements Link_Checker_Client {
 		$response = wp_safe_remote_get(
 			$query_url,
 			array(
-				'timeout' => $this->timeout,
+				'timeout' => $this->timeout / 1000, // Setting is in ms, WP_Http expects seconds.
 				'headers' => $headers,
 			)
 		);

--- a/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_Snapshot_Client.php
@@ -170,7 +170,7 @@ class HTTP_Snapshot_Client implements Snapshot_Client {
 		$response = wp_safe_remote_post(
 			esc_url( $snapshot_url ),
 			array(
-				'timeout'   => apply_filters( 'iawmlf_create_snapshot_timeout', 1000 ),
+				'timeout'   => apply_filters( 'iawmlf_create_snapshot_timeout', 5000 ) / 1000, // Filter is in ms, WP_Http expects seconds.
 				'body'      => array( 'url' => $url ),
 				'sslverify' => false,
 				'headers'   => $this->get_headers(),

--- a/tests/Dashboard/Test_Dashboard_Notifications.php
+++ b/tests/Dashboard/Test_Dashboard_Notifications.php
@@ -57,6 +57,26 @@ class Test_Dashboard_Notifications extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Cached account details must be normalised on read, so partial payloads render safely.
+	 *
+	 * @return void
+	 */
+	public function test_cached_account_details_are_normalised_on_read(): void {
+		// A raw API payload, cached, missing most of the expected keys.
+		set_transient( 'iawmlf_account_details', array( 'available' => '5' ), HOUR_IN_SECONDS );
+
+		$this->assertSame(
+			array(
+				'available'            => 5,
+				'daily_captures'       => 0,
+				'daily_captures_limit' => 0,
+				'processing'           => 0,
+			),
+			Dashboard_Notifications::get_account_details()
+		);
+	}
+
+	/**
 	 * @testdox Saving either archive.org key must clear the cached account details.
 	 *
 	 * @return void

--- a/tests/Dashboard/Test_Dashboard_Notifications.php
+++ b/tests/Dashboard/Test_Dashboard_Notifications.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Tests for the Dashboard Notifications.
+ *
+ * @since 1.4.4
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Dashboard_Notifications
+ *
+ * @group Dashboard
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Dashboard;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Dashboard_Notifications;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\System_Client;
+
+/**
+ * Test_Dashboard_Notifications
+ */
+class Test_Dashboard_Notifications extends \WP_UnitTestCase {
+
+	/**
+	 * On tear down, remove the filters and transients.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'iawmlf_system_client' );
+		delete_transient( 'iawmlf_account_details' );
+	}
+
+	/**
+	 * @testdox A failed account details lookup must be cached, not retried on every call. (S064)
+	 *
+	 * @return void
+	 */
+	public function test_failed_account_details_lookup_is_cached(): void {
+		delete_transient( 'iawmlf_account_details' );
+
+		$client = $this->createMock( System_Client::class );
+		$client->expects( $this->once() )
+			->method( 'get_user_stats' )
+			->willReturn( null );
+
+		add_filter( 'iawmlf_system_client', fn() => $client );
+
+		$this->assertNull( Dashboard_Notifications::get_account_details() );
+
+		// The second call must be served from the cached failure - the client must not be asked again.
+		$this->assertNull( Dashboard_Notifications::get_account_details() );
+	}
+}

--- a/tests/Dashboard/Test_Dashboard_Notifications.php
+++ b/tests/Dashboard/Test_Dashboard_Notifications.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Dashboard;
 
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Settings_Page;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Dashboard_Notifications;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\System_Client;
 
@@ -52,5 +54,29 @@ class Test_Dashboard_Notifications extends \WP_UnitTestCase {
 
 		// The second call must be served from the cached failure - the client must not be asked again.
 		$this->assertNull( Dashboard_Notifications::get_account_details() );
+	}
+
+	/**
+	 * @testdox Saving either archive.org key must clear the cached account details.
+	 *
+	 * @return void
+	 */
+	public function test_saving_keys_clears_cached_account_details(): void {
+		( new Settings_Page() )->initialize();
+
+		// First-time save (add_option path).
+		set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
+		update_option( Settings::ARCHIVE_ORG_ACCESS_KEY, 'first-access-key' );
+		$this->assertFalse( get_transient( 'iawmlf_account_details' ), 'A first-time access key save must clear the cached account details.' );
+
+		// Re-save (update_option path).
+		set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
+		update_option( Settings::ARCHIVE_ORG_ACCESS_KEY, 'corrected-access-key' );
+		$this->assertFalse( get_transient( 'iawmlf_account_details' ), 'An access key change must clear the cached account details.' );
+
+		// The secret key clears it too.
+		set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
+		update_option( Settings::ARCHIVE_ORG_SECRET_KEY, 'first-secret-key' );
+		$this->assertFalse( get_transient( 'iawmlf_account_details' ), 'A secret key save must clear the cached account details.' );
 	}
 }

--- a/tests/Event/Test_Event_Controller.php
+++ b/tests/Event/Test_Event_Controller.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Tests for the Event Controller.
+ *
+ * @since 1.4.4
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Event\Event_Controller
+ *
+ * @group Event
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Event;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Event_Controller;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Scan_Posts_Event;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Scan_Own_Posts_Event;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Failed_Event_Garbage_Collection_Event;
+
+/**
+ * Test_Event_Controller
+ */
+class Test_Event_Controller extends \WP_UnitTestCase {
+
+	/**
+	 * On tear down, remove the filters.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'wp_doing_cron' );
+	}
+
+	/**
+	 * @testdox The action scheduler self-checks should not be hooked on front-end requests. (S014)
+	 *
+	 * @return void
+	 */
+	public function test_scheduler_self_checks_not_hooked_on_front_end(): void {
+		remove_all_actions( 'init' );
+		add_filter( 'wp_doing_cron', '__return_false' );
+
+		( new Event_Controller() )->initialize();
+
+		$this->assertFalse( has_action( 'init', array( Scan_Posts_Event::class, 'add_to_action_scheduler' ) ) );
+		$this->assertFalse( has_action( 'init', array( Scan_Own_Posts_Event::class, 'add_to_action_scheduler' ) ) );
+		$this->assertFalse( has_action( 'init', array( Failed_Event_Garbage_Collection_Event::class, 'add_to_action_scheduler' ) ) );
+	}
+
+	/**
+	 * @testdox The action scheduler self-checks should be hooked when running under cron.
+	 *
+	 * @return void
+	 */
+	public function test_scheduler_self_checks_hooked_in_cron(): void {
+		remove_all_actions( 'init' );
+		add_filter( 'wp_doing_cron', '__return_true' );
+
+		( new Event_Controller() )->initialize();
+
+		$this->assertNotFalse( has_action( 'init', array( Scan_Posts_Event::class, 'add_to_action_scheduler' ) ) );
+		$this->assertNotFalse( has_action( 'init', array( Scan_Own_Posts_Event::class, 'add_to_action_scheduler' ) ) );
+		$this->assertNotFalse( has_action( 'init', array( Failed_Event_Garbage_Collection_Event::class, 'add_to_action_scheduler' ) ) );
+	}
+}

--- a/tests/Event/Test_Find_Or_Create_Snapshot.php
+++ b/tests/Event/Test_Find_Or_Create_Snapshot.php
@@ -115,7 +115,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		delete_transient( 'iawmlf_archive_api_online' );
 
 		$repo = new Link_Repository();
-		$link = $repo->upsert( new Link( 'https://example.com' ) );
+		$link = $repo->upsert( new Link( 'https://foc-baseline.example.com' ) );
 
 		$event = new Find_Or_Create_Snapshot_Event();
 		$event->setup();
@@ -141,7 +141,7 @@ class Test_Find_Or_Create_Snapshot extends \WP_UnitTestCase {
 		delete_transient( 'iawmlf_archive_api_online' );
 
 		$repo = new Link_Repository();
-		$link = $repo->upsert( new Link( 'https://example.com' ) );
+		$link = $repo->upsert( new Link( "https://foc-non2xx-{$code}.example.com" ) );
 		$id   = $link->get_id();
 
 		// Capture the state before the event runs.

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -532,4 +532,29 @@ class Test_Link extends \WP_UnitTestCase {
 		// Clear the option.
 		delete_option( Settings::CAST_ARCHIVED_TO_HTTPS );
 	}
+
+	/**
+	 * @testdox The JSON representation should only carry the newest 3 checks, leaving the stored history untouched. (S004)
+	 *
+	 * @return void
+	 */
+	public function test_json_serialize_trims_checks_to_last_three(): void {
+		$link = new Link( 'https://example.com' );
+
+		$link->add_check( 200, '2024-01-01 00:00:00' );
+		$link->add_check( 200, '2024-01-02 00:00:00' );
+		$link->add_check( 200, '2024-01-03 00:00:00' );
+		$link->add_check( 200, '2024-01-04 00:00:00' );
+		$link->add_check( 200, '2024-01-05 00:00:00' );
+
+		$json = $link->jsonSerialize();
+
+		// The stored history is untouched.
+		$this->assertCount( 5, $link->get_checks() );
+
+		// The JSON output holds only the newest 3.
+		$this->assertCount( 3, $json['checks'] );
+		$this->assertSame( '2024-01-03 00:00:00', $json['checks'][0]['date'] );
+		$this->assertSame( '2024-01-05 00:00:00', $json['checks'][2]['date'] );
+	}
 }

--- a/tests/Link/Test_Link_Repository.php
+++ b/tests/Link/Test_Link_Repository.php
@@ -1221,4 +1221,57 @@ class Test_Link_Repository extends \WP_UnitTestCase {
 		$deleted_link = $this->link_repository->find_by_id( $link->get_id() );
 		$this->assertNull( $deleted_link );
 	}
+
+	/**
+	 * @testdox Sorting by date ascending must order checked links oldest first and place never-checked links last. (T071)
+	 *
+	 * @return void
+	 */
+	public function test_order_by_date_asc_handles_never_checked_links(): void {
+		// 3 links with checks, inserted out of date order.
+		$mid = new Link( 'https://t071-checked-mid.example.com' );
+		$mid->add_check( 200, '2022-06-01 00:00:00' );
+		$this->link_repository->upsert( $mid );
+
+		$newest = new Link( 'https://t071-checked-newest.example.com' );
+		$newest->add_check( 200, '2023-06-01 00:00:00' );
+		$this->link_repository->upsert( $newest );
+
+		$oldest = new Link( 'https://t071-checked-oldest.example.com' );
+		$oldest->add_check( 200, '2021-06-01 00:00:00' );
+		$this->link_repository->upsert( $oldest );
+
+		// 2 links never checked (empty checks array).
+		$this->link_repository->upsert( new Link( 'https://t071-unchecked-a.example.com' ) );
+		$this->link_repository->upsert( new Link( 'https://t071-unchecked-b.example.com' ) );
+
+		global $wpdb;
+		$wpdb->last_error = '';
+
+		$links = $this->link_repository->query_links( 10, 1, array(), array(), array(), Link_Repository::ORDER_DATE_ASC );
+
+		$this->assertSame( '', $wpdb->last_error, 'The date-ascending sort must not raise a database error.' );
+		$this->assertCount( 5, $links );
+
+		$hrefs = array_map(
+			function ( $link ) {
+				return $link->get_href();
+			},
+			$links
+		);
+
+		// Checked links first, oldest to newest.
+		$this->assertSame( 'https://t071-checked-oldest.example.com', $hrefs[0] );
+		$this->assertSame( 'https://t071-checked-mid.example.com', $hrefs[1] );
+		$this->assertSame( 'https://t071-checked-newest.example.com', $hrefs[2] );
+
+		// Never-checked links sort last; their order between themselves is not defined.
+		$this->assertEqualsCanonicalizing(
+			array(
+				'https://t071-unchecked-a.example.com',
+				'https://t071-unchecked-b.example.com',
+			),
+			array_slice( $hrefs, 3 )
+		);
+	}
 }

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -215,4 +215,28 @@ public function test_excluded_status_codes( string $status_code, string $expecte
 public function test_status_codes_that_mark_link_as_excluded( string $status_code, bool $expected ): void {
 	$this->assertEquals( $expected, iawmlf_is_excluded_status_code( $status_code ) );
 }
+
+	/**
+	 * @testdox A cached offline answer must be served from the transient, not trigger another API call. (S038)
+	 *
+	 * @return void
+	 */
+	public function test_archive_api_offline_state_is_cached(): void {
+		delete_transient( 'iawmlf_archive_api_online' );
+
+		$client = $this->createMock( \Internet_Archive\Wayback_Machine_Link_Fixer\Wayback_Machine\System_Client::class );
+		$client->expects( $this->once() )
+			->method( 'is_online' )
+			->willReturn( false );
+
+		$filter = fn() => $client;
+		add_filter( 'iawmlf_system_client', $filter );
+
+		$this->assertFalse( iawmlf_is_archive_api_online() );
+		// The second call must be served from the cached 'no' - the client must not be asked again.
+		$this->assertFalse( iawmlf_is_archive_api_online() );
+
+		remove_filter( 'iawmlf_system_client', $filter );
+		delete_transient( 'iawmlf_archive_api_online' );
+	}
 }

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -239,4 +239,18 @@ public function test_status_codes_that_mark_link_as_excluded( string $status_cod
 		remove_filter( 'iawmlf_system_client', $filter );
 		delete_transient( 'iawmlf_archive_api_online' );
 	}
+
+	/**
+	 * @testdox A legacy boolean transient left by the pre-yes/no format must not read as offline.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_boolean_transient_does_not_read_as_offline(): void {
+		// The old format stored a raw boolean under the same key.
+		set_transient( 'iawmlf_archive_api_online', true, HOUR_IN_SECONDS );
+
+		$this->assertTrue( iawmlf_is_archive_api_online(), 'A legacy boolean cache entry must not report the API as offline.' );
+
+		delete_transient( 'iawmlf_archive_api_online' );
+	}
 }

--- a/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
@@ -81,7 +81,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		);
 
 		try{
-			$client->check_single( 'https://example.com' );
+			$client->check_single( 'https://make-request.example.com' );
 		} catch (Service_Offline_Exception $e) {
 			// Show a note to say offline, but dont stop the test.
 			$this->markTestSkipped( 'The service is offline' );
@@ -90,8 +90,8 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		// Check the url starts with https://iabot-api.archive.org/livewebcheck
 		$this->assertStringStartsWith( 'https://iabot-api.archive.org/livewebcheck', $called_url );
 
-		// Check contains url=https://example.com
-		$this->assertStringContainsString( 'url=https://example.com', $called_url );
+		// Check contains url=https://make-request.example.com
+		$this->assertStringContainsString( 'url=https://make-request.example.com', $called_url );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		);
 
 		try{
-			$client->check_single( 'https://example.com', array( 'foo' => 'bar' ) );
+			$client->check_single( 'https://additional-params.example.com', array( 'foo' => 'bar' ) );
 		} catch (Service_Offline_Exception $e) {
 			// Show a note to say offline, but dont stop the test.
 			$this->markTestSkipped( 'The service is offline' );
@@ -128,8 +128,8 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		// Check the url starts with https://iabot-api.archive.org/livewebcheck
 		$this->assertStringStartsWith( 'https://iabot-api.archive.org/livewebcheck', $called_url );
 
-		// Check contains url=https://example.com
-		$this->assertStringContainsString( 'url=https://example.com', $called_url );
+		// Check contains url=https://additional-params.example.com
+		$this->assertStringContainsString( 'url=https://additional-params.example.com', $called_url );
 
 		// Check contains foo=bar
 		$this->assertStringContainsString( 'foo=bar', $called_url );
@@ -167,7 +167,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			3
 		);
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://change-url-base.example.com' );
 
 		// Check we have our custom URL.
 		$this->assertStringStartsWith( 'https://anotherurl.someplace.fakeit', $called_url );
@@ -207,7 +207,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		);
 
 		try{
-			$client->check_single( 'https://example.com' );
+			$client->check_single( 'https://custom-params.example.com' );
 		} catch (Service_Offline_Exception $e) {
 			// Show a note to say offline, but dont stop the test.
 			$this->markTestSkipped( 'The service is offline ' . $e->getMessage() );
@@ -235,7 +235,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Service_Offline_Exception::class );
 		$this->expectExceptionMessage( 'The service is offline. Response:404' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://service-offline.example.com' );
 	}
 
 	/**
@@ -261,7 +261,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Invalid_Response_Exception::class );
 		$this->expectExceptionMessage( 'The response is invalid.' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://invalid-no-code.example.com' );
 	}
 
 	/**
@@ -282,7 +282,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Invalid_Response_Exception::class );
 		$this->expectExceptionMessage( 'The response is invalid.' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://invalid-no-body.example.com' );
 	}
 
 	/**
@@ -305,7 +305,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			)
 		);
 
-		$final = $client->get_final_url( 'https://example.com' );
+		$final = $client->get_final_url( 'https://resolve-final.example.com' );
 
 		$this->assertEquals( 'http://redirect.com', $final );
 	}
@@ -330,9 +330,9 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			)
 		);
 
-		$final = $client->get_final_url( 'https://example.com' );
+		$final = $client->get_final_url( 'https://no-location-key.example.com' );
 
-		$this->assertEquals( 'https://example.com', $final );
+		$this->assertEquals( 'https://no-location-key.example.com', $final );
 	}
 
 	/**
@@ -355,9 +355,9 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			)
 		);
 
-		$final = $client->get_final_url( 'https://example.com' );
+		$final = $client->get_final_url( 'https://location-not-string.example.com' );
 
-		$this->assertEquals( 'https://example.com', $final );
+		$this->assertEquals( 'https://location-not-string.example.com', $final );
 	}
 
 	/**
@@ -380,9 +380,9 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			)
 		);
 
-		$final = $client->get_final_url( 'https://example.com' );
+		$final = $client->get_final_url( 'https://location-empty.example.com' );
 
-		$this->assertEquals( 'https://example.com', $final );
+		$this->assertEquals( 'https://location-empty.example.com', $final );
 	}
 
 	/**
@@ -403,7 +403,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Service_Offline_Exception::class );
 		$this->expectExceptionMessage( 'The service is offline. SomeError' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://wp-error.example.com' );
 	}
 
 	/**
@@ -428,7 +428,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Invalid_Response_Exception::class );
 		$this->expectExceptionMessage( 'The response is invalid.' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://body-not-string.example.com' );
 	}
 
 	/**
@@ -451,7 +451,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			)
 		);
 
-		$code = $client->check_single( 'https://example.com' );
+		$code = $client->check_single( 'https://return-http-code.example.com' );
 
 		$this->assertEquals( 201, $code );
 	}
@@ -479,7 +479,7 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 		$this->expectException( Invalid_Response_Exception::class );
 		$this->expectExceptionMessage( 'The response is invalid' );
 
-		$client->check_single( 'https://example.com' );
+		$client->check_single( 'https://status-not-numeric.example.com' );
 	}
 
 	/**
@@ -502,8 +502,34 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 			3
 		);
 
-		( new HTTP_Link_Checker_Client() )->check_single( 'https://example.com' );
+		( new HTTP_Link_Checker_Client() )->check_single( 'https://timeout-seconds.example.com' );
 
 		$this->assertSame( 5, $captured_timeout );
+	}
+
+	/**
+	 * @testdox Checking a link whose response holds no redirect location should make a single HTTP request, the repeat query being served from the cache. (S012)
+	 *
+	 * @return void
+	 */
+	public function test_check_single_without_redirect_makes_one_request() {
+		$request_count = 0;
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( &$request_count ) {
+				++$request_count;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'status' => 200 ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$code = ( new HTTP_Link_Checker_Client() )->check_single( 'https://iawmlf-cache-test.com' );
+
+		$this->assertSame( 200, $code );
+		$this->assertSame( 1, $request_count );
 	}
 }

--- a/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Link_Checker_Client.php
@@ -481,4 +481,29 @@ class Test_HTTP_Link_Checker_Client extends \WP_UnitTestCase {
 
 		$client->check_single( 'https://example.com' );
 	}
+
+	/**
+	 * @testdox The request timeout must be passed to the HTTP client in seconds - the 5000ms setting converts to 5s. (S001)
+	 *
+	 * @return void
+	 */
+	public function test_timeout_is_passed_to_http_client_in_seconds() {
+		$captured_timeout = null;
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( &$captured_timeout ) {
+				$captured_timeout = $args['timeout'];
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'status' => 200 ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		( new HTTP_Link_Checker_Client() )->check_single( 'https://example.com' );
+
+		$this->assertSame( 5, $captured_timeout );
+	}
 }

--- a/tests/Wayback_Machine/Test_HTTP_Snapshot_Client.php
+++ b/tests/Wayback_Machine/Test_HTTP_Snapshot_Client.php
@@ -531,4 +531,29 @@ class Test_HTTP_Snapshot_Client extends \WP_UnitTestCase {
 		$client = new HTTP_Snapshot_Client();
 		$result = $client->get_snapshot_status( '12345' );
 	}
+
+	/**
+	 * @testdox The create snapshot request timeout must be passed to the HTTP client in seconds - the 5000ms default converts to 5s. (T119)
+	 *
+	 * @return void
+	 */
+	public function test_create_snapshot_timeout_is_passed_in_seconds() {
+		$captured_timeout = null;
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( &$captured_timeout ) {
+				$captured_timeout = $args['timeout'];
+				return array(
+					'body'     => 'spn.watchJob("some id")',
+					'response' => array( 'code' => 200 ),
+				);
+			},
+			10,
+			3
+		);
+
+		( new HTTP_Snapshot_Client() )->create_snapshot( 'http://example.com' );
+
+		$this->assertSame( 5, $captured_timeout );
+	}
 }


### PR DESCRIPTION
Works through the performance/queries/caching audit group in #359. Each item was re-verified against the current code before being fixed or struck; the issue body tracks the per-item outcome.

## Fixed

- **S001 / T119** — the link-checker (5000) and create-snapshot (1000) HTTP timeouts were written as milliseconds but `WP_Http` reads seconds (up to 83 minutes per hung request). The filter surfaces stay in ms; the value is converted to seconds at the point of use, and the create-snapshot default moves to 5000ms (5s).
- **S012** — `check_single()` made two identical livewebcheck requests for a non-redirecting link. `query_url()` now memoises responses for the current request (keyed on url + params + headers), so the repeat query is served from memory. Tests driving the real client use unique URLs per test/provider-case since the cache spans the PHPUnit process.
- **S004** — `jsonSerialize()` inlined the entire unbounded check history into every page twice. The JSON now carries the newest 3 checks; the stored history is untouched.
- **S038** — `iawmlf_is_archive_api_online()` could never serve a cached offline answer (a stored `false` is indistinguishable from a missing transient), so every request re-ran the blocking status call exactly when the API was down. The transient now stores `'yes'`/`'no'`; durations unchanged.
- **S064** — `get_account_details()` only cached success, so sites with missing/invalid archive.org keys made the blocking user-stats request on every dashboard load. Failures now cache a `NO DATA` sentinel for the same hour.
- **S003** — the settings post-search AJAX ran an unbounded `WP_Query` (`posts_per_page => -1`, `SQL_CALC_FOUND_ROWS`, leading-wildcard LIKE) from two typed characters. Now paginated at 100 per page with `no_found_rows`; the dropdown appends further pages via a "Show more" row or scrolling to the end. Verified manually in the browser at a page size of 2.
- **S014** — the three `init` callbacks that self-check the recurring Action Scheduler events each queried the AS table on every request, front end included. Gated to `is_admin() || wp_doing_cron()`; cron ticks still re-heal a lost schedule within minutes.
- **S102** — the settings screen registered 21 settings / 4 sections / 20 fields on every `admin_init` including admin-ajax. Now only on the settings screen render and the `options.php` save (the wizard saves via `update_option()` directly and is unaffected).

## Testing

- `composer test:php` — 400 tests, 1021 assertions, green.
- `composer lint:php` — clean.
- Manual: settings post-search pagination verified in the browser (2-per-page), settings screen render + save paths preserved by the S102 gate.
