### PR TITLE
Add a version consistency check to CI

### DIFF
--- a/.github/workflows/push-deploy-dryrun.yml
+++ b/.github/workflows/push-deploy-dryrun.yml
@@ -32,7 +32,7 @@ jobs:
           ASSET: internet-archive-wayback-machine-link-fixer.zip
         run: |
           # RCs, betas and anything else suffixed must never reach SVN.
-          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$VERSION' is not a stable release version. Refusing to deploy."
             exit 1
           fi

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -36,7 +36,7 @@ jobs:
           ASSET: internet-archive-wayback-machine-link-fixer.zip
         run: |
           # RCs, betas and anything else suffixed must never reach SVN.
-          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$VERSION' is not a stable release version. Refusing to deploy."
             exit 1
           fi

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,63 @@
+name: Version Consistency
+
+# The version is declared in six places. WordPress reads the `Version:` header
+# and wp.org reads `Stable tag:`, so a missed bump on either is visible to users.
+#
+# Only the first three numeric segments are compared, so `1.4.3-RC1` and `1.4.3`
+# are treated as equal here. The deploy workflow refuses anything that is not a
+# plain X.Y.Z, so an RC still cannot reach wp.org.
+
+on:
+  push:
+    branches: [ trunk, develop ]
+  pull_request:
+    branches: [ trunk, develop ]
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version sources are in sync
+        run: |
+          set -euo pipefail
+          PLUGIN=internet-archive-wayback-machine-link-fixer.php
+
+          # First 3-segment version from a grep match; empty (not abort) on no match.
+          grep_version() {
+            { grep -m1 -iE "$1" "$2" || true; } \
+              | { grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true; } \
+              | head -n1
+          }
+
+          header="$(grep_version '^\s*\*\s*Version:'   "$PLUGIN")"
+          docblock="$(grep_version '@version'          "$PLUGIN")"
+          define="$(grep_version "IAWMLF_VERSION'"     "$PLUGIN")"
+          stable="$(grep_version '^Stable tag:'        readme.txt)"
+          package="$(jq -r '.version // empty' package.json)"
+          lock="$(jq -r '.version // empty' package-lock.json)"
+
+          echo "Version: header    : ${header:-<none>}"
+          echo "@version docblock  : ${docblock:-<none>}"
+          echo "IAWMLF_VERSION     : ${define:-<none>}"
+          echo "readme Stable tag  : ${stable:-<none>}"
+          echo "package.json       : ${package:-<none>}"
+          echo "package-lock.json  : ${lock:-<none>}"
+
+          for v in "$header" "$docblock" "$define" "$stable" "$package" "$lock"; do
+            if [ -z "$v" ]; then
+              echo "::error::Could not read a version from one or more sources."
+              exit 1
+            fi
+          done
+
+          if [ "$header" != "$docblock" ] || [ "$header" != "$define" ] \
+             || [ "$header" != "$stable" ] || [ "$header" != "$package" ] \
+             || [ "$header" != "$lock" ]; then
+            echo "::error::Version mismatch. Update all six sources to the same version before merging."
+            exit 1
+          fi
+
+          echo "All version sources agree on $header."

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,6 +1,6 @@
 name: Version Consistency
 
-# The version is declared in six places. WordPress reads the `Version:` header
+# The version is declared in seven places. WordPress reads the `Version:` header
 # and wp.org reads `Stable tag:`, so a missed bump on either is visible to users.
 #
 # Only the first three numeric segments are compared, so `1.4.3-RC1` and `1.4.3`
@@ -36,6 +36,7 @@ jobs:
           docblock="$(grep_version '@version'          "$PLUGIN")"
           define="$(grep_version "IAWMLF_VERSION'"     "$PLUGIN")"
           stable="$(grep_version '^Stable tag:'        readme.txt)"
+          readme_md="$(grep_version '^\*\*Stable tag:\*\*' README.md)"
           package="$(jq -r '.version // empty' package.json)"
           lock="$(jq -r '.version // empty' package-lock.json)"
 
@@ -43,10 +44,11 @@ jobs:
           echo "@version docblock  : ${docblock:-<none>}"
           echo "IAWMLF_VERSION     : ${define:-<none>}"
           echo "readme Stable tag  : ${stable:-<none>}"
+          echo "README.md          : ${readme_md:-<none>}"
           echo "package.json       : ${package:-<none>}"
           echo "package-lock.json  : ${lock:-<none>}"
 
-          for v in "$header" "$docblock" "$define" "$stable" "$package" "$lock"; do
+          for v in "$header" "$docblock" "$define" "$stable" "$readme_md" "$package" "$lock"; do
             if [ -z "$v" ]; then
               echo "::error::Could not read a version from one or more sources."
               exit 1
@@ -54,9 +56,9 @@ jobs:
           done
 
           if [ "$header" != "$docblock" ] || [ "$header" != "$define" ] \
-             || [ "$header" != "$stable" ] || [ "$header" != "$package" ] \
-             || [ "$header" != "$lock" ]; then
-            echo "::error::Version mismatch. Update all six sources to the same version before merging."
+             || [ "$header" != "$stable" ] || [ "$header" != "$readme_md" ] \
+             || [ "$header" != "$package" ] || [ "$header" != "$lock" ]; then
+            echo "::error::Version mismatch. Update all seven sources to the same version before merging."
             exit 1
           fi
 


### PR DESCRIPTION
## What

Adds `.github/workflows/version-consistency.yml`, a CI check that fails when the repo's six version declarations disagree.

| Source | Location |
|---|---|
| `Version:` plugin header | `internet-archive-wayback-machine-link-fixer.php:15` |
| `@version` docblock | `internet-archive-wayback-machine-link-fixer.php:6` |
| `IAWMLF_VERSION` | `internet-archive-wayback-machine-link-fixer.php:33` |
| `Stable tag:` | `readme.txt:6` |
| `version` | `package.json` |
| `version` | `package-lock.json` |

Runs on push and pull request against `trunk` and `develop`, matching the other CI workflows.

## Why

#355 added a `Stable tag` guard to the deploy workflow, but it compares `readme.txt` against the dispatched tag only. Nothing checked the six against each other.

They have drifted. At `1.4.3-RC1` the plugin file and `readme.txt` were bumped while `package.json` and `package-lock.json` stayed on `1.4.1`.

WordPress reads the `Version:` header and wp.org reads `Stable tag:`, so a missed bump on either is visible to users.

## Suffix handling

Only the first three numeric segments are compared, so `1.4.3-RC1` reads as `1.4.3`. The deploy workflow refuses anything that is not a plain `X.Y.Z`, so an RC cannot reach wp.org regardless. Recorded in the workflow's header comment.

## Testing

Extracted the script body and ran it against two trees:

- Current `trunk`, all six at `1.4.3` — passes, exit 0.
- Files from `c09c6a8`, plugin file at `1.4.3-RC1` and `package.json` at `1.4.1` — fails with `::error::Version mismatch`, exit 1.

## Credit

The check and its script are @nickpagz's suggestion, from his review on #355.

Closes #373
