### PR TITLE
Audit 1.4.3 — admin UI, UX and accessibility fixes (#370)

### DIFF
--- a/assets/css/src/admin/_dashboard.scss
+++ b/assets/css/src/admin/_dashboard.scss
@@ -337,6 +337,14 @@
         min-width: 0; // Allow flex shrinking
     }
     &-title {
+        // A button, not a link - it toggles the details panel rather than navigating.
+        appearance: none;
+        background: none;
+        border: 0;
+        padding: 0;
+        margin: 0;
+        text-align: left;
+        cursor: pointer;
         color: #2271b1;
         text-decoration: none;
         flex: 1;

--- a/assets/js/src/dashboard.js
+++ b/assets/js/src/dashboard.js
@@ -79,10 +79,9 @@
 
 				titleLink.appendChild(arrow);
 
-				// Add click handler to prevent default link behavior and toggle
-				titleLink.addEventListener('click', function (e) {
-					e.preventDefault();
+				titleLink.setAttribute('aria-expanded', 'false');
 
+				titleLink.addEventListener('click', function () {
 					const isVisible = posts.style.display !== 'none';
 
 					if (isVisible) {
@@ -94,6 +93,8 @@
 						arrow.style.transform = 'translateY(-50%) rotate(180deg)';
 						item.classList.add('expanded');
 					}
+
+					titleLink.setAttribute('aria-expanded', isVisible ? 'false' : 'true');
 				});
 
 				// Add hover effect

--- a/e2e/fixtures/clean-notice-placement.php
+++ b/e2e/fixtures/clean-notice-placement.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * E2E clean up for seed-notice-placement.php.
+ *
+ * Restores every option the seeder overwrote to the value it held before, and
+ * removes the notification cache transient in case the spec never consumed it.
+ *
+ * Run via: wp eval-file e2e/fixtures/clean-notice-placement.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded — is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/notice-placement-shared.php';
+
+$admin = get_user_by( 'login', 'admin' );
+if ( $admin ) {
+	delete_transient( iawmlf_e2e_notice_placement_transient( (int) $admin->ID ) );
+}
+
+$backup = get_option( IAWMLF_E2E_NOTICE_PLACEMENT_BACKUP, array() );
+
+foreach ( iawmlf_e2e_notice_placement_options() as $option ) {
+	// Absent before means absent after.
+	if ( ! is_array( $backup ) || ! array_key_exists( $option, $backup ) || null === $backup[ $option ] ) {
+		delete_option( $option );
+		continue;
+	}
+
+	update_option( $option, $backup[ $option ] );
+}
+
+delete_option( IAWMLF_E2E_NOTICE_PLACEMENT_BACKUP );
+
+echo "CLEANED=1\n";

--- a/e2e/fixtures/notice-placement-shared.php
+++ b/e2e/fixtures/notice-placement-shared.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Shared names for the admin notice placement seeder and its clean up.
+ *
+ * Loaded by seed-notice-placement.php and clean-notice-placement.php.
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+const IAWMLF_E2E_NOTICE_PLACEMENT_ACTION  = 'iawmlf_e2e_placement';
+const IAWMLF_E2E_NOTICE_PLACEMENT_KEY     = 'e2eplacement';
+const IAWMLF_E2E_NOTICE_PLACEMENT_MESSAGE = 'IAWMLF e2e notice placement probe.';
+const IAWMLF_E2E_NOTICE_PLACEMENT_BACKUP  = 'iawmlf_e2e_notice_placement_backup';
+
+/**
+ * The options the seeder overwrites, and the clean up restores.
+ *
+ * @return string[]
+ */
+function iawmlf_e2e_notice_placement_options(): array {
+	return array(
+		Settings::POST_ACTIVATION_ONBOARDING_KEY,
+		Settings::SETUP_WIZARD_COMPLETED_KEY,
+		Settings::SETUP_WIZARD_STEP_KEY,
+		Settings::ARCHIVE_ORG_ACCESS_KEY,
+		Settings::ARCHIVE_ORG_SECRET_KEY,
+	);
+}
+
+/**
+ * The notification cache transient name, mirroring
+ * List_Table_Action_Notification_Cache::compile_cache_key().
+ *
+ * @param int $user_id The admin user id.
+ *
+ * @return string
+ */
+function iawmlf_e2e_notice_placement_transient( int $user_id ): string {
+	return 'iawmlf_list_table_action_cache_' . $user_id . '_'
+		. IAWMLF_E2E_NOTICE_PLACEMENT_ACTION . '_' . IAWMLF_E2E_NOTICE_PLACEMENT_KEY;
+}

--- a/e2e/fixtures/seed-notice-placement.php
+++ b/e2e/fixtures/seed-notice-placement.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * E2E seeder: admin notices must print inside the page's .wrap container.
+ *
+ * Sets up both notices the spec checks:
+ *
+ *   - Settings page: clears the Archive.org credentials so
+ *     iawmlf_render_not_authenticated_notice() prints the unauthenticated notice.
+ *   - Links page: writes a List_Table_Action_Notification_Cache transient for the
+ *     admin user, so visiting the list with the matching query args replays it.
+ *
+ * Run via: wp eval-file e2e/fixtures/seed-notice-placement.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded — is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+$admin = get_user_by( 'login', 'admin' );
+if ( ! $admin ) {
+	fwrite( STDERR, "No 'admin' user found.\n" );
+	exit( 1 );
+}
+
+// Settings page: no credentials means the unauthenticated notice renders.
+delete_option( Settings::ARCHIVE_ORG_ACCESS_KEY );
+delete_option( Settings::ARCHIVE_ORG_SECRET_KEY );
+
+// Links page: replay a cached bulk-action notice. Key format mirrors
+// List_Table_Action_Notification_Cache::compile_cache_key().
+$action  = 'iawmlf_e2e_placement';
+$key     = 'e2eplacement';
+$message = 'IAWMLF e2e notice placement probe.';
+
+set_transient(
+	'iawmlf_list_table_action_cache_' . $admin->ID . '_' . $action . '_' . $key,
+	array(
+		array(
+			'message' => $message,
+			'type'    => 'error',
+		),
+	),
+	5 * MINUTE_IN_SECONDS
+);
+
+// Output for the playwright spec. Each on its own line, KEY=VALUE.
+echo "NOTICE_ACTION={$action}\n";
+echo "NOTICE_KEY={$key}\n";
+echo "NOTICE_MESSAGE={$message}\n";

--- a/e2e/fixtures/seed-notice-placement.php
+++ b/e2e/fixtures/seed-notice-placement.php
@@ -2,12 +2,16 @@
 /**
  * E2E seeder: admin notices must print inside the page's .wrap container.
  *
- * Sets up both notices the spec checks:
+ * Sets up both notices the spec checks, and does not depend on any other spec
+ * having run first:
  *
+ *   - Onboarding is marked complete, or every admin page redirects to the wizard.
  *   - Settings page: clears the Archive.org credentials so
  *     iawmlf_render_not_authenticated_notice() prints the unauthenticated notice.
  *   - Links page: writes a List_Table_Action_Notification_Cache transient for the
  *     admin user, so visiting the list with the matching query args replays it.
+ *
+ * Anything overwritten is stashed so clean-notice-placement.php can restore it.
  *
  * Run via: wp eval-file e2e/fixtures/seed-notice-placement.php
  */
@@ -25,21 +29,31 @@ if ( ! $admin ) {
 	exit( 1 );
 }
 
+require_once __DIR__ . '/notice-placement-shared.php';
+
+// Stash the options this seeder overwrites, so the state can be put back.
+$backup = array();
+foreach ( iawmlf_e2e_notice_placement_options() as $option ) {
+	$backup[ $option ] = get_option( $option, null );
+}
+update_option( IAWMLF_E2E_NOTICE_PLACEMENT_BACKUP, $backup );
+
+// Onboarding must be complete or every admin page redirects to the setup wizard.
+update_option( Settings::POST_ACTIVATION_ONBOARDING_KEY, Settings::ONBOARDING_COMPLETED_OPTION );
+update_option( Settings::SETUP_WIZARD_COMPLETED_KEY, true );
+update_option( Settings::SETUP_WIZARD_STEP_KEY, 'complete' );
+
 // Settings page: no credentials means the unauthenticated notice renders.
 delete_option( Settings::ARCHIVE_ORG_ACCESS_KEY );
 delete_option( Settings::ARCHIVE_ORG_SECRET_KEY );
 
 // Links page: replay a cached bulk-action notice. Key format mirrors
 // List_Table_Action_Notification_Cache::compile_cache_key().
-$action  = 'iawmlf_e2e_placement';
-$key     = 'e2eplacement';
-$message = 'IAWMLF e2e notice placement probe.';
-
 set_transient(
-	'iawmlf_list_table_action_cache_' . $admin->ID . '_' . $action . '_' . $key,
+	iawmlf_e2e_notice_placement_transient( (int) $admin->ID ),
 	array(
 		array(
-			'message' => $message,
+			'message' => IAWMLF_E2E_NOTICE_PLACEMENT_MESSAGE,
 			'type'    => 'error',
 		),
 	),
@@ -47,6 +61,6 @@ set_transient(
 );
 
 // Output for the playwright spec. Each on its own line, KEY=VALUE.
-echo "NOTICE_ACTION={$action}\n";
-echo "NOTICE_KEY={$key}\n";
-echo "NOTICE_MESSAGE={$message}\n";
+echo 'NOTICE_ACTION=' . IAWMLF_E2E_NOTICE_PLACEMENT_ACTION . "\n";
+echo 'NOTICE_KEY=' . IAWMLF_E2E_NOTICE_PLACEMENT_KEY . "\n";
+echo 'NOTICE_MESSAGE=' . IAWMLF_E2E_NOTICE_PLACEMENT_MESSAGE . "\n";

--- a/e2e/specs/admin-notice-placement.spec.js
+++ b/e2e/specs/admin-notice-placement.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * Admin notices must be printed inside the page's `.wrap` container.
+ *
+ * Both the Links page and the Advanced Settings page used to print their notice
+ * before opening `.wrap`, so it landed outside the container that WordPress
+ * styles and positions notices within.
+ *
+ * These assertions run against the server-rendered HTML rather than the live
+ * DOM. Admin scripts can relocate `.notice` elements after load, so a DOM
+ * position would not prove where the page actually printed the notice.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+const REPO_ROOT = path.join( __dirname, '../..' );
+
+const SETTINGS_PATH = '/wp-admin/admin.php?page=iawmlf_settings';
+const LINKS_PATH = '/wp-admin/admin.php?page=iawmlf-links';
+
+function wpCli( command ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- ${ command }`,
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+}
+
+function seed() {
+	const output = wpCli( 'wp eval-file e2e/fixtures/seed-notice-placement.php' );
+
+	const parse = ( key ) => {
+		const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+		if ( ! m ) {
+			throw new Error( `Seeder did not print ${ key }. Output was:\n${ output }` );
+		}
+		return m[ 1 ].trim();
+	};
+
+	return {
+		action: parse( 'NOTICE_ACTION' ),
+		key: parse( 'NOTICE_KEY' ),
+		message: parse( 'NOTICE_MESSAGE' ),
+	};
+}
+
+/**
+ * Assert a notice containing `needle` is printed after `.wrap` opens.
+ *
+ * @param {string} html   The server-rendered page HTML.
+ * @param {string} needle Text unique to the notice under test.
+ */
+function expectNoticeInsideWrap( html, needle ) {
+	const wrapAt = html.indexOf( '<div class="wrap">' );
+	const noticeAt = html.indexOf( needle );
+
+	expect( wrapAt, 'the page should render a .wrap container' ).toBeGreaterThan( -1 );
+	expect( noticeAt, `the page should render a notice containing "${ needle }"` ).toBeGreaterThan( -1 );
+	expect( noticeAt, 'the notice should be printed inside .wrap, not before it' ).toBeGreaterThan( wrapAt );
+}
+
+test.describe( 'admin notice placement', () => {
+	let seeded;
+
+	test.beforeAll( () => {
+		seeded = seed();
+	} );
+
+	test( 'the settings page prints its notice inside .wrap', async ( { page } ) => {
+		const response = await page.request.get( SETTINGS_PATH );
+		expect( response.ok() ).toBe( true );
+
+		expectNoticeInsideWrap( await response.text(), 'unauthenticated mode' );
+	} );
+
+	test( 'the links page prints its notice inside .wrap', async ( { page } ) => {
+		const url = `${ LINKS_PATH }&iawmlf_completed_action=${ seeded.action }&iawmlf_notification=${ seeded.key }`;
+
+		const response = await page.request.get( url );
+		expect( response.ok() ).toBe( true );
+
+		expectNoticeInsideWrap( await response.text(), seeded.message );
+	} );
+} );

--- a/e2e/specs/admin-notice-placement.spec.js
+++ b/e2e/specs/admin-notice-placement.spec.js
@@ -67,6 +67,10 @@ test.describe( 'admin notice placement', () => {
 		seeded = seed();
 	} );
 
+	test.afterAll( () => {
+		wpCli( 'wp eval-file e2e/fixtures/clean-notice-placement.php' );
+	} );
+
 	test( 'the settings page prints its notice inside .wrap', async ( { page } ) => {
 		const response = await page.request.get( SETTINGS_PATH );
 		expect( response.ok() ).toBe( true );

--- a/languages/internet-archive-wayback-machine-link-fixer.pot
+++ b/languages/internet-archive-wayback-machine-link-fixer.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-09-01T10:58:42+00:00\n"
+"POT-Creation-Date: 2026-09-03T08:42:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: internet-archive-wayback-machine-link-fixer\n"
@@ -27,7 +27,7 @@ msgstr ""
 
 #. Author of the plugin
 #: internet-archive-wayback-machine-link-fixer.php:19
-#: src/Dashboard/Settings_Page.php:236
+#: src/Dashboard/Settings_Page.php:237
 msgid "Internet Archive"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgid "Wayback Link Fixer"
 msgstr ""
 
 #: src/Dashboard/Dashboard_Page.php:145
-#: src/Dashboard/Settings_Page.php:600
+#: src/Dashboard/Settings_Page.php:601
 msgid "Link Fixer"
 msgstr ""
 
@@ -338,7 +338,7 @@ msgid "Dashboard"
 msgstr ""
 
 #: src/Dashboard/Report_Page.php:101
-#: src/Dashboard/Report_Page.php:316
+#: src/Dashboard/Report_Page.php:313
 msgid "Wayback Link Fixer - Links"
 msgstr ""
 
@@ -399,266 +399,266 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:220
+#: src/Dashboard/Settings_Page.php:218
 msgid "Rerun The Setup Wizard"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:227
+#: src/Dashboard/Settings_Page.php:225
 msgid "Wayback Link Fixer - Advanced Settings"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:237
+#: src/Dashboard/Settings_Page.php:238
 msgid "This plugin is powered by the Internet Archive. If you find the plugin useful, please chip in! Your support will help us build the web we deserve."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:239
+#: src/Dashboard/Settings_Page.php:240
 msgid "Donate"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:240
+#: src/Dashboard/Settings_Page.php:241
 msgid "Dismiss"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:249
+#: src/Dashboard/Settings_Page.php:250
 #: templates/admin/reports/link-details.php:271
 msgid "Save Changes"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:570
+#: src/Dashboard/Settings_Page.php:571
 msgid "Plugin Settings"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:581
+#: src/Dashboard/Settings_Page.php:582
 msgid "Archive.org API"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:586
+#: src/Dashboard/Settings_Page.php:587
 msgid "To increase your daily snapshot limit from 4,000 to 30,000, you can enter your free Archive.org API credentials. Visit"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:588
+#: src/Dashboard/Settings_Page.php:589
 msgid "archive.org/account/s3.php to generate your Access Key and Secret Key."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:602
-#: src/Dashboard/Settings_Page.php:858
+#: src/Dashboard/Settings_Page.php:603
+#: src/Dashboard/Settings_Page.php:859
 msgid "Enable the Link Fixer to scan links in your selected post types. It will find or create archived versions on the Internet Archive to ensure links remain accessible if they break."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:613
+#: src/Dashboard/Settings_Page.php:614
 #: templates/admin/dashboard/widget.php:104
 msgid "Auto Archiver"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:616
+#: src/Dashboard/Settings_Page.php:617
 msgid "Keep your content securely archived with the Auto Archiver. Each time you update a post, a fresh copy is saved to the Wayback Machine. Ensure your work remains accessible and preserved over time."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:618
+#: src/Dashboard/Settings_Page.php:619
 msgid "Non-production environment detected - auto archiving is disabled to prevent staging and development sites from being archived."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:630
+#: src/Dashboard/Settings_Page.php:631
 msgid "Enable Link Fixer"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:638
+#: src/Dashboard/Settings_Page.php:639
 msgid "Post Types"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:647
+#: src/Dashboard/Settings_Page.php:648
 msgid "Wipe Data on Uninstall"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:655
+#: src/Dashboard/Settings_Page.php:656
 msgid "Existing Posts"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:664
+#: src/Dashboard/Settings_Page.php:665
 msgid "Fixer Option"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:674
+#: src/Dashboard/Settings_Page.php:675
 msgid "Link Icon"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:683
+#: src/Dashboard/Settings_Page.php:684
 msgid "Link Exclusions"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:692
-#: src/Dashboard/Settings_Page.php:787
+#: src/Dashboard/Settings_Page.php:693
+#: src/Dashboard/Settings_Page.php:788
 msgid "Post Exclusions"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:701
+#: src/Dashboard/Settings_Page.php:702
 msgid "Check Frequency"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:710
+#: src/Dashboard/Settings_Page.php:711
 msgid "Failure Threshold"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:719
+#: src/Dashboard/Settings_Page.php:720
 msgid "Cast Archived Links to HTTPS"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:730
-#: src/Dashboard/Settings_Page.php:1437
+#: src/Dashboard/Settings_Page.php:731
+#: src/Dashboard/Settings_Page.php:1438
 msgid "Archive.org Access Key"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:741
-#: src/Dashboard/Settings_Page.php:1413
+#: src/Dashboard/Settings_Page.php:742
+#: src/Dashboard/Settings_Page.php:1414
 msgid "Archive.org Secret Key"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:752
+#: src/Dashboard/Settings_Page.php:753
 msgid "Auto Archive Posts"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:760
+#: src/Dashboard/Settings_Page.php:761
 msgid "Routinely Archive"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:769
+#: src/Dashboard/Settings_Page.php:770
 msgid "Routine Interval"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:778
+#: src/Dashboard/Settings_Page.php:779
 msgid "Allowed Post Types"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:809
+#: src/Dashboard/Settings_Page.php:810
 msgid "The Archive.org API keys are invalid. Please check your settings."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:810
+#: src/Dashboard/Settings_Page.php:811
 msgid "API credentials will be verified when you save the settings."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:890
+#: src/Dashboard/Settings_Page.php:891
 msgid "Please choose which post types will have their content checked and links added to the Wayback Machine."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:920
+#: src/Dashboard/Settings_Page.php:921
 msgid "Please choose which post types will be automatically archived to the Wayback Machine when they are published."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:939
+#: src/Dashboard/Settings_Page.php:940
 msgid "If checked, this will remove all local data when the plugin is uninstalled. Leave unchecked if you plan to reinstall this plugin."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:962
+#: src/Dashboard/Settings_Page.php:963
 msgid "When enabled, all posts of the allowed types will be scanned, and their links will be archived in the Wayback Machine."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:965
+#: src/Dashboard/Settings_Page.php:966
 msgid "This runs in the background and may take hours or days, depending on post and link count."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:983
+#: src/Dashboard/Settings_Page.php:984
 msgid "Enter a list of URLs (or parts of URLs) to exclude from link processing. You can use an asterisk (<code>*</code>) as a wildcard. For example, <code>https://example.com/some-path/*</code> would exclude anything after '/some-path/', and <code>*twitter.com*</code> would exclude any URL containing 'twitter.com'."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:998
+#: src/Dashboard/Settings_Page.php:999
 msgid "Add a new exclusion (https://x.com*)"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1001
+#: src/Dashboard/Settings_Page.php:1002
 msgid "Add"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1006
+#: src/Dashboard/Settings_Page.php:1007
 msgid "No exclusions found."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1051
+#: src/Dashboard/Settings_Page.php:1052
 msgid "Search for posts to exclude from link processing. Excluded posts will not have their links scanned or archived."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1059
-#: src/Dashboard/Settings_Page.php:1182
+#: src/Dashboard/Settings_Page.php:1060
+#: src/Dashboard/Settings_Page.php:1183
 msgid "Search by post title, slug, or ID..."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1069
-#: src/Dashboard/Settings_Page.php:1192
+#: src/Dashboard/Settings_Page.php:1070
+#: src/Dashboard/Settings_Page.php:1193
 msgid "No post exclusions found."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1077
-#: src/Dashboard/Settings_Page.php:1200
+#: src/Dashboard/Settings_Page.php:1078
+#: src/Dashboard/Settings_Page.php:1201
 #: templates/admin/reports/link-details.php:195
 msgid "Post"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1081
-#: src/Dashboard/Settings_Page.php:1204
+#: src/Dashboard/Settings_Page.php:1082
+#: src/Dashboard/Settings_Page.php:1205
 msgid "Unknown Post"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1139
-#: src/Dashboard/Settings_Page.php:1159
-#: src/Dashboard/Settings_Page.php:1262
-#: src/Dashboard/Settings_Page.php:1282
-#: src/Dashboard/Settings_Page.php:1390
+#: src/Dashboard/Settings_Page.php:1140
+#: src/Dashboard/Settings_Page.php:1160
+#: src/Dashboard/Settings_Page.php:1263
+#: src/Dashboard/Settings_Page.php:1283
+#: src/Dashboard/Settings_Page.php:1391
 msgid "Remove"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1174
+#: src/Dashboard/Settings_Page.php:1175
 msgid "Search for posts to exclude from auto archiving. Excluded posts will not be submitted to the Wayback Machine when created or updated."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1305
+#: src/Dashboard/Settings_Page.php:1306
 msgid "How often to recheck each link for validity. Avoid checking too often, as temporary outages or maintenance can cause false “broken” results. The default is 3 days."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1329
+#: src/Dashboard/Settings_Page.php:1330
 msgid "Number of consecutive failed checks before a link is marked as broken. Occasional single failures are normal, so use a value high enough to confirm genuine link loss. The default is 3."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1352
+#: src/Dashboard/Settings_Page.php:1353
 msgid "Force HTTPS"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1355
+#: src/Dashboard/Settings_Page.php:1356
 msgid "Enabling this will convert all archived urls from http to https."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1457
+#: src/Dashboard/Settings_Page.php:1458
 msgid "Redirect broken links to snapshots on the Wayback Machine"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1460
+#: src/Dashboard/Settings_Page.php:1461
 msgid "Check broken links but do not redirect them"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1463
+#: src/Dashboard/Settings_Page.php:1464
 msgid "Do not auto check links"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1467
+#: src/Dashboard/Settings_Page.php:1468
 msgid "Choose how to handle broken links."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1497
+#: src/Dashboard/Settings_Page.php:1498
 msgid "Example Link"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1501
+#: src/Dashboard/Settings_Page.php:1502
 msgid "Choose an icon to display next to fixed links."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1523
+#: src/Dashboard/Settings_Page.php:1524
 msgid "When active, your own content will be automatically archived on the Wayback Machine each time you publish or update it."
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1546
+#: src/Dashboard/Settings_Page.php:1547
 msgid "Regularly archive your posts on the Wayback Machine"
 msgstr ""
 
-#: src/Dashboard/Settings_Page.php:1571
+#: src/Dashboard/Settings_Page.php:1572
 msgid "Interval in days for regular archiving."
 msgstr ""
 
@@ -817,8 +817,8 @@ msgid "URL"
 msgstr ""
 
 #: src/Report/Report_Table.php:758
-#: templates/admin/dashboard/link-list.php:121
-#: templates/admin/dashboard/link-list.php:126
+#: templates/admin/dashboard/link-list.php:122
+#: templates/admin/dashboard/link-list.php:127
 #: templates/admin/links-table/help-tab-columns.php:16
 #: templates/admin/reports/link-details.php:43
 #: templates/admin/reports/link-details.php:46
@@ -969,35 +969,35 @@ msgstr ""
 msgid "Link is not excluded from checks"
 msgstr ""
 
-#: src/Report/Report_Table.php:1219
+#: src/Report/Report_Table.php:1221
 msgid "N/a"
 msgstr ""
 
 #. translators: %s: HTTP status code (e.g. 404).
-#: src/Report/Report_Table.php:1235
+#: src/Report/Report_Table.php:1237
 #, php-format
 msgid "%s status"
 msgstr ""
 
-#: src/Report/Report_Table.php:1239
-#: src/Report/Report_Table.php:1254
-#: templates/admin/dashboard/link-list.php:63
+#: src/Report/Report_Table.php:1241
+#: src/Report/Report_Table.php:1256
+#: templates/admin/dashboard/link-list.php:64
 msgid "No HTTP Code"
 msgstr ""
 
 #. translators: %1$s: last check date (e.g. "5 Jan 2025"), %2$s: HTTP status code (e.g. "404 status")
-#: src/Report/Report_Table.php:1248
-#: templates/admin/dashboard/link-list.php:68
+#: src/Report/Report_Table.php:1250
+#: templates/admin/dashboard/link-list.php:69
 #, php-format
 msgid "%1$s with %2$s"
 msgstr ""
 
-#: src/Report/Report_Table.php:1251
+#: src/Report/Report_Table.php:1253
 msgid "Missing date"
 msgstr ""
 
-#: src/Report/Report_Table.php:1266
-msgid "No links have been created yet."
+#: src/Report/Report_Table.php:1268
+msgid "No links to display."
 msgstr ""
 
 #: src/Settings/Settings.php:662
@@ -1099,91 +1099,92 @@ msgstr ""
 msgid "Excluded post"
 msgstr ""
 
-#: src/WP_Post/WP_Post_Table_Controller.php:175
+#: src/WP_Post/WP_Post_Table_Controller.php:161
+#: src/WP_Post/WP_Post_Table_Controller.php:176
 msgid "No links found"
 msgstr ""
 
 #. translators: 1: number of broken links, 2: total number of links
-#: src/WP_Post/WP_Post_Table_Controller.php:185
+#: src/WP_Post/WP_Post_Table_Controller.php:186
 #, php-format
 msgid "%1$s broken out of %2$s"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:61
+#: templates/admin/dashboard/link-list.php:62
 msgid "status"
 msgstr ""
 
 #. translators: %s: last checked date
-#: templates/admin/dashboard/link-list.php:75
+#: templates/admin/dashboard/link-list.php:76
 #, php-format
 msgid "Checked: %s"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:90
+#: templates/admin/dashboard/link-list.php:91
 msgid "Link Details:"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:92
+#: templates/admin/dashboard/link-list.php:93
 msgid "View Full Report"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:101
+#: templates/admin/dashboard/link-list.php:102
 #: templates/admin/reports/link-details.php:129
 msgid "Current Status"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:110
+#: templates/admin/dashboard/link-list.php:111
 msgid "Full URL"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:122
+#: templates/admin/dashboard/link-list.php:123
 #: templates/admin/reports/link-details.php:43
 msgid "EXCLUDED"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:131
+#: templates/admin/dashboard/link-list.php:132
 #: templates/admin/reports/link-details.php:51
 msgid "NEW - This link has been queued and will be processed by the Internet Archive as soon as possible."
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:133
+#: templates/admin/dashboard/link-list.php:134
 #: templates/admin/reports/link-details.php:53
 msgid "PENDING - Queued for submission to the Internet Archive. Processing time varies based on queue size."
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:136
+#: templates/admin/dashboard/link-list.php:137
 msgid "HAS ARCHIVE - A snapshot of this link is available on the Internet Archive"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:138
+#: templates/admin/dashboard/link-list.php:139
 #: templates/admin/reports/link-details.php:62
 msgid "NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible."
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:149
+#: templates/admin/dashboard/link-list.php:150
 #: templates/admin/reports/link-details.php:68
 msgid "Archived URL"
 msgstr ""
 
 #. translators: %d: number of posts
-#: templates/admin/dashboard/link-list.php:163
+#: templates/admin/dashboard/link-list.php:164
 #, php-format
 msgid "Found in %d post:"
 msgid_plural "Found in %d posts:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/admin/dashboard/link-list.php:174
+#: templates/admin/dashboard/link-list.php:175
 msgid "(No title)"
 msgstr ""
 
 #. translators: %d: number of additional posts containing this link beyond the first 12 shown
-#: templates/admin/dashboard/link-list.php:182
+#: templates/admin/dashboard/link-list.php:183
 #, php-format
 msgid "... and %d more"
 msgstr ""
 
-#: templates/admin/dashboard/link-list.php:191
+#: templates/admin/dashboard/link-list.php:192
 msgid "No posts found with this link."
 msgstr ""
 

--- a/src/Dashboard/Report_Page.php
+++ b/src/Dashboard/Report_Page.php
@@ -304,9 +304,6 @@ class Report_Page {
 		// Render the list table, reusing the load-{hook} instance so its notices render.
 		$table = $this->table ?? new Report_Table( new Link_Repository() );
 
-		// Render any notices.
-		$table->render_notices();
-
 		// Get the current page.
 		$current_page = isset( $_REQUEST['page'] ) ? \sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : self::SLUG; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.
 
@@ -317,6 +314,9 @@ class Report_Page {
 		);
 
 		echo '<hr class="wp-header-end">';
+
+		// Notices belong inside .wrap, after wp-header-end, where WordPress positions them.
+		$table->render_notices();
 
 		// If we have a post id in params, show a message.
 		if ( array_key_exists( 'iawmlf_filtered_post_id', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, Can be linked, so no nonce possible.

--- a/src/Dashboard/Settings_Page.php
+++ b/src/Dashboard/Settings_Page.php
@@ -209,8 +209,6 @@ class Settings_Page {
 	 * @return  void
 	 */
 	public function render_page(): void {
-		iawmlf_render_not_authenticated_notice();
-
 		// Check if the wizard has been completed.
 		$wizard_link = '';
 		if ( Settings::is_wizard_completed() ) {
@@ -229,9 +227,12 @@ class Settings_Page {
 
 		echo '<hr class="wp-header-end">';
 
+		// Notices belong inside .wrap, after wp-header-end, where WordPress positions them.
+		iawmlf_render_not_authenticated_notice();
+
 		if ( ! get_user_meta( get_current_user_id(), 'iawmlf_dismiss_donation_cta', true ) ) {
 			printf(
-				'<div class="iawmlf_donation_cta" id="iawmlf_donation_cta"><img src="%s" alt="%s" class="iawmlf_donation_cta__logo" /><p>%s</p><a href="%s" target="_blank" class="button button-primary iawmlf_donation_cta__button">%s</a><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+				'<div class="iawmlf_donation_cta" id="iawmlf_donation_cta"><img src="%s" alt="%s" class="iawmlf_donation_cta__logo" /><p>%s</p><a href="%s" target="_blank" rel="noopener noreferrer" class="button button-primary iawmlf_donation_cta__button">%s</a><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
 				esc_url( IAWMLF_URL . 'assets/images/ia-logo.svg' ),
 				esc_attr__( 'Internet Archive', 'internet-archive-wayback-machine-link-fixer' ),
 				esc_html__( 'This plugin is powered by the Internet Archive. If you find the plugin useful, please chip in! Your support will help us build the web we deserve.', 'internet-archive-wayback-machine-link-fixer' ),
@@ -582,7 +583,7 @@ class Settings_Page {
 			function () {
 				printf(
 					/* translators: 1: Opening sentence, 2: URL to the Internet Archive S3 keys page, 3: Closing sentence. */
-					'<p class="description">%1$s <a href="%2$s" target="_blank">%3$s</a></p>',
+					'<p class="description">%1$s <a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></p>',
 					esc_html__( 'To increase your daily snapshot limit from 4,000 to 30,000, you can enter your free Archive.org API credentials. Visit', 'internet-archive-wayback-machine-link-fixer' ),
 					esc_url( 'https://archive.org/account/s3.php' ),
 					esc_html__( 'archive.org/account/s3.php to generate your Access Key and Secret Key.', 'internet-archive-wayback-machine-link-fixer' )
@@ -620,7 +621,7 @@ class Settings_Page {
 			},
 			self::PAGE_SLUG,
 			array(
-				'before_section' => sprintf( '<div id="iawmlf_settings_link_fixer_section" class="iawmlf_settings_postbox auto-archiver %s">', ! Environmental::is_production() ? 'staging' : '' ),
+				'before_section' => sprintf( '<div id="iawmlf_settings_auto_archiver_section" class="iawmlf_settings_postbox auto-archiver %s">', ! Environmental::is_production() ? 'staging' : '' ),
 				'after_section'  => '</div>',
 			)
 		);

--- a/src/Report/Report_Table.php
+++ b/src/Report/Report_Table.php
@@ -1123,7 +1123,7 @@ class Report_Table extends \WP_List_Table {
 
 				if ( $item->has_archived_href() ) {
 					return sprintf(
-						'<a href="%s" target="_blank">%s</a>',
+						'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 						esc_url( $item->get_archived_href() ),
 						$this->get_dashicon( 'dashicons-yes-alt', __( 'Has a valid archive snapshot', 'internet-archive-wayback-machine-link-fixer' ) )
 					);
@@ -1178,12 +1178,14 @@ class Report_Table extends \WP_List_Table {
 	 * @return string
 	 */
 	private function get_dashicon( string $icon, string $title = '' ): string {
+		// Without a title the icon is decorative, so hide it from screen readers.
 		return '' === $title ? sprintf(
-			'<span class="dashicons %s"></span>',
+			'<span class="dashicons %s" aria-hidden="true"></span>',
 			esc_attr( $icon )
 		) : sprintf(
-			'<span class="dashicons %s" title="%s"></span>',
+			'<span class="dashicons %s" title="%s" role="img" aria-label="%s"></span>',
 			esc_attr( $icon ),
+			esc_attr( $title ),
 			esc_attr( $title )
 		);
 	}
@@ -1197,7 +1199,7 @@ class Report_Table extends \WP_List_Table {
 	 */
 	private function compile_link_name( Link $item ): string {
 		return sprintf(
-			'%s <a href="%s" target="_blank">%s</a>',
+			'%s <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 			esc_html( iawmlf_trim_string( $item->get_href(), 200 ) ),
 			esc_url( $item->get_href() ),
 			'<span class="dashicons dashicons-external"></span>'
@@ -1228,7 +1230,7 @@ class Report_Table extends \WP_List_Table {
 
 		$last_status_display = $last_check_status
 			? sprintf(
-				'<a href="%1$s" target="_blank">%2$s</a>',
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 				esc_url( "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/{$last_check_status}" ),
 				sprintf(
 					// translators: %s: HTTP status code (e.g. 404).
@@ -1263,6 +1265,6 @@ class Report_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function no_items() {
-		echo esc_html__( 'No links have been created yet.', 'internet-archive-wayback-machine-link-fixer' );
+		echo esc_html__( 'No links to display.', 'internet-archive-wayback-machine-link-fixer' );
 	}
 }

--- a/src/Util/Esc.php
+++ b/src/Util/Esc.php
@@ -58,6 +58,12 @@ class Esc {
 				'id'     => array(),
 				'style'  => array(),
 			),
+			// The footer uses an empty span as a flex spacer on step 1.
+			'span'   => array(
+				'class' => array(),
+				'id'    => array(),
+				'style' => array(),
+			),
 		);
 	}
 }

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -156,8 +156,9 @@ class WP_Post_Table_Controller {
 		// Get the links from the posts meta.
 		$links = get_post_meta( $post_id, Settings::LINK_META_KEY, true );
 
-		// If we have no links (empty or not an array), return.
+		// If we have no links (empty or not an array), say so rather than leaving the cell blank.
 		if ( ! is_array( $links ) || empty( $links ) ) {
+			echo esc_html__( 'No links found', 'internet-archive-wayback-machine-link-fixer' );
 			return;
 		}
 

--- a/templates/admin/dashboard/link-list.php
+++ b/templates/admin/dashboard/link-list.php
@@ -35,9 +35,10 @@ defined( 'ABSPATH' ) || exit;
 							<span class="iawmlf_dashboard-link-check-status <?php echo esc_attr( $iawmlf_link->is_broken() ? 'broken' : 'working' ); ?>">
 								<span class="dashicons <?php echo esc_attr( $iawmlf_link->is_broken() ? 'dashicons-no-alt' : 'dashicons-yes-alt' ); ?>"></span>
 							</span>
-							<a href="<?php echo esc_url( add_query_arg( array( 'iawmlf_link_id' => $iawmlf_link->get_id() ), $iawmlf_link_table ) ); ?>" class="iawmlf_dashboard-link-check-title">
+							<?php $iawmlf_details_id = $iawmlf_section_id . '-link-' . $iawmlf_link->get_id(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, not a global ?>
+							<button type="button" class="iawmlf_dashboard-link-check-title" aria-expanded="false" aria-controls="<?php echo esc_attr( $iawmlf_details_id ); ?>">
 								<?php echo esc_html( $iawmlf_link->get_href() ); ?>
-							</a>
+							</button>
 						</div>
 						<div class="iawmlf_dashboard-link-check-meta">
 							<?php if ( $iawmlf_link->get_last_check() ) : ?>
@@ -83,7 +84,7 @@ defined( 'ABSPATH' ) || exit;
 
 					</div>
 
-					<div class="iawmlf_dashboard-link-check-details">
+					<div class="iawmlf_dashboard-link-check-details" id="<?php echo esc_attr( $iawmlf_details_id ); ?>">
 						<div class="iawmlf_dashboard-link-check-posts">
 							<div class="iawmlf_dashboard-link-check-details">
 								<div class="iawmlf_dashboard-link-check-details-item">
@@ -147,7 +148,7 @@ defined( 'ABSPATH' ) || exit;
 										<div class="iawmlf_link-archived-url-section">
 											<p class="iawmlf_link_archived_url">
 												<strong><?php esc_html_e( 'Archived URL', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>:
-												<a href="<?php echo esc_url( $iawmlf_link->get_archived_href() ); ?>" target="_blank">
+												<a href="<?php echo esc_url( $iawmlf_link->get_archived_href() ); ?>" target="_blank" rel="noopener noreferrer">
 													<?php echo esc_html( $iawmlf_link->get_archived_href() ); ?>
 												</a>
 											</p>

--- a/templates/admin/reports/link-details.php
+++ b/templates/admin/reports/link-details.php
@@ -37,7 +37,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 							<h2 class="handle ui-sortable-handle"><?php esc_html_e( 'Link Details', 'internet-archive-wayback-machine-link-fixer' ); ?></h2>
 						</div>
 						<div class="inside">
-							<p class="iawmlf_link_url"><strong><?php esc_html_e( 'URL', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $iawmlf_link->get_href() ); ?>" target="_blank"><?php echo esc_html( $iawmlf_link->get_href() ); ?></a></p>
+							<p class="iawmlf_link_url"><strong><?php esc_html_e( 'URL', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $iawmlf_link->get_href() ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $iawmlf_link->get_href() ); ?></a></p>
 
 							<?php if ( $iawmlf_link->is_excluded() ) : ?>
 								<p class="iawmlf_link_archived_url"><strong><?php esc_html_e( 'Archive Status', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <?php esc_html_e( 'EXCLUDED', 'internet-archive-wayback-machine-link-fixer' ); ?></p>
@@ -56,7 +56,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 										printf(
 											/* translators: %s: The archived URL */
 											esc_html__( 'HAS ARCHIVE - A snapshot of this link is available on the Internet Archive: %s', 'internet-archive-wayback-machine-link-fixer' ),
-											'<a href="' . esc_url( $iawmlf_link->get_archived_href() ) . '" target="_blank">' . esc_html__( 'View Snapshot', 'internet-archive-wayback-machine-link-fixer' ) . '</a>'
+											'<a href="' . esc_url( $iawmlf_link->get_archived_href() ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'View Snapshot', 'internet-archive-wayback-machine-link-fixer' ) . '</a>'
 										);
 									} else {
 										esc_html_e( 'NO ARCHIVE - Unable to create or find a snapshot. This can happen if the URL is blocked by robots.txt, requires authentication, or is no longer accessible.', 'internet-archive-wayback-machine-link-fixer' );
@@ -65,7 +65,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 								</p>
 
 								<?php if ( '' !== $iawmlf_link->get_archived_href() ) : ?>
-									<p class="iawmlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $iawmlf_link->get_archived_href() ); ?>" target="_blank"><?php echo esc_html( $iawmlf_link->get_archived_href() ); ?></a></p>
+									<p class="iawmlf_link_archived_url"><strong><?php esc_html_e( 'Archived URL', 'internet-archive-wayback-machine-link-fixer' ); ?></strong>: <a href="<?php echo esc_url( $iawmlf_link->get_archived_href() ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $iawmlf_link->get_archived_href() ); ?></a></p>
 								<?php endif; ?>
 							<?php endif; ?>
 
@@ -106,7 +106,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 								<label>
 									<?php if ( Link_Exclusion::get_instance()->is_excluded( $iawmlf_link ) ) : ?>
 										<input type="hidden" name="iawmlf_exclude_link" value="<?php echo esc_attr( $iawmlf_link->is_excluded() ); ?>" />
-										<input type="checkbox" disabled name="iawmlf_exclude_link_disp" value="1" id="iawmlf_toggle_exclusion" <?php checked( $iawmlf_link->is_excluded() ); ?> disabled />
+										<input type="checkbox" disabled name="iawmlf_exclude_link_disp" value="1" id="iawmlf_toggle_exclusion" <?php checked( $iawmlf_link->is_excluded() ); ?> />
 										<?php esc_html_e( 'This link is excluded by a settings or built-in exclusion rule and cannot be toggled here.', 'internet-archive-wayback-machine-link-fixer' ); ?>
 									<?php else : ?>
 										<input type="checkbox" name="iawmlf_exclude_link" value="1" id="iawmlf_toggle_exclusion" <?php checked( $iawmlf_link->is_excluded() ); ?> />
@@ -170,7 +170,7 @@ $iawmlf_link_title = iawmlf_trim_string( str_replace( array( 'http://', 'https:/
 													?>
 												</td>
 												<?php if ( is_numeric( $iawmlf_check['http_code'] ) ) : ?>
-													<td class="iawmlf-archived__http-code"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/<?php echo esc_attr( $iawmlf_check['http_code'] ); ?>" target="_blank"><?php echo esc_html( $iawmlf_check['http_code'] ); ?></a></td>
+													<td class="iawmlf-archived__http-code"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/<?php echo esc_attr( $iawmlf_check['http_code'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $iawmlf_check['http_code'] ); ?></a></td>
 												<?php else : ?>
 													<td class="iawmlf-archived__error"><?php esc_html_e( 'Error', 'internet-archive-wayback-machine-link-fixer' ); ?></td>
 												<?php endif; ?>

--- a/templates/admin/wizard/step-1.php
+++ b/templates/admin/wizard/step-1.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
 		printf(
 			/* translators: %s: Wayback Machine link */
 			esc_html__( 'This plugin automatically fixes broken links on your site by redirecting them to archived versions on the %s.', 'internet-archive-wayback-machine-link-fixer' ),
-			'<a href="https://wayback.archive.org" target="_blank">' . esc_html__( 'Wayback Machine', 'internet-archive-wayback-machine-link-fixer' ) . '</a>'
+			'<a href="https://wayback.archive.org" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Wayback Machine', 'internet-archive-wayback-machine-link-fixer' ) . '</a>'
 		);
 		?>
 	</p>

--- a/tests/WP_Post/Test_WP_Post_Table_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Table_Controller.php
@@ -82,4 +82,40 @@ class Test_WP_Post_Table_Controller extends \WP_UnitTestCase {
 		// Clean up.
 		delete_option( Settings::LINK_FIXER_EXCLUDED_POSTS );
 	}
+
+	/**
+	 * @testdox It should show "No links found" when the post has no link meta at all.
+	 *
+	 * @return void
+	 */
+	public function test_render_link_column_shows_no_links_found_without_meta(): void {
+		$post_id = self::factory()->post->create();
+
+		$controller = new WP_Post_Table_Controller();
+
+		ob_start();
+		$controller->render_link_column( WP_Post_Table_Controller::LINK_COLUMN_KEY, $post_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'No links found', $output );
+	}
+
+	/**
+	 * @testdox It should show "No links found" when the link meta holds only ids that no longer resolve.
+	 *
+	 * @return void
+	 */
+	public function test_render_link_column_shows_no_links_found_for_unresolvable_ids(): void {
+		$post_id = self::factory()->post->create();
+
+		update_post_meta( $post_id, Settings::LINK_META_KEY, array( 999999 ) );
+
+		$controller = new WP_Post_Table_Controller();
+
+		ob_start();
+		$controller->render_link_column( WP_Post_Table_Controller::LINK_COLUMN_KEY, $post_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'No links found', $output );
+	}
 }


### PR DESCRIPTION
Fixes nine items from the admin UI, UX and accessibility group in #370.

**S088 — the dashboard accordion toggle was a link that never navigated.**

`link-list.php` rendered each link title as a real `<a href>` to the details page, and `dashboard.js` cancelled every click on it to toggle the details panel instead. Middle-click and ctrl-click bypassed the handler and navigated; plain click and keyboard Enter toggled. Screen readers announced a link to a page it would never open.

Now a `<button>` carrying `aria-expanded` and `aria-controls`, kept visually identical by a button reset in the stylesheet. Nothing is lost — the panel already contains a "View Full Report" link to the details page.

**S089 — the three status columns were unreadable to a screen reader.**

Archive Status, Link Health and Excluded render only a dashicon `<span>`, with the label in a `title` attribute. The glyph is CSS content and `title` on a bare span isn't reliably announced, so those cells read as empty.

`get_dashicon()` now emits `role="img"` and `aria-label` alongside the existing `title`, and `aria-hidden="true"` on the decorative no-title case. Every caller already passed a proper label.

**S097 — admin notices printed outside `.wrap`.**

`Report_Page::render_list_page()` called `render_notices()` before opening `.wrap`, and `Settings_Page::render_page()` called `iawmlf_render_not_authenticated_notice()` before its own. Both moved to just after `<hr class="wp-header-end">`.

Covered by a new e2e spec. It asserts against the server-rendered HTML rather than the live DOM, because admin scripts can relocate `.notice` elements after load and a DOM position wouldn't prove where the page printed it. Both assertions fail on the unfixed code.

**S091 — duplicate DOM id.** The Auto Archiver settings section opened a `<div>` with the Link Fixer section's id. Renamed to `iawmlf_settings_auto_archiver_section`, matching the naming the Archive.org section already uses.

**S086 — wizard footer spacer stripped.** `Esc::wizard_allowed_tags()` had no `span` entry, and every wizard step runs its footer through `wp_kses()` with that list. Step 1 renders an empty `<span>` as a flex spacer in place of the Previous button, so it was stripped and the Next button shifted left.

**S146 — misleading empty table.** `no_items()` always said "No links have been created yet", including when a search or any of the four filters returned nothing. Now "No links to display.", which is true either way.

**S156 — blank cell in the post-list Links column.** With no link meta the column returned without output, giving an empty cell indistinguishable from a rendering failure; with unresolvable ids it printed "No links found". Both now print the same message. Two tests added — one fails on the unfixed code, the other pins the existing branch.

**S150 — duplicate `disabled` attribute** on the exclusion checkbox.

**S163 — inconsistent `rel` on external links.** 11 of the 13 `target="_blank"` links across the admin screens had no `rel` at all. All now carry `rel="noopener noreferrer"`. Several point at user-supplied URLs, where `noreferrer` also keeps the admin URL out of the referrer header.

The `.pot` is regenerated.
