### PR TITLE
Audit 1.4.3 — verify the remaining dead code findings, fix S043 and S144

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -305,7 +305,7 @@ function iawmlf_render_not_authenticated_notice(): void {
 				print wp_kses_post(
 					sprintf(
 						// translators: %s is a link to the settings page.
-						__( 'Your Archive.org API credentials are invalid. <a href="%s">Please check your settings.</a>. As a result you are in in unauthenticated mode, which restricts you to 4000 new snapshots per day.', 'internet-archive-wayback-machine-link-fixer' ),
+						__( 'Your Archive.org API credentials are invalid. <a href="%s">Please check your settings.</a> As a result you are in unauthenticated mode, which restricts you to 4000 new snapshots per day.', 'internet-archive-wayback-machine-link-fixer' ),
 						esc_url( admin_url( 'options-general.php?page=' . Settings_Page::PAGE_SLUG ) )
 					)
 				);

--- a/languages/internet-archive-wayback-machine-link-fixer.pot
+++ b/languages/internet-archive-wayback-machine-link-fixer.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-27T14:08:14+00:00\n"
+"POT-Creation-Date: 2026-09-01T10:58:42+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: internet-archive-wayback-machine-link-fixer\n"
@@ -75,7 +75,7 @@ msgstr ""
 #. translators: %s is a link to the settings page.
 #: functions.php:308
 #, php-format
-msgid "Your Archive.org API credentials are invalid. <a href=\"%s\">Please check your settings.</a>. As a result you are in in unauthenticated mode, which restricts you to 4000 new snapshots per day."
+msgid "Your Archive.org API credentials are invalid. <a href=\"%s\">Please check your settings.</a> As a result you are in unauthenticated mode, which restricts you to 4000 new snapshots per day."
 msgstr ""
 
 #: functions.php:335

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -535,7 +535,35 @@ class Link implements \JsonSerializable {
 			$link->set_broken();
 		}
 
+		if ( isset( $data['message'] ) ) {
+			$link->set_message( (string) $data['message'] );
+		}
+
+		$link->set_excluded( ! empty( $data['excluded'] ) );
+
 		return $link;
+	}
+
+	/**
+	 * Full state as JSON, the inverse of from_json().
+	 *
+	 * Not jsonSerialize(), which is the front end payload - that omits the message
+	 * (Archive.org status text and manual exclusion detail, both of which name a
+	 * user) and keeps only the newest three checks.
+	 *
+	 * @return string
+	 */
+	public function to_json(): string {
+		return (string) wp_json_encode(
+			array_merge(
+				$this->jsonSerialize(),
+				array(
+					'checks'   => $this->checks,
+					'message'  => $this->message,
+					'excluded' => $this->is_excluded,
+				)
+			)
+		);
 	}
 
 	/**

--- a/tests/Link/Test_Link.php
+++ b/tests/Link/Test_Link.php
@@ -373,6 +373,24 @@ class Test_Link extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox A link cast to json and back keeps its message and excluded flag. (S043)
+	 *
+	 * @return void
+	 */
+	public function test_json_round_trip_keeps_message_and_excluded(): void {
+		$link = new Link( 'https://example.com' );
+		$link->set_id( 1 );
+		$link->set_excluded();
+		$link->set_message( sprintf( Link::MANUAL_EXCLUSION_TEMPLATE, 'admin', '2026-01-01' ) );
+
+		$link = Link::from_json( $link->to_json() );
+
+		$this->assertTrue( $link->is_excluded() );
+		$this->assertSame( 'User Requested To Exclude (admin on 2026-01-01)', $link->get_message() );
+		$this->assertTrue( $link->is_manual_exclusion() );
+	}
+
+	/**
 	 * @testdox Malformed json produces a link rather than warnings from reading null as an array. (S043)
 	 *
 	 * @return void


### PR DESCRIPTION
## What

Works through the remaining items in #365. PR #369 already covered part of the group; this pass verified every one of the 17 against `trunk` and fixed the two that were both real and worth changing.

## Fixed

**S043 — `Link` JSON round trips lost state.**

`Link::from_json()` never read back the link's message or its excluded flag, so a link serialised and read back returned with both wiped. That also broke `is_manual_exclusion()`, which needs both to tell an admin-requested exclusion from an automatic one.

Adds `Link::to_json()` as the true inverse of `from_json()` — full state, plus the complete check history rather than the newest three.

`jsonSerialize()` is deliberately unchanged. It is the front end payload: `WP_Post_Controller` embeds it in public page HTML (`:328`) and hands it to a public script (`:259`). The message field holds Archive.org status text and, for a manual exclusion, the display name of the admin who made it. Widening `jsonSerialize()` would publish that on every public page.

Test added for the round trip, watched fail, then fixed.

**S144 — two typos in the invalid credentials notice.**

`functions.php:308` read "settings.</a>. As a result you are in in unauthenticated mode". Fixed the doubled "in" and the stray full stop. POT regenerated; there are no `.po` files in the repository, so no translation is invalidated.

## Verified as already done

Each fixed by #369, confirmed against `trunk`:

| Item | Evidence |
|---|---|
| S042 | `Wayback_Machine_Client` appears nowhere; both event classes import `Wayback_Machine_Service` and the docblocks resolve. |
| S111 | The class has no imports at all. A scan of every `use` in `src/` and `migrations/` finds **0** unused. |
| T260 | The `Process_Local_Post_Event` import is gone; all four remaining imports back one cleaner each. |
| T270 | `Throwable` appears nowhere in either HTTP client. |
| T169 | `:236` verifies against `self::NONCE`; `Settings_Page.php:188` creates it from the constant. |
| T137 | The public `STATS_TRANSIENT_KEY` is gone; only the private one in `Dashboard_Statistics` remains. |
| S144 (first half) | The discarded message variable is gone; one inline composition remains. |
| S129 (second half) | The duplicate `is_excluded()` branch in `Link_Check_Action` is gone. |

## Confirmed but left in place

Real findings, deliberately not actioned:

- **S098** — `wizard.js` listens for `#is_active` and `.is_optional`. Neither exists, and the two wizard activate inputs are `type="hidden"`, so there is nothing to toggle. Still enqueued.
- **S147** — `compile_details_cell()` returns early at `:1218` when there is no last check, so the `$last_check ?:` ternary at `:1252-1254` can only take its true branch. `$last_status_display` already falls back to "No HTTP Code" at `:1238`.
- **S148** — `$iawmlf_previous_state` is `DISABLED` only on `step-1`, where `:66` renders a `<span>` instead of the button; `$iawmlf_next_state` is `DISABLED` only on `complete`, where `:73` renders a link instead. Each is set exactly when its button does not exist.
- **S143** — four dead variables, not one. `$iawmlf_process_done` is never read, and `$iawmlf_process_new` / `$iawmlf_process_pending` exist only to feed `$iawmlf_still_processing`, which is never printed. Only `$iawmlf_not_checked` is displayed.
- **S114** — `Setup_Wizard::is_setup_complete()` has no callers anywhere. Kept: the `@deprecated` tag already makes IDEs strike the call site and show the replacement.
- **S145** — the mismatch is real. The bulk handler reads `iawmlf_link_action`; `iawmlf_links` exists only as the field name at `:1164` with nothing reading it, plus a leftover strip at `:306`. Whether the branch is unreachable was not confirmed — that needs core's `WP_List_Table`.

## Corrections to the audit

Two findings did not survive checking:

- **S129 (first half)** — no branch in `Create_New_Snapshot_Event` is dead. The `:175` catch fires on a `TypeError` from `map_link()` under strict types; `:161` is reachable because the `:176`/`:198` retries requeue past the maximum without checking it; `:189` fires on a missing row. Only the stray indentation at `:247-250` is left over.
- **T236** — inverted. `||` short-circuits left to right, so a missing or invalid nonce is caught by the first two clauses and `check_admin_referer()` is never called. It is only reached once the nonce is already verified for the same action, making the **third** clause the redundant one — and it still fires the `check_admin_referer` action hook, so it is not free to remove.
- **S135** — `blocks/` is not tracked in git and is on no branch. The boilerplate block went in `672a697` and the build scripts in #369; only local empty directories remain.

## Testing

- Full suite: 460 tests, 1136 assertions, 38 skipped (the live Archive.org tests, gated on the online check). No failures.
- PHPCS clean on every changed file.
