### PR TITLE
Audit 1.4.3 — correctness & logic bugs (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Specify how often to recheck each link for validity. Avoid checking too often, a
 
 ![Failure Threshold](./_docs/settings--failure-threshold.png)
 
-Specify the number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 5.
+Specify the number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 3.
 
 
 #### Fixer Option

--- a/README.md
+++ b/README.md
@@ -671,17 +671,6 @@ add_filter( 'iawmlf_routinely_update_wayback_machine_interval', function( int $i
 });
 ```
 
-#### `iawmlf_scan_content`
-
-This filter controls the content a post is scanned for links. By default the post content has its blocks and shortcodes rendered, so links they output are found. The rest of the `the_content` chain is deliberately not applied, as it would pull in links belonging to other plugins (embeds, related posts, ad injectors).
-
-```php
-add_filter( 'iawmlf_scan_content', function( string $rendered, string $raw, int $post_id ): string {
-	// Scan the fully filtered content instead.
-	return apply_filters( 'the_content', $raw );
-}, 10, 3 );
-```
-
 #### `iawmlf_link_exclusions`
 
 This filter enhances the link exclusions defined in admin settings by adding additional exclusions to the link checker.
@@ -742,6 +731,17 @@ add_filter( 'iawmlf_is_production_environment', function( bool $is_production ):
 #### Configuration Filters
 
 These filters control various aspects of plugin behavior and performance.
+
+#### `iawmlf_scan_content`
+
+This filter controls the content a post is scanned for links. By default the post content has its blocks and shortcodes rendered, so links they output are found. The rest of the `the_content` chain is deliberately not applied, as it would pull in links belonging to other plugins (embeds, related posts, ad injectors).
+
+```php
+add_filter( 'iawmlf_scan_content', function( string $rendered, string $raw, int $post_id ): string {
+	// Scan the fully filtered content instead.
+	return apply_filters( 'the_content', $raw );
+}, 10, 3 );
+```
 
 #### `iawmlf_link_checker_timeout`
 

--- a/README.md
+++ b/README.md
@@ -671,6 +671,17 @@ add_filter( 'iawmlf_routinely_update_wayback_machine_interval', function( int $i
 });
 ```
 
+#### `iawmlf_scan_content`
+
+This filter controls the content a post is scanned for links. By default the post content has its blocks and shortcodes rendered, so links they output are found. The rest of the `the_content` chain is deliberately not applied, as it would pull in links belonging to other plugins (embeds, related posts, ad injectors).
+
+```php
+add_filter( 'iawmlf_scan_content', function( string $rendered, string $raw, int $post_id ): string {
+	// Scan the fully filtered content instead.
+	return apply_filters( 'the_content', $raw );
+}, 10, 3 );
+```
+
 #### `iawmlf_link_exclusions`
 
 This filter enhances the link exclusions defined in admin settings by adding additional exclusions to the link checker.

--- a/README.md
+++ b/README.md
@@ -663,11 +663,11 @@ add_filter( 'iawmlf_routinely_update_wayback_machine', function( bool $routinely
 
 #### `iawmlf_routinely_update_wayback_machine_interval`
 
-This filter overrides the admin setting that controls how long between each routine update. The default is 14 days. The time is given in seconds.
+This filter overrides the admin setting that controls how long between each routine update. The value is given in days, with a minimum of 1 day. The default is 28 days — any value below 1 falls back to the default.
 
 ```php
 add_filter( 'iawmlf_routinely_update_wayback_machine_interval', function( int $interval ): int {
-	return 7 * \DAY_IN_SECONDS; // 7 days
+	return 7; // 7 days
 });
 ```
 

--- a/functions.php
+++ b/functions.php
@@ -357,6 +357,9 @@ function iawmlf_is_archive_link( string $url ): bool {
 		'http://web-wp.archive.org/web/',
 	);
 
+	// The compared region is scheme + host, which are case-insensitive.
+	$url = strtolower( $url );
+
 	foreach ( $urls as $archive_url ) {
 		if ( 0 === strpos( $url, $archive_url ) ) {
 			return true;

--- a/functions.php
+++ b/functions.php
@@ -421,6 +421,18 @@ function iawmlf_normalize_url( string $url ): string {
 	// URL Encode the url parameters.
 	$url_parts = wp_parse_url( $url );
 
+	// Punycode an international host. WordPress bundles the encoder, so intl is not required.
+	if ( isset( $url_parts['host'] )
+		&& 1 === preg_match( '/[^\x20-\x7e]/', $url_parts['host'] )
+		&& class_exists( '\WpOrg\Requests\IdnaEncoder' )
+	) {
+		try {
+			$url_parts['host'] = \WpOrg\Requests\IdnaEncoder::encode( $url_parts['host'] );
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Leave the host as written; the URL just fails validation downstream.
+		}
+	}
+
 	// If we have a path, encode it.
 	if ( isset( $url_parts['path'] ) ) {
 		// Decode first to avoid double-encoding, then re-encode

--- a/functions.php
+++ b/functions.php
@@ -383,11 +383,11 @@ function iawmlf_is_current_site_link( string $url ): bool {
 		get_site_url( null, '', 'https' ),
 		get_site_url( null, '', 'http' ),
 	);
-	// Normalize the URL.
-	$normalized_url = iawmlf_normalize_url( $url );
+	// Normalize the URL, lowercased - the compared region is scheme + host.
+	$normalized_url = strtolower( iawmlf_normalize_url( $url ) );
 
 	// Noprmalize the site URLs.
-	$site_urls = array_map( 'iawmlf_normalize_url', $site_urls );
+	$site_urls = array_map( fn( string $site_url ): string => strtolower( iawmlf_normalize_url( $site_url ) ), $site_urls );
 
 	// Check if the URL starts with any of the site URLs, with a boundary so lookalike domains don't match.
 	foreach ( $site_urls as $site_url ) {

--- a/src/Ajax/Post_Search_Ajax.php
+++ b/src/Ajax/Post_Search_Ajax.php
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Ajax;
 
 use Exception;
+use Throwable;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -65,7 +66,7 @@ class Post_Search_Ajax {
 		// Validate the request.
 		try {
 			$this->validate_request();
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			$this->send_error( $e->getMessage(), 403 );
 		}
 

--- a/src/Dashboard/Dashboard_Notifications.php
+++ b/src/Dashboard/Dashboard_Notifications.php
@@ -139,7 +139,7 @@ class Dashboard_Notifications {
 				set_transient( 'iawmlf_account_details', $details, HOUR_IN_SECONDS );
 				return self::normalize_account_details( $details );
 			}
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			// Cache the failure so its not retried on every call.
 			set_transient( 'iawmlf_account_details', 'NO DATA', HOUR_IN_SECONDS );
 			return null;

--- a/src/Dashboard/Dashboard_Statistics.php
+++ b/src/Dashboard/Dashboard_Statistics.php
@@ -289,15 +289,9 @@ class Dashboard_Statistics {
 		$meta_query = array();
 		if ( ! $all ) {
 			$meta_query = array(
-				'relation' => 'OR',
 				array(
 					'key'     => Settings::LINK_META_KEY,
 					'compare' => 'NOT EXISTS',
-				),
-				array(
-					'key'     => Settings::LINK_META_KEY,
-					'value'   => time(),
-					'compare' => '=',
 				),
 			);
 		}

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -416,10 +416,9 @@ class Report_Page {
 		$exclude = isset( $_POST['iawmlf_exclude_link'] );
 
 		if ( $exclude ) {
-			$link->set_excluded( true );
-
-			// Set message if not already set.
-			if ( '' === $link->get_message() ) {
+			// On the transition into excluded, always write the marker - it is how
+			// background events tell a manual exclusion from a system one.
+			if ( ! $link->is_excluded() ) {
 				$user = wp_get_current_user();
 				$link->set_message(
 					sprintf(
@@ -429,6 +428,8 @@ class Report_Page {
 					)
 				);
 			}
+
+			$link->set_excluded( true );
 		} else {
 			$link->set_excluded( false );
 

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -412,8 +412,9 @@ class Report_Page {
 			return;
 		}
 
-		// Determine the exclusion state from the checkbox.
-		$exclude = isset( $_POST['iawmlf_exclude_link'] );
+		// Determine the exclusion state from the checkbox value - the pattern-excluded
+		// form submits a hidden copy carrying the DB flag, so presence alone means nothing.
+		$exclude = ! empty( $_POST['iawmlf_exclude_link'] );
 
 		if ( $exclude ) {
 			// On the transition into excluded, always write the marker - it is how

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -284,6 +284,11 @@ class Report_Page {
 	 * @return void
 	 */
 	public function handle_bulk_actions(): void {
+		// The single link view has no bulk actions, and load-{hook} fires for it too.
+		if ( isset( $_GET['iawmlf_link_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
+			return;
+		}
+
 		$this->table = new Report_Table( new Link_Repository() );
 		$this->table->process_bulk_action();
 	}

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -43,6 +43,13 @@ class Report_Page {
 	private $hook;
 
 	/**
+	 * The list table, created on load-{hook} so bulk-action notices survive into the render.
+	 *
+	 * @var Report_Table|null
+	 */
+	private $table;
+
+	/**
 	 * Creates a new instance of the report page.
 	 */
 	public function __construct() {
@@ -102,6 +109,9 @@ class Report_Page {
 
 		// Handle the link details form submission.
 		add_action( "load-$hook", array( $this, 'handle_link_details_form' ) );
+
+		// Process bulk actions before any output, so a real redirect can be issued.
+		add_action( "load-$hook", array( $this, 'handle_bulk_actions' ) );
 
 		// Add the screen options.
 		add_action( "load-$hook", array( $this, 'register_screen_options' ) );
@@ -269,6 +279,16 @@ class Report_Page {
 	}
 
 	/**
+	 * Process the list table bulk actions on load-{hook}, before any output.
+	 *
+	 * @return void
+	 */
+	public function handle_bulk_actions(): void {
+		$this->table = new Report_Table( new Link_Repository() );
+		$this->table->process_bulk_action();
+	}
+
+	/**
 	 * Render the report list page.
 	 *
 	 * @since 1.2.0
@@ -276,11 +296,8 @@ class Report_Page {
 	 * @return void
 	 */
 	private function render_list_page(): void {
-		// Render the list table.
-		$table = new Report_Table( new Link_Repository() );
-
-		// Run the bulk actions.
-		$table->process_bulk_action();
+		// Render the list table, reusing the load-{hook} instance so its notices render.
+		$table = $this->table ?? new Report_Table( new Link_Repository() );
 
 		// Render any notices.
 		$table->render_notices();

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -74,7 +74,7 @@ class Report_Page {
 		add_filter(
 			'set-screen-option',
 			function ( $status, $option, $value ) {
-				return ( 'links_per_page' === $option ) ? (int) $value : $status;
+				return ( 'links_per_page' === $option ) ? max( 1, (int) $value ) : $status;
 			},
 			10,
 			3

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -370,9 +370,9 @@ class Settings_Page {
 				'type'              => 'integer',
 				'sanitize_callback' => function ( $value ) {
 					$value = absint( $value );
-					return 0 === $value ? 5 : $value;
+					return 0 === $value ? 3 : $value;
 				},
-				'default'           => 5,
+				'default'           => 3,
 				'show_in_rest'      => array(
 					'name'   => Settings::MINIMUM_CHECKS_BEFORE_BROKEN,
 					'schema' => array(
@@ -389,9 +389,9 @@ class Settings_Page {
 				'type'              => 'integer',
 				'sanitize_callback' => function ( $value ) {
 					$value = absint( $value );
-					return 0 === $value ? 7 : $value;
+					return 0 === $value ? 3 : $value;
 				},
-				'default'           => 7,
+				'default'           => 3,
 				'show_in_rest'      => array(
 					'name'   => Settings::LINK_CHECK_DURATION_IN_DAYS,
 					'schema' => array(
@@ -1301,7 +1301,7 @@ class Settings_Page {
 			data-group="link_fixer"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'How often to recheck each link for validity. Avoid checking too often, as temporary outages or maintenance can cause false “broken” results. The default is 7 days.', 'internet-archive-wayback-machine-link-fixer' ); ?>
+			<?php esc_html_e( 'How often to recheck each link for validity. Avoid checking too often, as temporary outages or maintenance can cause false “broken” results. The default is 3 days.', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</p>
 		<?php
 	}
@@ -1325,7 +1325,7 @@ class Settings_Page {
 			data-group="link_fixer"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 5.', 'internet-archive-wayback-machine-link-fixer' ); ?>
+			<?php esc_html_e( 'Number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 3.', 'internet-archive-wayback-machine-link-fixer' ); ?>
 		</p>
 		<?php
 	}

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -284,8 +284,8 @@ class Setup_Wizard {
 		$index    = array_keys( $steps );
 		$previous = array_search( $current_step, $index, true ) - 1;
 
-		// Update the step.
-		$previous_step = $index[ $previous ];
+		// An unrecognised step falls back to step-1.
+		$previous_step = $index[ $previous ] ?? 'step-1';
 		Settings::update_setup_wizard_step( $previous_step );
 	}
 

--- a/src/Dashboard/Setup_Wizard.php
+++ b/src/Dashboard/Setup_Wizard.php
@@ -120,6 +120,11 @@ class Setup_Wizard {
 			return;
 		}
 
+		// Never abort an in-flight form submission - the redirect catches the next page view.
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) ) {
+			return;
+		}
+
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}

--- a/src/Event/Scan_Own_Posts_Event.php
+++ b/src/Event/Scan_Own_Posts_Event.php
@@ -100,11 +100,8 @@ class Scan_Own_Posts_Event {
 		// Run setup.
 		$this->setup();
 
-		$allowed_delay = Settings::own_link_routine_update_interval();
-		// Cast delay to seconds.
-		$allowed_delay = 0 === $allowed_delay
-			? 0
-			: $allowed_delay * DAY_IN_SECONDS;
+		// Cast delay to seconds (the setting is in days, min 1).
+		$allowed_delay = Settings::own_link_routine_update_interval() * DAY_IN_SECONDS;
 
 		$allowed_post_types = Settings::own_link_allowed_post_types();
 		$excluded_posts     = Settings::get_auto_archiver_excluded_posts();

--- a/src/Event/Scan_Posts_Event.php
+++ b/src/Event/Scan_Posts_Event.php
@@ -147,15 +147,9 @@ class Scan_Posts_Event {
 				'update_post_meta_cache' => false,
 				'post__not_in'           => Settings::get_link_fixer_excluded_posts(),
 				'meta_query'             => array(
-					'relation' => 'OR',
 					array(
 						'key'     => Settings::LINK_META_KEY,
 						'compare' => 'NOT EXISTS',
-					),
-					array(
-						'key'     => Settings::LINK_META_KEY,
-						'value'   => time(),
-						'compare' => '=',
 					),
 				),
 			)

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -282,14 +282,11 @@ class Link implements \JsonSerializable {
 	 * @return string
 	 */
 	public function get_archived_href(): ?string {
-		$archived_href = $this->archived_href;
+		$archived_href = $this->get_stored_archived_href();
 
 		if ( null === $archived_href || '' === $archived_href ) {
 			return $archived_href;
 		}
-
-		// If the url starts http(s)://web.archive.org/web/, replace it with http(s)://web-wp.archive.org/web/
-		$archived_href = preg_replace( '#^http(s?)://web\.archive\.org/web/#i', 'http$1://web-wp.archive.org/web/', $archived_href );
 
 		// If the setting to cast to https is enabled, cast the start of the url to https.
 		if ( Settings::should_cast_archived_to_https() ) {
@@ -298,6 +295,25 @@ class Link implements \JsonSerializable {
 		}
 
 		return $archived_href;
+	}
+
+	/**
+	 * Get the archived href as it should be stored.
+	 *
+	 * The host rewrite is canonical and persisted, but the https cast is a display
+	 * setting and must never be written to the database - it would outlive the setting.
+	 *
+	 * @return string|null
+	 */
+	public function get_stored_archived_href(): ?string {
+		$archived_href = $this->archived_href;
+
+		if ( null === $archived_href || '' === $archived_href ) {
+			return $archived_href;
+		}
+
+		// If the url starts http(s)://web.archive.org/web/, replace it with http(s)://web-wp.archive.org/web/
+		return preg_replace( '#^http(s?)://web\.archive\.org/web/#i', 'http$1://web-wp.archive.org/web/', $archived_href );
 	}
 
 

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -289,12 +289,7 @@ class Link implements \JsonSerializable {
 		}
 
 		// If the url starts http(s)://web.archive.org/web/, replace it with http(s)://web-wp.archive.org/web/
-		if ( 0 === strpos( $archived_href, 'https://web.archive.org/web/' ) ) {
-			$archived_href = str_replace( 'https://web.archive.org/web/', 'https://web-wp.archive.org/web/', $archived_href );
-		}
-		if ( 0 === strpos( $archived_href, 'http://web.archive.org/web/' ) ) {
-			$archived_href = str_replace( 'http://web.archive.org/web/', 'http://web-wp.archive.org/web/', $archived_href );
-		}
+		$archived_href = preg_replace( '#^http(s?)://web\.archive\.org/web/#i', 'http$1://web-wp.archive.org/web/', $archived_href );
 
 		// If the setting to cast to https is enabled, cast the start of the url to https.
 		if ( Settings::should_cast_archived_to_https() ) {

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Link;
 
 use DateTime;
+use DateTimeZone;
+use DateTimeImmutable;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -534,8 +536,35 @@ class Link implements \JsonSerializable {
 			'redirect_href' => $this->redirect_href,
 			'checks'        => array_slice( $this->checks, -3 ), // Newest 3 only, the full history is not needed client side.
 			'broken'        => $this->is_broken,
-			'last_checked'  => $this->get_last_check(),
+			'last_checked'  => self::serialize_check( $this->get_last_check() ),
 			'process'       => $this->archive_process,
 		);
+	}
+
+	/**
+	 * Format a check for the client, with the date as an unambiguous UTC timestamp.
+	 *
+	 * Check dates are stored as UTC in 'Y-m-d H:i:s', which browsers read as local time.
+	 * Only last_checked is consumed client side, so only it is converted.
+	 *
+	 * @param array|null $check The check to format.
+	 *
+	 * @return array|null
+	 */
+	private static function serialize_check( ?array $check ): ?array {
+		if ( null === $check || ! isset( $check['date'] ) ) {
+			return $check;
+		}
+
+		$date = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', (string) $check['date'], new DateTimeZone( 'UTC' ) );
+
+		// A malformed date is passed through rather than fataling the payload.
+		if ( false === $date ) {
+			return $check;
+		}
+
+		$check['date'] = $date->format( DATE_ATOM );
+
+		return $check;
 	}
 }

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -315,7 +315,10 @@ class Link implements \JsonSerializable {
 		}
 
 		// If the url starts http(s)://web.archive.org/web/, replace it with http(s)://web-wp.archive.org/web/
-		return preg_replace( '#^http(s?)://web\.archive\.org/web/#i', 'http$1://web-wp.archive.org/web/', $archived_href );
+		// Lowercase literals, not a backreference - a captured 'S' would give an unusable 'httpS://' scheme.
+		$archived_href = preg_replace( '#^https://web\.archive\.org/web/#i', 'https://web-wp.archive.org/web/', $archived_href );
+
+		return preg_replace( '#^http://web\.archive\.org/web/#i', 'http://web-wp.archive.org/web/', $archived_href );
 	}
 
 

--- a/src/Link/Link_Exclusion.php
+++ b/src/Link/Link_Exclusion.php
@@ -76,8 +76,10 @@ class Link_Exclusion {
 	 * @return boolean
 	 */
 	public function is_globally_excluded( Link $link ): bool {
+		$href = self::canonical_href( $link->get_href() );
+
 		foreach ( $this->bundled as $pattern ) {
-			if ( fnmatch( strtolower( $pattern ), strtolower( $link->get_href() ) ) ) {
+			if ( fnmatch( $pattern, $href ) ) {
 				return true;
 			}
 		}
@@ -93,13 +95,39 @@ class Link_Exclusion {
 	 * @return boolean
 	 */
 	public function is_settings_excluded( Link $link ): bool {
+		$href = self::canonical_href( $link->get_href() );
+
 		foreach ( $this->settings as $pattern ) {
-			if ( fnmatch( strtolower( $pattern ), strtolower( $link->get_href() ) ) ) {
+			if ( fnmatch( $pattern, $href ) ) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Lowercase the scheme and host of a URL, leaving the rest untouched.
+	 *
+	 * Scheme and host are case-insensitive, so this is canonicalisation. The path and
+	 * query are case-sensitive, so lowercasing those would widen what a pattern matches.
+	 *
+	 * @param string $href The URL to canonicalise.
+	 *
+	 * @return string
+	 */
+	private static function canonical_href( string $href ): string {
+		$parts = wp_parse_url( $href );
+
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) || empty( $parts['scheme'] ) ) {
+			return $href;
+		}
+
+		$prefix = $parts['scheme'] . '://' . $parts['host'];
+
+		return 0 === strpos( $href, $prefix )
+			? strtolower( $prefix ) . substr( $href, strlen( $prefix ) )
+			: $href;
 	}
 
 	/**

--- a/src/Link/Link_Exclusion.php
+++ b/src/Link/Link_Exclusion.php
@@ -77,7 +77,7 @@ class Link_Exclusion {
 	 */
 	public function is_globally_excluded( Link $link ): bool {
 		foreach ( $this->bundled as $pattern ) {
-			if ( fnmatch( $pattern, $link->get_href() ) ) {
+			if ( fnmatch( strtolower( $pattern ), strtolower( $link->get_href() ) ) ) {
 				return true;
 			}
 		}
@@ -94,7 +94,7 @@ class Link_Exclusion {
 	 */
 	public function is_settings_excluded( Link $link ): bool {
 		foreach ( $this->settings as $pattern ) {
-			if ( fnmatch( $pattern, $link->get_href() ) ) {
+			if ( fnmatch( strtolower( $pattern ), strtolower( $link->get_href() ) ) ) {
 				return true;
 			}
 		}

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -627,18 +627,15 @@ class Link_Repository {
 	 * @return array
 	 */
 	private function get_date_range( string $date ): array {
-		// Create DateTime object from 'yyyy-mm' date.
-		$date = new DateTime( $date );
+		// The month boundaries in the site timezone, converted to UTC to match the stored check dates.
+		$start = new DateTime( $date . '-01 00:00:00', wp_timezone() );
+		$end   = ( clone $start )->modify( 'last day of this month' )->setTime( 23, 59, 59 );
 
-		// Get the start of the month.
-		$start = $date->format( 'Y-m-01' );
-
-		// Get the end of the month.
-		$end = $date->format( 'Y-m-t' );
+		$utc = new \DateTimeZone( 'UTC' );
 
 		return array(
-			'start' => esc_attr( $start ),
-			'end'   => esc_attr( $end ),
+			'start' => $start->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'end'   => $end->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
 		);
 	}
 

--- a/src/Link/Link_Repository.php
+++ b/src/Link/Link_Repository.php
@@ -155,7 +155,7 @@ class Link_Repository {
 	private function insert( Link $link ): Link {
 		// Extract the values.
 		$href            = $link->get_href();
-		$archived_href   = $link->get_archived_href();
+		$archived_href   = $link->get_stored_archived_href();
 		$checks          = $link->get_checks();
 		$redirect_href   = $link->get_redirect_href();
 		$is_broken       = $link->is_broken();
@@ -216,7 +216,7 @@ class Link_Repository {
 		// Extract the values.
 		$id              = $link->get_id();
 		$href            = $link->get_href();
-		$archived_href   = $link->get_archived_href();
+		$archived_href   = $link->get_stored_archived_href();
 		$checks          = $link->get_checks();
 		$redirect_href   = $link->get_redirect_href();
 		$is_broken       = $link->is_broken();

--- a/src/Processor/Content_Scanner.php
+++ b/src/Processor/Content_Scanner.php
@@ -44,6 +44,24 @@ class Content_Scanner {
 	}
 
 	/**
+	 * Whether a scan is currently rendering content.
+	 *
+	 * @var boolean
+	 */
+	private static $rendering = false;
+
+	/**
+	 * Is a scan currently rendering content?
+	 *
+	 * Lets display-time output (the link payload span) opt out of a scan render.
+	 *
+	 * @return boolean
+	 */
+	public static function is_rendering(): bool {
+		return self::$rendering;
+	}
+
+	/**
 	 * Creates a new instance of the post scanner for a given post id.
 	 *
 	 * @param integer $post_id The post id.
@@ -51,8 +69,36 @@ class Content_Scanner {
 	 * @return self
 	 */
 	public static function for_post( int $post_id ): self {
-		$content = get_post_field( 'post_content', $post_id );
-		return new self( $content );
+		$content = (string) get_post_field( 'post_content', $post_id );
+
+		return new self( self::render_content( $content, $post_id ) );
+	}
+
+	/**
+	 * Render blocks and shortcodes so the links they output are visible to the scan.
+	 *
+	 * The full the_content chain is deliberately not applied - it would pull in links
+	 * belonging to other plugins (embeds, related posts, ad injectors). Use the
+	 * iawmlf_scan_content filter to widen or replace this.
+	 *
+	 * @param string  $content The raw post content.
+	 * @param integer $post_id The post id.
+	 *
+	 * @return string
+	 */
+	private static function render_content( string $content, int $post_id ): string {
+		self::$rendering = true;
+
+		// Buffered, so a shortcode that echoes its output is scanned too.
+		ob_start();
+		try {
+			$rendered = do_shortcode( do_blocks( $content ) );
+		} finally {
+			$echoed          = (string) ob_get_clean();
+			self::$rendering = false;
+		}
+
+		return (string) apply_filters( 'iawmlf_scan_content', $rendered . $echoed, $content, $post_id );
 	}
 
 	/**

--- a/src/Processor/Content_Scanner.php
+++ b/src/Processor/Content_Scanner.php
@@ -93,6 +93,9 @@ class Content_Scanner {
 		ob_start();
 		try {
 			$rendered = do_shortcode( do_blocks( $content ) );
+		} catch ( \Throwable $e ) {
+			// Third party render callbacks run here - a failing one must not break the save or the scan batch.
+			$rendered = $content;
 		} finally {
 			$echoed          = (string) ob_get_clean();
 			self::$rendering = false;

--- a/src/Processor/Content_Scanner.php
+++ b/src/Processor/Content_Scanner.php
@@ -80,6 +80,13 @@ class Content_Scanner {
 			// If this is a valid url, add it to the collection.
 			if ( filter_var( $href, FILTER_VALIDATE_URL ) ) {
 				$this->links[] = $href;
+				continue;
+			}
+
+			// International URLs (non-ASCII host, path or query) fail the raw check, so retry encoded.
+			$encoded = iawmlf_normalize_url( $href );
+			if ( filter_var( $encoded, FILTER_VALIDATE_URL ) ) {
+				$this->links[] = $encoded;
 			}
 		}
 

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -387,13 +387,16 @@ class Report_Table extends \WP_List_Table {
 				continue;
 			}
 
+			// Show the raw value if the date does not parse, rather than fatal.
+			$last_check_date = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] );
+
 			// Add a success notice.
 			$this->notices[] = array(
 				'message' => sprintf(
 					// translators: %1$s is the link url, %2$s is the last check date, %3$s is the last check http code.
 					__( 'Link %1$s checked successfully on %2$s with %3$s status', 'internet-archive-wayback-machine-link-fixer' ),
 					esc_html( iawmlf_trim_string( $link_url, 54 ) ),
-					DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )->format( get_option( 'date_format' ) ),
+					$last_check_date ? $last_check_date->format( get_option( 'date_format' ) ) : esc_html( $last_check['date'] ),
 					esc_html( $last_check['http_code'] )
 				),
 				'type'    => 'success',
@@ -1235,12 +1238,17 @@ class Report_Table extends \WP_List_Table {
 			)
 			: __( 'No HTTP Code', 'internet-archive-wayback-machine-link-fixer' );
 
+		// Show the raw value if the date does not parse, rather than fatal.
+		$last_check_date = $last_check['date']
+			? DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )
+			: false;
+
 		return sprintf(
 			// translators: %1$s: last check date (e.g. "5 Jan 2025"), %2$s: HTTP status code (e.g. "404 status")
 			__( '%1$s with %2$s', 'internet-archive-wayback-machine-link-fixer' ),
-			$last_check['date']
-				? DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $last_check['date'] )->format( get_option( 'date_format' ) )
-				: __( 'Missing date', 'internet-archive-wayback-machine-link-fixer' ),
+			$last_check_date
+				? $last_check_date->format( get_option( 'date_format' ) )
+				: ( $last_check['date'] ? $last_check['date'] : __( 'Missing date', 'internet-archive-wayback-machine-link-fixer' ) ),
 			$last_check
 				? $last_status_display
 				: __( 'No HTTP Code', 'internet-archive-wayback-machine-link-fixer' )

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -173,7 +173,7 @@ class Report_Table extends \WP_List_Table {
 		$from_meta = get_user_meta( get_current_user_id(), $option['option'], true );
 
 		return is_numeric( $from_meta )
-			? absint( $from_meta )
+			? max( 1, absint( $from_meta ) )
 			: absint( $option['default'] );
 	}
 

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -289,8 +289,8 @@ class Report_Table extends \WP_List_Table {
 
 		$url = $this->get_redirect_action_url( $cache_key );
 
-		// Redirect to the page using JS as page already loaded headers.
-		printf( '<script>window.location = %s;</script>', wp_json_encode( $url ) );
+		// Runs on load-{hook}, before any output, so a real redirect is possible.
+		wp_safe_redirect( $url );
 		exit;
 	}
 

--- a/src/Rest/Link_Check_Rest.php
+++ b/src/Rest/Link_Check_Rest.php
@@ -11,7 +11,7 @@ declare( strict_types = 1 );
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Rest;
 
 use DateTime;
-use Exception;
+use Throwable;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
@@ -169,7 +169,7 @@ class Link_Check_Rest {
 		// Get the current status.
 		try {
 			$status = $this->link_checker->check_single( $link->get_href() );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			return new WP_Error(
 				'link_check_failed',
 				$e->getMessage(),

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -12,7 +12,6 @@ namespace Internet_Archive\Wayback_Machine_Link_Fixer\Settings;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Util\Environmental;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Migration\Abstract_Migration;
-use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Check_Archive_Services_Online_Event;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -342,25 +341,6 @@ class Settings {
 	 */
 	public static function is_archive_api_online(): bool {
 		return iawmlf_is_archive_api_online();
-	}
-
-	/**
-	 * Get the archive api extended status.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @return array|null
-	 */
-	public static function get_archive_api_status(): ?array {
-		$status = get_transient( self::ARCHIVE_ORG_STATUS_KEY );
-
-		// If we dont have a status, trigger a check.
-		if ( false === $status ) {
-			Check_Archive_Services_Online_Event::add_to_queue();
-			return null;
-		}
-
-		return is_array( $status ) ? $status : null;
 	}
 
 	/**

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -179,7 +179,7 @@ class WP_Post_Controller {
 		$links          = $post_processor->process();
 
 		// Remove any excluded links.
-		$links = Link_Exclusion::get_instance()->filter_excluded( $links );
+		$links = Link_Exclusion::get_instance()->filter_excluded( $links, $post_id );
 
 		// Update the link meta.
 		$this->update_link_meta( $post_id, $links );

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -20,6 +20,7 @@ use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Exclusion;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Rest\Link_Check_Rest;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Link\Link_Repository;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Processor\Post_Processor;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Processor\Content_Scanner;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Process_Local_Post_Event;
 
 defined( 'ABSPATH' ) || exit;
@@ -284,6 +285,11 @@ class WP_Post_Controller {
 	 * @return string
 	 */
 	public function render_block( string $block_content, array $block ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// A scan renders blocks to find links - the payload span has no place in that.
+		if ( Content_Scanner::is_rendering() ) {
+			return $block_content;
+		}
+
 		if ( ! Settings::should_render_html_link_output() ) {
 			return $block_content;
 		}

--- a/src/Wayback_Machine/HTTP_Client/HTTP_System_Client.php
+++ b/src/Wayback_Machine/HTTP_Client/HTTP_System_Client.php
@@ -95,7 +95,7 @@ class HTTP_System_Client implements System_Client {
 
 		try {
 			$response = wp_safe_remote_get( $url, array( 'headers' => $headers ) );
-		} catch ( \Exception $e ) {
+		} catch ( Throwable $e ) {
 			throw Invalid_Response_Exception::create( esc_html( $e->getMessage() ) );
 		}
 		if ( is_wp_error( $response ) ) {

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -205,11 +205,14 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 													<a href="<?php echo esc_url( get_edit_post_link( $iawmlf_post->ID ) ); ?>">
 														<?php if ( '' === $iawmlf_post->post_title ) : ?>
 															<?php
+															$iawmlf_post_type_object = get_post_type_object( $iawmlf_post->post_type );
 															printf(
 																// Translators: %1$s is the post ID, %2$s is the post type label (e.g., "Post", "Page").
 																esc_html__( 'Untitled %2$s (ID: %1$d)', 'internet-archive-wayback-machine-link-fixer' ),
 																absint( $iawmlf_post->ID ),
-																esc_html( get_post_type_object( $iawmlf_post->post_type )->labels->singular_name )
+																$iawmlf_post_type_object
+																	? esc_html( $iawmlf_post_type_object->labels->singular_name )
+																	: esc_html__( 'Unknown', 'internet-archive-wayback-machine-link-fixer' )
 															);
 															?>
 														<?php else : ?>

--- a/tests/Dashboard/Test_Report_Page.php
+++ b/tests/Dashboard/Test_Report_Page.php
@@ -148,6 +148,29 @@ class Test_Report_Page extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A manual exclusion must carry the user marker even when the link already had a system message, so background events cannot lift it. (S053)
+	 *
+	 * @return void
+	 */
+	public function test_manual_exclusion_with_existing_message_is_marked_as_manual(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// A link with a leftover system message, not yet excluded.
+		$link = new Link( 'https://example.com/s053-existing-message' );
+		$link->set_message( 'Redirected. SomeSystemError' );
+		$link = $this->link_repository->upsert( $link );
+
+		$_POST['iawmlf_exclude_link'] = '1';
+		$this->submit_link_details_form( $link->get_id() );
+		unset( $_POST['iawmlf_exclude_link'] );
+
+		$saved = $this->link_repository->find_by_id( $link->get_id() );
+
+		$this->assertTrue( $saved->is_excluded() );
+		$this->assertTrue( $saved->is_manual_exclusion(), 'The exclusion must be recognised as manual despite the pre-existing message.' );
+	}
+
+	/**
 	 * @testdox The default filter value should include the updated flag.
 	 *
 	 * @return void

--- a/tests/Dashboard/Test_Report_Page.php
+++ b/tests/Dashboard/Test_Report_Page.php
@@ -191,6 +191,22 @@ class Test_Report_Page extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Bulk action processing must be hooked to load-{hook}, before any output. (S056)
+	 *
+	 * @return void
+	 */
+	public function test_bulk_actions_are_processed_on_load_hook(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$page = new Report_Page();
+		$page->register_page();
+
+		$hook = get_plugin_page_hookname( 'iawmlf-links', \Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Dashboard_Page::DASHBOARD_SLUG );
+
+		$this->assertNotFalse( has_action( "load-$hook", array( $page, 'handle_bulk_actions' ) ) );
+	}
+
+	/**
 	 * @testdox The default filter value should include the updated flag.
 	 *
 	 * @return void

--- a/tests/Dashboard/Test_Report_Page.php
+++ b/tests/Dashboard/Test_Report_Page.php
@@ -171,6 +171,26 @@ class Test_Report_Page extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Saving the details form of a pattern-excluded link must not flip its database exclusion flag. (S054)
+	 *
+	 * @return void
+	 */
+	public function test_saving_pattern_excluded_link_does_not_set_db_flag(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$link = $this->link_repository->upsert( new Link( 'https://pattern-excluded.example.com/s054' ) );
+
+		// The template renders a hidden iawmlf_exclude_link carrying the DB flag - empty when not excluded.
+		$_POST['iawmlf_exclude_link'] = '';
+		$this->submit_link_details_form( $link->get_id() );
+		unset( $_POST['iawmlf_exclude_link'] );
+
+		$saved = $this->link_repository->find_by_id( $link->get_id() );
+
+		$this->assertFalse( $saved->is_excluded(), 'Saving the form must not flip the exclusion flag on.' );
+	}
+
+	/**
 	 * @testdox The default filter value should include the updated flag.
 	 *
 	 * @return void

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -512,6 +512,12 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'https://example.com' );
 		$link->set_archived_href( 'https://Web.Archive.org/web/20240101000000/https://example.com' );
 		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+
+		// A capitalised scheme must come back lowercase, not as a mixed 'httpS'.
+		$link = new Link( 'https://example.com' );
+		$link->set_archived_href( 'HTTPS://Web.Archive.org/web/20240101000000/https://example.com' );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_stored_archived_href() );
 	}
 
 	/**

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -507,6 +507,11 @@ class Test_Link extends \WP_UnitTestCase {
 		$link = new Link( 'http://example.com' );
 		$link->set_archived_href( 'http://web.archive.org/web/20240101000000/https://example.com' );
 		$this->assertSame( 'http://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
+
+		// A capitalised host is still reparsed.
+		$link = new Link( 'https://example.com' );
+		$link->set_archived_href( 'https://Web.Archive.org/web/20240101000000/https://example.com' );
+		$this->assertSame( 'https://web-wp.archive.org/web/20240101000000/https://example.com', $link->get_archived_href() );
 	}
 
 	/**

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -562,4 +562,73 @@ class Test_Link extends \WP_UnitTestCase {
 		$this->assertSame( '2024-01-03 00:00:00', $json['checks'][0]['date'] );
 		$this->assertSame( '2024-01-05 00:00:00', $json['checks'][2]['date'] );
 	}
+
+	/**
+	 * @testdox The last checked date sent to the browser must be an unambiguous UTC timestamp. (S157)
+	 *
+	 * @dataProvider provide_site_timezones
+	 *
+	 * @param string $timezone The site timezone to run under.
+	 *
+	 * @return void
+	 */
+	public function test_last_checked_is_serialized_as_utc( string $timezone ): void {
+		update_option( 'timezone_string', $timezone );
+
+		$link = new Link( 'https://s157-utc.example.com' );
+		$link->add_check( 200, '2024-01-01 12:00:00' );
+
+		$json = $link->jsonSerialize();
+
+		// A bare 'Y-m-d H:i:s' is read as local time by browsers; the stored value is UTC.
+		$this->assertSame(
+			'2024-01-01T12:00:00+00:00',
+			$json['last_checked']['date'],
+			'The timestamp must be UTC regardless of the site timezone.'
+		);
+
+		// The http code is untouched.
+		$this->assertSame( 200, $json['last_checked']['http_code'] );
+
+		update_option( 'timezone_string', '' );
+	}
+
+	/**
+	 * Site timezones to serialize under.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_site_timezones(): array {
+		return array(
+			'utc'       => array( 'UTC' ),
+			'ahead'     => array( 'Asia/Karachi' ),
+			'behind'    => array( 'America/New_York' ),
+			'half hour' => array( 'Asia/Kolkata' ),
+		);
+	}
+
+	/**
+	 * @testdox A malformed check date must be passed through rather than fataling the payload. (S157)
+	 *
+	 * @return void
+	 */
+	public function test_malformed_last_checked_date_is_passed_through(): void {
+		$link = new Link( 'https://s157-malformed.example.com' );
+		$link->add_check( 200, 'not-a-date' );
+
+		$json = $link->jsonSerialize();
+
+		$this->assertSame( 'not-a-date', $json['last_checked']['date'] );
+	}
+
+	/**
+	 * @testdox A link with no checks must serialize a null last checked value. (S157)
+	 *
+	 * @return void
+	 */
+	public function test_last_checked_is_null_when_never_checked(): void {
+		$link = new Link( 'https://s157-never-checked.example.com' );
+
+		$this->assertNull( $link->jsonSerialize()['last_checked'] );
+	}
 }

--- a/tests/Link/Test_Link_Exclusion.php
+++ b/tests/Link/Test_Link_Exclusion.php
@@ -69,17 +69,33 @@ class Test_Link_Exclusion extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Pattern matching must be case-insensitive - a capitalised LinkedIn URL still hits the bundled exclusion. (S069)
+	 * @testdox The host is matched case-insensitively - a capitalised LinkedIn URL still hits the bundled exclusion. (S069)
 	 *
 	 * @return void
 	 */
-	public function test_matching_is_case_insensitive(): void {
+	public function test_host_matching_is_case_insensitive(): void {
 		// The real bundled list - no filter override.
 		$this->assertTrue( $this->is_excluded( 'https://www.LinkedIn.com/in/someone' ) );
+		$this->assertTrue( $this->is_excluded( 'HTTPS://WWW.LINKEDIN.COM/in/someone' ) );
 
-		// Settings list patterns too, in both directions.
-		update_option( Settings::LINK_EXCLUSIONS, array( '*Example.org*' ) );
-		$this->assertTrue( $this->is_excluded( 'https://example.org/x' ) );
+		// Settings list patterns match a capitalised host too.
+		update_option( Settings::LINK_EXCLUSIONS, array( '*excluded-host.tld*' ) );
+		$this->assertTrue( $this->is_excluded( 'https://Excluded-Host.tld/some/path' ) );
+	}
+
+	/**
+	 * @testdox The path stays case-sensitive - lowercasing the whole URL would widen what a pattern excludes.
+	 *
+	 * @return void
+	 */
+	public function test_path_matching_stays_case_sensitive(): void {
+		update_option( Settings::LINK_EXCLUSIONS, array( '*/Docs/Private*' ) );
+
+		// The pattern is matched as written.
+		$this->assertTrue( $this->is_excluded( 'https://some-host.tld/Docs/Private/page' ) );
+
+		// A different path is a different resource on most servers, so it must not match.
+		$this->assertFalse( $this->is_excluded( 'https://some-host.tld/docs/private/page' ) );
 	}
 
 	/**

--- a/tests/Link/Test_Link_Exclusion.php
+++ b/tests/Link/Test_Link_Exclusion.php
@@ -69,6 +69,20 @@ class Test_Link_Exclusion extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Pattern matching must be case-insensitive - a capitalised LinkedIn URL still hits the bundled exclusion. (S069)
+	 *
+	 * @return void
+	 */
+	public function test_matching_is_case_insensitive(): void {
+		// The real bundled list - no filter override.
+		$this->assertTrue( $this->is_excluded( 'https://www.LinkedIn.com/in/someone' ) );
+
+		// Settings list patterns too, in both directions.
+		update_option( Settings::LINK_EXCLUSIONS, array( '*Example.org*' ) );
+		$this->assertTrue( $this->is_excluded( 'https://example.org/x' ) );
+	}
+
+	/**
 	 * @testdox A stored Settings list pattern excludes matching links.
 	 *
 	 * @return void

--- a/tests/Link/Test_Link_Repository.php
+++ b/tests/Link/Test_Link_Repository.php
@@ -92,6 +92,49 @@ class Test_Link_Repository extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox The display-time https cast must never be written to the database. (T068)
+	 *
+	 * @return void
+	 */
+	public function test_https_cast_is_not_persisted(): void {
+		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, true );
+
+		$link = new Link( 'https://t068-https-cast.example.com' );
+		$link->set_archived_href( 'http://web.archive.org/web/20240101000000/https://t068-https-cast.example.com' );
+		$link = $this->link_repository->upsert( $link );
+
+		// Save again - the update path must not bake the cast in either.
+		$link->add_check( 200 );
+		$this->link_repository->upsert( $link );
+
+		$wpdb   = $GLOBALS['wpdb'];
+		$stored = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT archived FROM ' . Settings::get_link_table_name() . ' WHERE id = %d', $link->get_id() )
+		);
+
+		$this->assertSame(
+			'http://web-wp.archive.org/web/20240101000000/https://t068-https-cast.example.com',
+			$stored,
+			'The stored value keeps the web-wp host rewrite but must stay http - the cast is display only.'
+		);
+
+		// Display still honours the setting.
+		$this->assertSame(
+			'https://web-wp.archive.org/web/20240101000000/https://t068-https-cast.example.com',
+			$this->link_repository->find_by_id( $link->get_id() )->get_archived_href()
+		);
+
+		// With the setting off, the same stored row displays as http again.
+		update_option( Settings::CAST_ARCHIVED_TO_HTTPS, false );
+		$this->assertSame(
+			'http://web-wp.archive.org/web/20240101000000/https://t068-https-cast.example.com',
+			$this->link_repository->find_by_id( $link->get_id() )->get_archived_href()
+		);
+
+		delete_option( Settings::CAST_ARCHIVED_TO_HTTPS );
+	}
+
+	/**
 	 * @testdox It should be possible to find a link by its URL.
 	 *
 	 * @return void

--- a/tests/Link/Test_Link_Repository.php
+++ b/tests/Link/Test_Link_Repository.php
@@ -513,6 +513,39 @@ class Test_Link_Repository extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox The month date filter must use the site timezone and include the whole last day of the month. (T072)
+	 *
+	 * @return void
+	 */
+	public function test_date_filter_uses_site_timezone(): void {
+		update_option( 'timezone_string', 'Asia/Karachi' ); // UTC+5.
+
+		// 20:00 UTC on 31st Dec is 01:00 on 1st Jan site time - inside January.
+		$early = new Link( 'https://t072-early-boundary.example.com' );
+		$early->add_check( 200, '2021-12-31 20:00:00' );
+		$this->link_repository->upsert( $early );
+
+		// 12:00 UTC on 31st Jan is 17:00 on 31st Jan site time - inside January.
+		$late = new Link( 'https://t072-late-boundary.example.com' );
+		$late->add_check( 200, '2022-01-31 12:00:00' );
+		$this->link_repository->upsert( $late );
+
+		$queried_links = $this->link_repository->query_links( 10, 1, array(), array(), array(), Link_Repository::ORDER_DATE_DESC, null, '2022-01' );
+
+		$hrefs = array_map(
+			function ( Link $link ): string {
+				return $link->get_href();
+			},
+			$queried_links
+		);
+
+		$this->assertContains( 'https://t072-early-boundary.example.com', $hrefs );
+		$this->assertContains( 'https://t072-late-boundary.example.com', $hrefs );
+
+		update_option( 'timezone_string', '' );
+	}
+
+	/**
 	 * @testdox It should be possible to get a list of all posts that a link is used on.
 	 *
 	 * @return void

--- a/tests/Processor/Test_Content_Scanner.php
+++ b/tests/Processor/Test_Content_Scanner.php
@@ -71,6 +71,102 @@ class Test_Content_Scanner extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox International URLs should be scanned in their encoded form, not silently dropped. (S126)
+	 *
+	 * @dataProvider data_provider_international_urls
+	 *
+	 * @param string $href     The href as written in the content.
+	 * @param string $expected The link expected in the scan results.
+	 *
+	 * @return void
+	 */
+	public function test_international_urls_are_scanned( string $href, string $expected ): void {
+		$scanner = new Content_Scanner( sprintf( 'A link to <a href="%s">example</a>', $href ) );
+		$links   = array_values( $scanner->scan()->get_links() );
+
+		$this->assertCount( 1, $links, "The link {$href} should have been scanned." );
+		$this->assertSame( $expected, $links[0] );
+	}
+
+	/**
+	 * Data provider for test_international_urls_are_scanned.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function data_provider_international_urls(): array {
+		return array(
+			'accented path'          => array( 'https://not-from.post/café', 'https://not-from.post/caf%C3%A9' ),
+			'accented query'         => array( 'https://not-from.post/page?q=café', 'https://not-from.post/page?q=caf%C3%A9' ),
+			'cyrillic path'          => array( 'https://not-from.post/привет', 'https://not-from.post/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82' ),
+			'idn host'               => array( 'https://例え.jp/path', 'https://xn--r8jz45g.jp/path' ),
+			'idn host accented path' => array( 'https://例え.jp/café', 'https://xn--r8jz45g.jp/caf%C3%A9' ),
+			'space in path'          => array( 'https://not-from.post/a b', 'https://not-from.post/a%20b' ),
+		);
+	}
+
+	/**
+	 * @testdox Plain ASCII URLs must be left exactly as written - the encoding fallback must not touch them. (S126)
+	 *
+	 * @dataProvider data_provider_ascii_urls_untouched
+	 *
+	 * @param string $href The href as written in the content.
+	 *
+	 * @return void
+	 */
+	public function test_ascii_urls_are_untouched( string $href ): void {
+		$scanner = new Content_Scanner( sprintf( 'A link to <a href="%s">example</a>', $href ) );
+		$links   = array_values( $scanner->scan()->get_links() );
+
+		$this->assertCount( 1, $links );
+		$this->assertSame( $href, $links[0], 'A valid ASCII URL must not be rewritten.' );
+	}
+
+	/**
+	 * Data provider for test_ascii_urls_are_untouched.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_provider_ascii_urls_untouched(): array {
+		return array(
+			'plain'             => array( 'https://not-from.post/content' ),
+			'trailing slash'    => array( 'https://not-from.post/content/' ),
+			'query string'      => array( 'https://not-from.post/page?a=1&b=2' ),
+			'already encoded'   => array( 'https://not-from.post/caf%C3%A9' ),
+			'fragment'          => array( 'https://not-from.post/page#section' ),
+			'port'              => array( 'https://not-from.post:8080/content' ),
+		);
+	}
+
+	/**
+	 * @testdox A malformed URL must still be rejected, even after the encoding fallback. (S126)
+	 *
+	 * @dataProvider data_provider_still_invalid_urls
+	 *
+	 * @param string $href The href as written in the content.
+	 *
+	 * @return void
+	 */
+	public function test_malformed_urls_are_still_rejected( string $href ): void {
+		$scanner = new Content_Scanner( sprintf( 'A link to <a href="%s">example</a>', $href ) );
+
+		$this->assertCount( 0, $scanner->scan()->get_links(), "The malformed URL {$href} should not have been scanned." );
+	}
+
+	/**
+	 * Data provider for test_malformed_urls_are_still_rejected.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_provider_still_invalid_urls(): array {
+		return array(
+			'underscore host' => array( 'https://from_invalid/content_broken' ),
+			'no host'         => array( 'https:///just-a-path' ),
+			'not http'        => array( 'ftp://not-from.post/file' ),
+			'relative'        => array( '/relative/path' ),
+		);
+	}
+
+	/**
 	 * @testdox Any duplicate links should be excluded from the list.
 	 *
 	 * @return void

--- a/tests/Processor/Test_Content_Scanner.php
+++ b/tests/Processor/Test_Content_Scanner.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Processor;
 
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Processor\Content_Scanner;
+use Internet_Archive\Wayback_Machine_Link_Fixer\WP_Post\WP_Post_Controller;
 
 /**
  * Test_Content_Scanner
@@ -164,6 +166,133 @@ class Test_Content_Scanner extends \WP_UnitTestCase {
 			'not http'        => array( 'ftp://not-from.post/file' ),
 			'relative'        => array( '/relative/path' ),
 		);
+	}
+
+	/**
+	 * @testdox Links output by a shortcode should be scanned, whether the shortcode returns or echoes them. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_shortcode_links_are_scanned(): void {
+		add_shortcode( 'iawmlf_returns_link', fn() => '<a href="https://not-from.post/returned">returned</a>' );
+		add_shortcode(
+			'iawmlf_echoes_link',
+			function () {
+				echo '<a href="https://not-from.post/echoed">echoed</a>';
+				return '';
+			}
+		);
+
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => 'Before [iawmlf_returns_link] middle [iawmlf_echoes_link] after.' )
+		);
+
+		$links = Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		remove_shortcode( 'iawmlf_returns_link' );
+		remove_shortcode( 'iawmlf_echoes_link' );
+
+		$this->assertContains( 'https://not-from.post/returned', $links );
+		$this->assertContains( 'https://not-from.post/echoed', $links );
+	}
+
+	/**
+	 * @testdox Links rendered by a dynamic block should be scanned. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_dynamic_block_links_are_scanned(): void {
+		register_block_type(
+			'iawmlf-test/dynamic',
+			array(
+				'render_callback' => fn() => '<a href="https://not-from.post/from-block">block</a>',
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => '<!-- wp:iawmlf-test/dynamic /-->' )
+		);
+
+		$links = Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		unregister_block_type( 'iawmlf-test/dynamic' );
+
+		$this->assertContains( 'https://not-from.post/from-block', $links );
+	}
+
+	/**
+	 * @testdox Raw links in the content must still be scanned once blocks and shortcodes are rendered. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_raw_links_still_scanned_after_rendering(): void {
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => '<!-- wp:paragraph --><p>A <a href="https://not-from.post/raw">raw link</a>.</p><!-- /wp:paragraph -->' )
+		);
+
+		$links = Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		$this->assertSame( array( 'https://not-from.post/raw' ), array_values( $links ) );
+	}
+
+	/**
+	 * @testdox The link payload span must not be injected while a scan renders blocks. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_own_render_block_output_is_suppressed_during_a_scan(): void {
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => '<!-- wp:paragraph --><p>A <a href="https://not-from.post/payload">link</a>.</p><!-- /wp:paragraph -->' )
+		);
+
+		// Store links against the post, so the payload span would have something to render.
+		( new WP_Post_Controller() )->process_links_in_content( $post_id );
+
+		$rendered_during_scan = null;
+		add_filter(
+			'iawmlf_scan_content',
+			function ( string $content ) use ( &$rendered_during_scan ): string {
+				$rendered_during_scan = $content;
+				return $content;
+			}
+		);
+
+		Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		remove_all_filters( 'iawmlf_scan_content' );
+
+		$this->assertIsString( $rendered_during_scan );
+		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $rendered_during_scan );
+
+		// Outside a scan the span is still added.
+		$this->assertFalse( Content_Scanner::is_rendering() );
+		$GLOBALS['post'] = get_post( $post_id );
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', do_blocks( get_post_field( 'post_content', $post_id ) ) );
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * @testdox The iawmlf_scan_content filter should be able to widen what is scanned. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_scan_content_filter_can_widen_the_scan(): void {
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => 'No links here.' )
+		);
+
+		add_filter(
+			'iawmlf_scan_content',
+			fn( string $content ): string => $content . '<a href="https://not-from.post/added-by-filter">added</a>'
+		);
+
+		$links = Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		remove_all_filters( 'iawmlf_scan_content' );
+
+		$this->assertContains( 'https://not-from.post/added-by-filter', $links );
 	}
 
 	/**

--- a/tests/Processor/Test_Content_Scanner.php
+++ b/tests/Processor/Test_Content_Scanner.php
@@ -197,6 +197,31 @@ class Test_Content_Scanner extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A shortcode that throws must not break the scan - it falls back to the raw content. (S126)
+	 *
+	 * @return void
+	 */
+	public function test_throwing_shortcode_falls_back_to_raw_content(): void {
+		add_shortcode(
+			'iawmlf_throws',
+			function () {
+				throw new \RuntimeException( 'Third party shortcode blew up.' );
+			}
+		);
+
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => 'A <a href="https://not-from.post/survives">link</a> and [iawmlf_throws].' )
+		);
+
+		$links = Content_Scanner::for_post( $post_id )->scan()->get_links();
+
+		remove_shortcode( 'iawmlf_throws' );
+
+		$this->assertContains( 'https://not-from.post/survives', $links, 'The raw content must still be scanned.' );
+		$this->assertFalse( Content_Scanner::is_rendering(), 'The rendering flag must be reset even when the render throws.' );
+	}
+
+	/**
 	 * @testdox Links rendered by a dynamic block should be scanned. (S126)
 	 *
 	 * @return void

--- a/tests/Report/Test_Report_Table_Actions.php
+++ b/tests/Report/Test_Report_Table_Actions.php
@@ -94,6 +94,40 @@ class Test_Report_Table_Actions extends \WP_UnitTestCase {
 
 
 	/**
+	 * @testdox After a bulk action, a real HTTP redirect is issued rather than a printed script tag. (S056)
+	 *
+	 * @return void
+	 */
+	public function test_redirect_after_action_issues_real_redirect(): void {
+		$_REQUEST['action'] = 'check';
+
+		$table = new Report_Table( $this->link_repository );
+
+		$location = null;
+		add_filter(
+			'wp_redirect',
+			function ( $redirect_location ) use ( &$location ) {
+				$location = $redirect_location;
+				throw new \Exception( 'redirect-captured' );
+			}
+		);
+
+		ob_start();
+		try {
+			$table->redirect_after_action();
+		} catch ( \Exception $e ) {
+			$this->assertSame( 'redirect-captured', $e->getMessage() );
+		}
+		$output = ob_get_clean();
+
+		remove_all_filters( 'wp_redirect' );
+		unset( $_REQUEST['action'] );
+
+		$this->assertNotNull( $location, 'A real redirect must be issued.' );
+		$this->assertSame( '', $output, 'Nothing must be printed - no script-tag redirect.' );
+	}
+
+	/**
 	 * @testdox Batch snapshot notices are separated, use singular/plural counts, and no success notice shows when nothing was queued. (S090)
 	 *
 	 * @return void

--- a/tests/Report/Test_Report_Table_Columns.php
+++ b/tests/Report/Test_Report_Table_Columns.php
@@ -39,4 +39,20 @@ class Test_Report_Table_Columns extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '"' . esc_url( $link->get_archived_href() ) . '"', $output );
 		$this->assertStringNotContainsString( '"' . $link->get_archived_href() . '"', $output );
 	}
+
+	/**
+	 * @testdox A malformed check date must not fatal the last-check column - the raw value is shown instead. (S058)
+	 *
+	 * @return void
+	 */
+	public function test_last_check_column_survives_malformed_check_date(): void {
+		$link = new Link( 'https://example.com/malformed-date' );
+		$link->add_check( 200, 'not-a-date' );
+
+		$table  = new Report_Table( new Link_Repository() );
+		$output = $table->column_default( $link, Report_Table::COLUMN_LINK_CHECKS_LAST );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'not-a-date', $output );
+	}
 }

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -177,6 +177,20 @@ public function test_is_current_site_link_rejects_lookalike_domains(): void {
 }
 
 	/**
+	 * @testdox A capitalised host is still recognised as a current-site link.
+	 *
+	 * @return void
+	 */
+public function test_is_current_site_link_is_case_insensitive(): void {
+	$site = get_site_url();
+	$host = wp_parse_url( $site, PHP_URL_HOST );
+
+	$capitalised = str_replace( $host, strtoupper( $host ), $site );
+
+	$this->assertTrue( \iawmlf_is_current_site_link( $capitalised . '/some/page' ) );
+}
+
+	/**
 	 * @testdox The constants should be defined and match the plugin metadata.
 	 *
 	 * @return void

--- a/tests/Test_Functions.php
+++ b/tests/Test_Functions.php
@@ -66,6 +66,7 @@ class Test_Functions extends \WP_UnitTestCase {
 			'Archive.org but not web'       => array( 'https://archive.org/details/something', false ),
 			'Contains but not starts with'  => array( 'https://example.com/web.archive.org/web/', false ),
 			'Almost matching URL'           => array( 'https://web.archive.org/details/', false ),
+			'Capitalised host (T155)'       => array( 'https://Web.Archive.org/web/20230101000000/https://example.com', true ),
 			'Empty string'                  => array( '', false ),
 		);
 	}

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -604,6 +604,49 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox The iawmlf_exclude_link_from_post filter should apply when a post is scanned, so an excluded link is never stored in the post meta. (T266)
+	 *
+	 * @return void
+	 */
+	public function test_exclude_link_from_post_filter_applies_on_scan(): void {
+		add_filter(
+			'iawmlf_exclude_link_from_post',
+			function ( bool $exclude, $link ): bool {
+				return 'https://from.post/filter-excluded' === $link->get_href() ? true : $exclude;
+			},
+			10,
+			2
+		);
+
+		$post_id = self::factory()->post->create();
+
+		$content = 'One <a href="https://from.post/filter-excluded">excluded</a> two <a href="https://from.post/filter-allowed">allowed</a>';
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+			)
+		);
+
+		// Clear any meta set by the save_post hook, then scan directly.
+		\delete_post_meta( $post_id, Settings::LINK_META_KEY );
+		( new WP_Post_Controller() )->process_links_in_content( $post_id );
+
+		$meta = get_post_meta( $post_id, Settings::LINK_META_KEY, true );
+		$this->assertIsArray( $meta );
+
+		$repository = new Link_Repository();
+		$excluded   = $repository->find_by_url( 'https://from.post/filter-excluded' );
+		$allowed    = $repository->find_by_url( 'https://from.post/filter-allowed' );
+
+		$this->assertContains( $allowed->get_id(), $meta, 'The non-excluded link should be stored in the post meta.' );
+		$this->assertNotContains( $excluded->get_id(), $meta, 'The filter-excluded link should not be stored in the post meta.' );
+
+		// Clean up.
+		\remove_all_filters( 'iawmlf_exclude_link_from_post' );
+	}
+
+	/**
 	 * @testdox When an option is selected to fix links, it should be rendered out the HTML.
 	 *
 	 * @since 1.3.1


### PR DESCRIPTION
Addresses the correctness & logic bugs from the 1.4.3 audit (#362). Every item was verified against current code before being actioned.

## Crashes on unusual data

- **S058** — A malformed check date fataled the whole links screen (`->format()` on `false`). Both unguarded spots now fall back to the raw stored value, matching the pattern already used in the templates.
- **S060** — An unrecognised wizard step made `array_search()` return `false`, and `false - 1` indexed a key that does not exist, passing `null` into `update_setup_wizard_step( string )`. Falls back to `step-1`.
- **S099** — `get_post_type_object()` returns `null` for a deregistered post type, fataling the link details screen for untitled posts. Falls back to "Unknown".
- **S057** — A links-per-page screen option of `0` caused a `DivisionByZeroError` and kept the screen fatal for that user. Clamped to a minimum of 1 on save and on read.
- **T089** — Four `catch` blocks handled only `Exception` while the rest of the codebase catches `Throwable`, so a `TypeError` escaped as a fatal — reaching the browser instead of the REST/AJAX JSON error, or taking down the dashboard widget instead of caching the failure.

## Silently doing the wrong thing

- **T266** — `process_links_in_content()` called `filter_excluded()` without the post ID it had in scope, so the documented `iawmlf_exclude_link_from_post` filter never fired on the path that stores the link list.
- **S053** — The manual-exclusion marker was only written when the message field was empty, so a link carrying a leftover system message lost its provenance and the snapshot-success event lifted the user's exclusion. The marker is now written on the transition into excluded.
- **S054** — The pattern-excluded details form renders a hidden `iawmlf_exclude_link` carrying the DB flag, so `isset()` was always true and clicking Save Changes silently set `excluded = 1`. The value is read instead of its presence.
- **S056** — Bulk actions were processed at render time, after output had started, so the redirect was a printed `<script>` tag: a dead page with JS off, and refreshing reran the action. Processing moved to `load-{hook}` (matching `handle_link_details_form`) with a real `wp_safe_redirect()`.
- **S061** — The onboarding redirect ran on `admin_init` for every request while onboarding was pending, aborting in-flight `options.php` and `admin-post.php` submissions and silently discarding the save. POSTs are now skipped; the redirect catches the next page view.

## URL matching is case-insensitive

The host part of a URL is case-insensitive by spec, but four comparisons were byte-exact:

- **S069** — `BUNDLED_LINK_EXCLUSIONS` exists because LinkedIn blocks the Internet Archive checker, but a capitalised LinkedIn URL missed the exclusion and was reported broken.
- **T155** — A capitalised archive.org URL was not recognised as already archived, so it was re-archived.
- Also fixed in the same sweep: `iawmlf_is_current_site_link()` (a capitalised own-site link was treated as external) and the `web-wp.archive.org` host rewrite in `Link::get_archived_href()`.

## Dates and timezones

- **T072** — The month date filter was built from bare UTC dates, so everything after midnight on the last day of the month fell outside the `BETWEEN`, and site-local month boundaries were ignored. Boundaries are now built in `wp_timezone()`, include the full last day, and are converted to UTC to match the stored check dates.
- **S157** — Check dates are stored as UTC in `Y-m-d H:i:s`, which browsers parse as **local** time, so the front-end "days since last check" sum was out by the site's offset and links were rechecked up to a day early or late. The payload now carries an ISO 8601 UTC timestamp — no JS change required.
- **T068** — Both write paths stored whatever `get_archived_href()` returned, so the "Force HTTPS" *display* setting was baked into the `archived` column on any save and outlived the setting being turned off. Writes use a new `get_stored_archived_href()`: the host rewrite is kept, the https cast stays display-only. Existing rows cannot be reversed — a rewritten value is indistinguishable from one legitimately stored as https.

## Content scanning

- **S126 (part 1)** — `filter_var( FILTER_VALIDATE_URL )` rejects any URL containing non-ASCII characters, so accented paths, non-Latin queries and IDN hosts were silently skipped: never checked, never archived. The scanner retries the encoded form, and `iawmlf_normalize_url()` punycodes an international host using the encoder WordPress bundles (no `intl` requirement). Valid ASCII URLs are stored exactly as written.
- **S126 (part 2)** — Only raw `post_content` was scanned, so links produced by shortcodes and dynamic blocks were invisible. Blocks and shortcodes are now rendered in a buffer (catching shortcodes that echo), with our own `render_block` payload span suppressed for the duration. The full `the_content` chain is deliberately **not** applied — it would pull in links belonging to other plugins — with the new `iawmlf_scan_content` filter as the escape hatch.

## Housekeeping

- **S024** — Removed the dead rescan `meta_query` clause. It compared the `iawmlf_links` meta (a serialised array of link IDs) against `time()` with `=`, which can never match. Duplicated in `Dashboard_Statistics`.
- **S065** — Removed `get_archive_api_status()`. Nothing called it, nothing ever wrote the transient it read, and its cache-miss path queued an event with no deduplication.
- **T197** — Collapsed the dead zero-interval ternary, and corrected the README: the routine update interval is in **days** (default 28, minimum 1), not seconds.
- **S062** — The check frequency and failure threshold each had three different defaults across `register_setting()`, the `get_option()` fallback and the help text. The `get_option()` fallback silently wins, so all places now agree on **3**, including the README.

## Testing

`composer test:php` — **441 tests, 1097 assertions, all passing** (up from 403).
`composer lint:php` — 0 errors, 0 warnings.

New tests cover: the exclusion filter firing on scan; the manual-exclusion marker surviving an existing message; the pattern-excluded save not flipping the flag; bulk actions being wired to `load-{hook}` and issuing a real redirect; a malformed check date not fataling the column; the date filter across site timezones; the https cast never reaching the database; international URL scanning (accented, Cyrillic, IDN, spaces) with ASCII URLs proven untouched and malformed URLs still rejected; shortcode and dynamic block links being found, including a shortcode that echoes; the payload span being suppressed during a scan; the `iawmlf_scan_content` filter; and the UTC timestamp holding across four site timezones.

CI runs the matrix already in place: mysql:5.7 and mariadb:10.6 across PHP 8.1–8.4.

Closes #362
