### PR TITLE
Audit 1.4.3 - architecture & code structure (#363)

### DIFF
--- a/src/Integrations.php
+++ b/src/Integrations.php
@@ -8,6 +8,8 @@
  * @since 1.0.0
  */
 
+declare(strict_types=1);
+
 namespace Internet_Archive\Wayback_Machine_Link_Fixer;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Ajax\Ajax_Controller;

--- a/src/Migration/Migrations.php
+++ b/src/Migration/Migrations.php
@@ -87,6 +87,11 @@ class Migrations {
 		$previously_run_migrations = Settings::migrations();
 
 		foreach ( array_reverse( self::$migrations ) as $migration ) {
+			// A migration that never ran has nothing to undo.
+			if ( ! in_array( $migration, $previously_run_migrations, true ) ) {
+				continue;
+			}
+
 			( new $migration() )->down();
 
 			// Remove the migration from the list of migrations that have been run.

--- a/src/Migration/Migrations.php
+++ b/src/Migration/Migrations.php
@@ -57,6 +57,26 @@ class Migrations {
 	}
 
 	/**
+	 * Run any pending migrations if the plugin version has changed.
+	 *
+	 * WordPress does not fire the activation hook on an update, so this is the only
+	 * thing that gets a schema change onto a site that was already running the plugin.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @return void
+	 */
+	public static function maybe_run(): void {
+		if ( IAWMLF_VERSION === Settings::installed_version() ) {
+			return;
+		}
+
+		self::up();
+
+		Settings::update_installed_version( IAWMLF_VERSION );
+	}
+
+	/**
 	 * Run the migrations on plugin uninstall.
 	 *
 	 * @since 0.1.0

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Internet_Archive\Wayback_Machine_Link_Fixer;
 
+use Internet_Archive\Wayback_Machine_Link_Fixer\Migration\Migrations;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -135,6 +137,9 @@ class Plugin {
 		if ( ! $this->is_active() ) {
 			return;
 		}
+
+		// An update never fires the activation hook, so pending migrations are caught here.
+		Migrations::maybe_run();
 
 		$this->initialize();
 	}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -44,6 +44,7 @@ class Settings {
 	public const SETUP_WIZARD_COMPLETED_KEY     = self::SETTINGS_PREFIX . 'setup_wizard_completed';
 	public const ONBOARDING_DATE_KEY            = self::SETTINGS_PREFIX . 'onboarding_date';
 	public const CAST_ARCHIVED_TO_HTTPS         = self::SETTINGS_PREFIX . 'cast_to_https';
+	public const INSTALLED_VERSION_KEY          = self::SETTINGS_PREFIX . 'installed_version';
 
 	// Table names.
 	public const LINK_TABLE = 'iawmlf_link_archive';
@@ -153,6 +154,32 @@ class Settings {
 	 */
 	public static function update_migrations( array $migrations ): void {
 		update_option( self::MIGRATIONS_KEY, $migrations, false );
+	}
+
+	/**
+	 * Get the plugin version the site was last loaded on.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @return string
+	 */
+	public static function installed_version(): string {
+		return (string) get_option( self::INSTALLED_VERSION_KEY, '' );
+	}
+
+	/**
+	 * Store the plugin version the site is now running.
+	 *
+	 * Autoloaded, so the version check on a normal request costs no extra query.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @param string $version The version to store.
+	 *
+	 * @return void
+	 */
+	public static function update_installed_version( string $version ): void {
+		update_option( self::INSTALLED_VERSION_KEY, $version, true );
 	}
 
 	/**

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -783,6 +783,7 @@ class Settings {
 		delete_option( self::PROCESS_LINKS );
 		delete_option( self::ALLOWED_POST_TYPES );
 		delete_option( self::MIGRATIONS_KEY );
+		delete_option( self::INSTALLED_VERSION_KEY );
 		delete_option( self::DROP_TABLES_ON_UNINSTALL_KEY );
 		delete_option( self::LINK_EXCLUSIONS );
 		delete_option( self::LINK_FIXER_EXCLUDED_POSTS );

--- a/src/Util/Esc.php
+++ b/src/Util/Esc.php
@@ -6,6 +6,8 @@
  * @since 1.3.0
  */
 
+declare(strict_types=1);
+
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Util;
 
 defined( 'ABSPATH' ) || exit;

--- a/tests/Dashboard/Test_Settings_Page.php
+++ b/tests/Dashboard/Test_Settings_Page.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Structural tests for the Settings Page.
+ *
+ * These assert invariants over whatever the page registers, never a fixed list of
+ * fields, so adding or renaming a setting does not mean editing a test.
+ *
+ * @coversDefaultClass \Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Settings_Page
+ */
+
+declare(strict_types=1);
+
+namespace Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Dashboard;
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Settings_Page;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Dashboard\Dashboard_Page;
+
+/**
+ * Test_Settings_Page
+ *
+ * @group Dashboard
+ * @group Settings_Page
+ */
+class Test_Settings_Page extends \WP_UnitTestCase {
+
+	/**
+	 * The globals WordPress writes settings registrations into.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $globals = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		foreach ( array( 'wp_registered_settings', 'wp_settings_sections', 'wp_settings_fields', 'new_allowed_options', 'submenu' ) as $key ) {
+			$this->globals[ $key ] = $GLOBALS[ $key ] ?? null;
+		}
+
+		if ( ! function_exists( 'add_submenu_page' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+	}
+
+	public function tear_down(): void {
+		foreach ( $this->globals as $key => $value ) {
+			$GLOBALS[ $key ] = $value;
+		}
+
+		unset( $_GET['page'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Register the fields as though the settings screen were being viewed.
+	 *
+	 * @return void
+	 */
+	private function register_on_settings_screen(): void {
+		$_GET['page'] = Settings_Page::PAGE_SLUG;
+
+		( new Settings_Page() )->register_fields();
+	}
+
+	/**
+	 * Every setting registered against this page.
+	 *
+	 * @return array<string, array>
+	 */
+	private function plugin_settings(): array {
+		return array_filter(
+			get_registered_settings(),
+			function ( array $setting ): bool {
+				return Settings_Page::PAGE_SLUG === ( $setting['group'] ?? '' );
+			}
+		);
+	}
+
+	/**
+	 * @testdox Registration is skipped away from the settings screen, so no other admin page pays for it.
+	 *
+	 * @return void
+	 */
+	public function test_fields_are_not_registered_away_from_the_settings_screen(): void {
+		$GLOBALS['pagenow'] = 'index.php';
+
+		( new Settings_Page() )->register_fields();
+
+		$this->assertEmpty( $this->plugin_settings() );
+	}
+
+	/**
+	 * @testdox Every setting is registered against the page slug and carries the plugin prefix.
+	 *
+	 * @return void
+	 */
+	public function test_settings_are_registered_against_the_page_slug(): void {
+		$this->register_on_settings_screen();
+
+		$settings = $this->plugin_settings();
+
+		$this->assertNotEmpty( $settings );
+
+		foreach ( array_keys( $settings ) as $key ) {
+			$this->assertStringStartsWith( Settings::SETTINGS_PREFIX, $key, "{$key} is not prefixed." );
+		}
+	}
+
+	/**
+	 * @testdox Every setting has a sanitize callback that can actually be called - an unsaved value would otherwise reach the option table raw.
+	 *
+	 * @return void
+	 */
+	public function test_every_setting_has_a_callable_sanitize_callback(): void {
+		$this->register_on_settings_screen();
+
+		foreach ( $this->plugin_settings() as $key => $setting ) {
+			$this->assertTrue(
+				is_callable( $setting['sanitize_callback'] ?? null ),
+				"{$key} has no usable sanitize callback."
+			);
+		}
+	}
+
+	/**
+	 * @testdox Every declared default matches the type it is declared as, so an absent option reads back as the right shape.
+	 *
+	 * @return void
+	 */
+	public function test_every_default_matches_its_declared_type(): void {
+		$this->register_on_settings_screen();
+
+		// WordPress setting types mapped to what gettype() reports.
+		$types = array(
+			'boolean' => 'boolean',
+			'integer' => 'integer',
+			'number'  => 'double',
+			'string'  => 'string',
+			'array'   => 'array',
+			'object'  => 'array',
+		);
+
+		foreach ( $this->plugin_settings() as $key => $setting ) {
+			if ( ! array_key_exists( 'default', $setting ) || ! isset( $types[ $setting['type'] ?? '' ] ) ) {
+				continue;
+			}
+
+			$this->assertSame(
+				$types[ $setting['type'] ],
+				gettype( $setting['default'] ),
+				"{$key} is declared as {$setting['type']} but its default is not."
+			);
+		}
+	}
+
+	/**
+	 * @testdox Every settings field has a render callback that exists - a renamed render method would otherwise fatal on the settings screen.
+	 *
+	 * @return void
+	 */
+	public function test_every_field_has_a_callable_render_callback(): void {
+		$this->register_on_settings_screen();
+
+		$fields = $GLOBALS['wp_settings_fields'][ Settings_Page::PAGE_SLUG ] ?? array();
+
+		$this->assertNotEmpty( $fields );
+
+		foreach ( $fields as $section => $section_fields ) {
+			foreach ( $section_fields as $id => $field ) {
+				$this->assertTrue(
+					is_callable( $field['callback'] ?? null ),
+					"The render callback for {$id} in {$section} cannot be called."
+				);
+			}
+		}
+	}
+
+	/**
+	 * @testdox Every field belongs to a section that was added - a field in an unknown section is silently never rendered.
+	 *
+	 * @return void
+	 */
+	public function test_every_field_belongs_to_a_registered_section(): void {
+		$this->register_on_settings_screen();
+
+		$sections = array_keys( $GLOBALS['wp_settings_sections'][ Settings_Page::PAGE_SLUG ] ?? array() );
+		$fields   = $GLOBALS['wp_settings_fields'][ Settings_Page::PAGE_SLUG ] ?? array();
+
+		$this->assertNotEmpty( $sections );
+
+		foreach ( array_keys( $fields ) as $section ) {
+			$this->assertContains( $section, $sections, "Fields are attached to {$section}, which was never added." );
+		}
+	}
+
+	/**
+	 * @testdox The settings page is added as a submenu of the plugin dashboard.
+	 *
+	 * @return void
+	 */
+	public function test_the_page_is_added_under_the_dashboard_menu(): void {
+		wp_set_current_user( \WP_UnitTestCase_Base::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		( new Settings_Page() )->register_page();
+
+		$slugs = wp_list_pluck( $GLOBALS['submenu'][ Dashboard_Page::DASHBOARD_SLUG ] ?? array(), 2 );
+
+		$this->assertContains( Settings_Page::PAGE_SLUG, $slugs );
+	}
+}

--- a/tests/Migration/Test_Migrations.php
+++ b/tests/Migration/Test_Migrations.php
@@ -32,7 +32,60 @@ class Test_Migrations extends \WP_UnitTestCase {
 
 		// Clear all migrations.
 		update_option( Settings::MIGRATIONS_KEY, array() );
+		delete_option( Settings::INSTALLED_VERSION_KEY );
 		Migrations::$migrations = array();
+	}
+
+	/**
+	 * @testdox A plugin update leaves the stored version behind, so any migration that has not run yet is run on load. (S007)
+	 *
+	 * @return void
+	 */
+	public function test_pending_migrations_run_when_stored_version_is_out_of_date(): void {
+		$migration_class = get_class( $this->createMock( Abstract_Migration::class ) );
+
+		Migrations::$migrations = array( $migration_class );
+
+		// The version the site was last loaded on.
+		update_option( Settings::INSTALLED_VERSION_KEY, '1.0.0' );
+
+		Migrations::maybe_run();
+
+		$this->assertContains( $migration_class, Settings::migrations() );
+		$this->assertSame( IAWMLF_VERSION, Settings::installed_version() );
+	}
+
+	/**
+	 * @testdox On an unchanged version nothing is run, so the check costs a single autoloaded option read. (S007)
+	 *
+	 * @return void
+	 */
+	public function test_migrations_are_not_run_when_stored_version_matches(): void {
+		$migration_class = get_class( $this->createMock( Abstract_Migration::class ) );
+
+		Migrations::$migrations = array( $migration_class );
+
+		Settings::update_installed_version( IAWMLF_VERSION );
+
+		Migrations::maybe_run();
+
+		$this->assertEmpty( Settings::migrations() );
+	}
+
+	/**
+	 * @testdox A fresh install has no stored version, so the migrations run and the version is stamped. (S007)
+	 *
+	 * @return void
+	 */
+	public function test_migrations_run_when_no_version_is_stored(): void {
+		$migration_class = get_class( $this->createMock( Abstract_Migration::class ) );
+
+		Migrations::$migrations = array( $migration_class );
+
+		Migrations::maybe_run();
+
+		$this->assertContains( $migration_class, Settings::migrations() );
+		$this->assertSame( IAWMLF_VERSION, Settings::installed_version() );
 	}
 
 	/**

--- a/tests/Migration/Test_Migrations.php
+++ b/tests/Migration/Test_Migrations.php
@@ -202,6 +202,22 @@ class Test_Migrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Uninstalling removes the version stamp - it is autoloaded, so leaving it behind costs every request of a site without the plugin.
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_clears_the_installed_version(): void {
+		update_option( Settings::DROP_TABLES_ON_UNINSTALL_KEY, true );
+
+		Settings::update_installed_version( IAWMLF_VERSION );
+		$this->assertSame( IAWMLF_VERSION, Settings::installed_version() );
+
+		iawmlf_uninstall();
+
+		$this->assertFalse( get_option( Settings::INSTALLED_VERSION_KEY ) );
+	}
+
+	/**
 	 * @testdox When the plugin is uninstalled, table should not be dropped if set to not drop.
 	 *
 	 * @return void

--- a/tests/Migration/Test_Migrations.php
+++ b/tests/Migration/Test_Migrations.php
@@ -249,6 +249,23 @@ class Test_Migrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A migration that never ran is not torn down on uninstall - its down() would undo something it never built. (S106)
+	 *
+	 * @return void
+	 */
+	public function test_down_skips_migrations_that_never_ran(): void {
+		Spy_Migration::$torn_down = array();
+
+		Migrations::$migrations = array( Ran_Migration::class, Never_Ran_Migration::class );
+		Settings::update_migrations( array( Ran_Migration::class ) );
+
+		Migrations::down();
+
+		$this->assertSame( array( Ran_Migration::class ), Spy_Migration::$torn_down );
+		$this->assertEmpty( Settings::migrations() );
+	}
+
+	/**
 	 * @testdox Ensure the archive_process column was added with the 3rd migration.
 	 * This is formally the 3rd migration, but it is now merged into the 1st migration.
 	 *
@@ -271,4 +288,36 @@ class Test_Migrations extends \WP_UnitTestCase {
 		$this->assertEquals( 'varchar(36)', $details[0]->Type );
 	}
 
+}
+
+/**
+ * Records every teardown, so a test can see which migrations were actually run down.
+ */
+abstract class Spy_Migration extends Abstract_Migration {
+
+	/**
+	 * The classes torn down so far.
+	 *
+	 * @var string[]
+	 */
+	public static $torn_down = array();
+
+	public function up(): void {
+	}
+
+	public function down(): void {
+		self::$torn_down[] = static::class;
+	}
+}
+
+/**
+ * A migration recorded in the migration log.
+ */
+class Ran_Migration extends Spy_Migration {
+}
+
+/**
+ * A migration registered but never run.
+ */
+class Never_Ran_Migration extends Spy_Migration {
 }

--- a/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
+++ b/tests/Util/Test_Action_Scheduler_Garbage_Collection.php
@@ -389,6 +389,44 @@ class Test_Action_Scheduler_Garbage_Collection extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox When each group only has a single create new snapshot action, nothing should be deleted.
+	 *
+	 * @return void
+	 */
+	public function test_clean_create_new_snapshot_events_single_attempt_not_deleted(): void {
+		$this->set_link_checker_to_throw();
+
+		$link_a = $this->link_repository->upsert( new Link( 'https://example.com' ) );
+		$link_b = $this->link_repository->upsert( new Link( 'https://example.org' ) );
+
+		$event = new Create_New_Snapshot_Event();
+
+		// Each link gets a single invocation → 1 action each.
+		try { $event( $link_a->get_id(), 0 ); } catch ( \Throwable $th ) {} // phpcs:ignore
+		try { $event( $link_b->get_id(), 0 ); } catch ( \Throwable $th ) {} // phpcs:ignore
+
+		// Mark as failed.
+		$this->wpdb->update(
+			"{$this->wpdb->prefix}actionscheduler_actions",
+			array( 'status' => 'failed' ),
+			array(
+				'hook'   => Create_New_Snapshot_Event::HANDLE,
+				'status' => 'pending',
+			)
+		);
+
+		// Run the garbage collector.
+		$gc = new Action_Scheduler_Garbage_Collection();
+		$gc->clean_create_new_snapshot_events();
+
+		// Both actions should still exist.
+		$remaining = $this->wpdb->get_results(
+			"SELECT * FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook = 'iawmlf_create_new_snapshot'"
+		);
+		$this->assertCount( 2, $remaining );
+	}
+
+	/**
 	 * @testdox When a before date is passed to create snapshot cleanup, only old actions should be cleaned.
 	 *
 	 * @return void


### PR DESCRIPTION
Works through the architecture and code structure audit in #363.

## Migrations now reach an updated site

`Migrations::up()` only ever ran from the activation hook, which WordPress does not fire when a plugin updates in place — not on auto-update, not on a ZIP upload, not via WP-CLI. Any schema change added in a new version would never reach a site that already had the plugin active.

The plugin version is now stored in an autoloaded option and compared to `IAWMLF_VERSION` on load. When they differ, pending migrations run and the new version is stamped. Because the option is autoloaded the check on a normal request is a string comparison with no extra query, and it catches every update route since it never asks *how* the files changed.

The migration log stays the authority on which migrations execute, so an existing 1.4.3 site stamps the new version and runs nothing.

## Uninstall no longer undoes migrations that never ran

`Migrations::down()` looped the whole registry and called `down()` on every registered migration regardless of whether it had run. A teardown could therefore drop something it never created. It now skips anything missing from the migration log, mirroring the guard `up()` already had.

## Test coverage

The settings page had no test file at all. Added one covering the registration invariants:

- registration is skipped away from the settings screen
- every setting is registered against the page slug and carries the plugin prefix
- every setting has a sanitize callback that can be called
- every declared default matches its declared type
- every field has a render callback that exists
- every field belongs to a section that was actually added
- the page is added under the plugin dashboard menu

Each test loops over whatever the page registered rather than a fixed list of fields, so adding a setting does not mean editing a test.

Also filled a gap in the Action Scheduler garbage collection tests: three of the four cleanup methods had a test proving a group with a single attempt is left alone, `clean_create_new_snapshot_events()` did not.

## Strict types

`Integrations.php` and `Util/Esc.php` were the only files under `src/` with code in them that did not declare strict types. `src/index.php` is left alone as an empty stub.

## Testing instructions

1. `composer install --ignore-platform-reqs`
2. `composer test:php` — 455 tests, 1193 assertions
3. `composer lint:php` — clean

To check the migration behaviour by hand: delete the `iawmlf_installed_version` option and load any page. The option reappears set to the current version, and the link table is untouched because the migration log already records `Migration_1`.

Closes #363
