### PR TITLE
Audit 1.4.3 — Action Scheduler pipeline (#371)

### DIFF
--- a/src/Event/Check_Snapshot_Status_Event.php
+++ b/src/Event/Check_Snapshot_Status_Event.php
@@ -46,21 +46,17 @@ class Check_Snapshot_Status_Event {
 	 * @var integer
 	 */
 	private $attempts = 0;
-	/**
-	 * Create instance of the class.
-	 */
-	public function __construct() {
-		$this->attempts = absint( apply_filters( 'iawmlf_check_snapshot_status_attempts', 3 ) );
-	}
 
 	/**
 	 * Setup the event.
+	 * Read at call time, so filters registered after plugins_loaded still apply.
 	 *
 	 * @return void
 	 */
 	public function setup(): void {
 		$this->link_repository = new Link_Repository();
 		$this->wayback_machine = new Wayback_Machine_Service();
+		$this->attempts        = absint( apply_filters( 'iawmlf_check_snapshot_status_attempts', 3 ) );
 	}
 
 	/**

--- a/src/Event/Check_Validator_Status.php
+++ b/src/Event/Check_Validator_Status.php
@@ -46,21 +46,17 @@ class Check_Validator_Status {
 	 * @var integer
 	 */
 	private $attempts = 0;
-	/**
-	 * Create instance of the class.
-	 */
-	public function __construct() {
-		$this->attempts = apply_filters( 'iawmlf_check_validator_status_attempts', 3 );
-	}
 
 	/**
 	 * Setup the event.
+	 * Read at call time, so filters registered after plugins_loaded still apply.
 	 *
 	 * @return void
 	 */
 	public function setup(): void {
 		$this->link_repository = new Link_Repository();
 		$this->wayback_machine = new Wayback_Machine_Service();
+		$this->attempts        = apply_filters( 'iawmlf_check_validator_status_attempts', 3 );
 	}
 
 	/**

--- a/src/Event/Scan_Own_Posts_Event.php
+++ b/src/Event/Scan_Own_Posts_Event.php
@@ -107,6 +107,9 @@ class Scan_Own_Posts_Event {
 		$excluded_posts     = Settings::get_auto_archiver_excluded_posts();
 		$posts_per_call     = absint( apply_filters( 'iawmlf_scan_own_posts_per_call', 10 ) );
 
+		// Posts already waiting in the queue, re-queuing them would only reset their delay.
+		$skipped_posts = array_unique( array_merge( $excluded_posts, self::get_queued_post_ids() ) );
+
 		$args = array(
 			'posts_per_page' => $posts_per_call,
 			'post_type'      => $allowed_post_types,
@@ -128,9 +131,9 @@ class Scan_Own_Posts_Event {
 			),
 		);
 
-		// Exclude any posts that have been marked as excluded.
-		if ( ! empty( $excluded_posts ) ) {
-			$args['post__not_in'] = $excluded_posts;
+		// Exclude any posts that are excluded or already queued.
+		if ( ! empty( $skipped_posts ) ) {
+			$args['post__not_in'] = $skipped_posts;
 		}
 
 		// Get all posts that are in the defined post types and have not been checked since
@@ -141,9 +144,42 @@ class Scan_Own_Posts_Event {
 			return;
 		}
 
-		// Loop through the posts and add them to the queue.
+		// Loop through the posts and add them to the queue. No delay, these are already due.
 		foreach ( $posts->posts as $post ) {
-			$this->post_controller->add_own_post_to_wayback_machine( $post->ID );
+			$this->post_controller->add_own_post_to_wayback_machine( $post->ID, 0 );
 		}
+	}
+
+	/**
+	 * Gets the ids of all posts that already have a process event waiting in the queue.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @return integer[]
+	 */
+	private static function get_queued_post_ids(): array {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return array();
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => Process_Local_Post_Event::HANDLE,
+				'status'   => array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ),
+				'per_page' => -1,
+			)
+		);
+
+		$post_ids = array();
+
+		foreach ( $actions as $action ) {
+			$args = $action->get_args();
+
+			if ( isset( $args['post_id'] ) ) {
+				$post_ids[] = (int) $args['post_id'];
+			}
+		}
+
+		return $post_ids;
 	}
 }

--- a/src/Event/Scan_Posts_Event.php
+++ b/src/Event/Scan_Posts_Event.php
@@ -162,8 +162,5 @@ class Scan_Posts_Event {
 				$this->post_controller->process_links_in_content( $post->ID );
 			}
 		}
-
-		// Add the event to the action scheduler again.
-		self::add_to_action_scheduler();
 	}
 }

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -138,13 +138,14 @@ class WP_Post_Controller {
 	/**
 	 * Adds the permalink of a post to the wayback machine.
 	 *
-	 * @param integer $post_id The post id.
+	 * @param integer      $post_id The post id.
+	 * @param integer|null $delay   The queue delay in seconds, null for the default of 1 hour.
 	 *
 	 * @return void
 	 *
 	 * @throws \Exception If the post id is not valid.
 	 */
-	public function add_own_post_to_wayback_machine( int $post_id ): void {
+	public function add_own_post_to_wayback_machine( int $post_id, ?int $delay = null ): void {
 
 		// Get the post.
 		$post = get_post( $post_id );
@@ -158,7 +159,11 @@ class WP_Post_Controller {
 		$can_add     = apply_filters( 'iawmlf_own_content_allow_post', ! $is_excluded, $post );
 
 		if ( $can_add ) {
-			Process_Local_Post_Event::add_to_queue_with_delay( $post_id );
+			if ( null === $delay ) {
+				Process_Local_Post_Event::add_to_queue_with_delay( $post_id );
+			} else {
+				Process_Local_Post_Event::add_to_queue_with_delay( $post_id, $delay );
+			}
 		}
 	}
 

--- a/tests/Event/Test_Check_Snapshot_Status_Event.php
+++ b/tests/Event/Test_Check_Snapshot_Status_Event.php
@@ -56,8 +56,82 @@ class Test_Check_Snapshot_Status_Event extends \WP_UnitTestCase {
 		// Remove client mocks so they can't leak into later tests under random ordering.
 		remove_all_filters( 'iawmlf_snapshot_client' );
 		remove_all_filters( 'iawmlf_link_checker_client' );
+		remove_all_filters( 'iawmlf_check_snapshot_status_attempts' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * @testdox A theme or init hook registers its filter after the event is built, and it should still apply.
+	 *
+	 * @return void
+	 */
+	public function test_attempts_filter_added_after_construction_applies(): void {
+		\remove_all_filters( 'iawmlf_check_snapshot_status_attempts' );
+
+		$this->set_snapshot_client_response(
+			array(
+				'status'  => 'pending',
+				'message' => '',
+			)
+		);
+
+		// Built on plugins_loaded, before the theme is loaded and before init.
+		$event = new Check_Snapshot_Status_Event();
+
+		// Registered later, as a theme or an init hook would.
+		\add_filter( 'iawmlf_check_snapshot_status_attempts', fn() => 10 );
+
+		$link = $this->link_repository->upsert( new Link( 'https://example.com' ) );
+
+		// Attempt 5 is under the filtered limit but over the default of 3.
+		$event( $link->get_id(), 'fake-id', 5 );
+
+		$queued = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT args FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook = %s AND status = 'pending'",
+				Check_Snapshot_Status_Event::HANDLE
+			)
+		);
+
+		$this->assertNotNull( $queued );
+		$this->assertSame( 6, json_decode( $queued->args )->attempt );
+	}
+
+	/**
+	 * @testdox The same filter registered before the event is built does apply.
+	 *
+	 * @return void
+	 */
+	public function test_attempts_filter_added_before_construction_applies(): void {
+		\remove_all_filters( 'iawmlf_check_snapshot_status_attempts' );
+
+		$this->set_snapshot_client_response(
+			array(
+				'status'  => 'pending',
+				'message' => '',
+			)
+		);
+
+		\add_filter( 'iawmlf_check_snapshot_status_attempts', fn() => 10 );
+
+		$link = $this->link_repository->upsert( new Link( 'https://example.com' ) );
+
+		$event = new Check_Snapshot_Status_Event();
+		$event->setup();
+
+		// Attempt 5 is under the filtered limit, so it should carry on and requeue.
+		$event( $link->get_id(), 'fake-id', 5 );
+
+		$queued = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT args FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook = %s AND status = 'pending'",
+				Check_Snapshot_Status_Event::HANDLE
+			)
+		);
+
+		$this->assertNotNull( $queued );
+		$this->assertSame( 6, json_decode( $queued->args )->attempt );
 	}
 
 	/**

--- a/tests/Event/Test_Check_Validator_Status.php
+++ b/tests/Event/Test_Check_Validator_Status.php
@@ -50,8 +50,41 @@ class Test_Check_Validator_Status extends \WP_UnitTestCase {
 	public function tear_down(): void {
 		remove_all_filters( 'iawmlf_snapshot_client' );
 		remove_all_filters( 'iawmlf_link_checker_client' );
+		remove_all_filters( 'iawmlf_check_validator_status_attempts' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * @testdox A theme or init hook registers its filter after the event is built, and it should still apply.
+	 *
+	 * @return void
+	 */
+	public function test_attempts_filter_added_after_construction_applies(): void {
+		\remove_all_filters( 'iawmlf_check_validator_status_attempts' );
+
+		$this->set_snapshot_client_response( array( 'status' => 'pending' ) );
+
+		// Built on plugins_loaded, before the theme is loaded and before init.
+		$event = new Check_Validator_Status();
+
+		// Registered later, as a theme or an init hook would.
+		\add_filter( 'iawmlf_check_validator_status_attempts', fn() => 10 );
+
+		$link = $this->link_repository->upsert( new Link( 'https://example.com' ) );
+
+		// Attempt 5 is under the filtered limit but over the default of 3.
+		$event( $link->get_id(), 'fake-job', 5 );
+
+		$queued = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT args FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook = %s AND status = 'pending'",
+				Check_Validator_Status::HANDLE
+			)
+		);
+
+		$this->assertNotNull( $queued );
+		$this->assertSame( 6, json_decode( $queued->args )->attempt );
 	}
 
 	/**

--- a/tests/Event/Test_Scan_Own_Posts_Event.php
+++ b/tests/Event/Test_Scan_Own_Posts_Event.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Internet_Archive\Wayback_Machine_Link_Fixer\Tests\Processor;
 
 use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Scan_Own_Posts_Event;
+use Internet_Archive\Wayback_Machine_Link_Fixer\Event\Process_Local_Post_Event;
 use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
 use Internet_Archive\Wayback_Machine_Link_Fixer_Tests\Tools\Wayback_Machine_Helper;
 
@@ -210,6 +211,180 @@ class Test_Scan_Own_Posts_Event extends \WP_UnitTestCase {
 
 		// Check that the action is for post 2.
 		$this->assertSame( $post_id_2, json_decode( $actions[0]->args )->post_id );
+	}
+
+	/**
+	 * @testdox The scan should queue its posts with no delay, as they are already due to be archived.
+	 *
+	 * @return void
+	 */
+	public function test_scan_queues_posts_with_no_delay(): void {
+		\add_filter( 'iawmlf_own_content_allow_post', '__return_true' );
+		\add_filter( 'iawmlf_routinely_update_wayback_machine', '__return_true' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$event = new Scan_Own_Posts_Event();
+		$event();
+
+		$pending = $this->get_pending_action( $post_id );
+
+		$this->assertNotNull( $pending );
+
+		// Due now, not an hour out.
+		$this->assertLessThan( 60, \strtotime( $pending->scheduled_date_gmt ) - time() );
+	}
+
+	/**
+	 * @testdox A post that already has a job waiting should not be picked up by the scan, as re-queuing would reset its delay.
+	 *
+	 * @return void
+	 */
+	public function test_posts_already_in_the_queue_are_not_rescanned(): void {
+		\add_filter( 'iawmlf_own_content_allow_post', '__return_true' );
+		\add_filter( 'iawmlf_routinely_update_wayback_machine', '__return_true' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		// The save hook queues the post an hour out.
+		Process_Local_Post_Event::add_to_queue_with_delay( $post_id );
+
+		$queued = $this->get_pending_action( $post_id );
+
+		$this->assertNotNull( $queued );
+
+		$event = new Scan_Own_Posts_Event();
+
+		// Four scan passes, with 15 minutes of simulated time between each.
+		for ( $pass = 0; $pass < 4; $pass++ ) {
+			$this->rewind_pending_action( $post_id, 15 * MINUTE_IN_SECONDS );
+
+			$event();
+
+			$pending = $this->get_pending_action( $post_id );
+
+			$this->assertNotNull( $pending, "No pending job after pass {$pass}." );
+
+			// Same job as the one the save hook queued, untouched by the scan.
+			$this->assertSame( (int) $queued->action_id, (int) $pending->action_id, "The job was replaced on pass {$pass}." );
+		}
+
+		// The job is now due, having counted down the full hour.
+		$this->assertLessThan( 60, \strtotime( $pending->scheduled_date_gmt ) - time() );
+
+		// Nothing was cancelled along the way.
+		$this->assertSame( 0, $this->count_actions( $post_id, 'canceled' ) );
+	}
+
+	/**
+	 * @testdox Posts that are already queued should not use up the scans batch, so every pass queues new work.
+	 *
+	 * @return void
+	 */
+	public function test_queued_posts_do_not_use_up_the_batch(): void {
+		\add_filter( 'iawmlf_own_content_allow_post', '__return_true' );
+		\add_filter( 'iawmlf_routinely_update_wayback_machine', '__return_true' );
+
+		// A batch of 2, with 4 posts to get through.
+		\add_filter( 'iawmlf_scan_own_posts_per_call', fn() => 2 );
+
+		$post_ids = $this->factory->post->create_many( 4, array( 'post_type' => 'post' ) );
+
+		$event = new Scan_Own_Posts_Event();
+		$event();
+
+		$this->assertSame( 2, $this->count_pending_actions() );
+
+		// The next pass should queue the other two, not re-queue the first two.
+		$event();
+
+		$this->assertSame( 4, $this->count_pending_actions() );
+
+		// One job per post, and none of them cancelled.
+		foreach ( $post_ids as $post_id ) {
+			$this->assertNotNull( $this->get_pending_action( $post_id ) );
+			$this->assertSame( 0, $this->count_actions( $post_id, 'canceled' ) );
+		}
+	}
+
+	/**
+	 * Gets the single pending job for a post, or null.
+	 *
+	 * @param integer $post_id The post id.
+	 *
+	 * @return object|null
+	 */
+	private function get_pending_action( int $post_id ) {
+		return $GLOBALS['wpdb']->get_row(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT * FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE status = 'pending' AND hook = %s AND args = %s",
+				Process_Local_Post_Event::HANDLE,
+				\wp_json_encode( array( 'post_id' => $post_id ) )
+			)
+		);
+	}
+
+	/**
+	 * Counts the jobs for a post with a given status.
+	 *
+	 * @param integer $post_id The post id.
+	 * @param string  $status  The action scheduler status.
+	 *
+	 * @return integer
+	 */
+	private function count_actions( int $post_id, string $status ): int {
+		return (int) $GLOBALS['wpdb']->get_var(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT COUNT(*) FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE status = %s AND hook = %s AND args = %s",
+				$status,
+				Process_Local_Post_Event::HANDLE,
+				\wp_json_encode( array( 'post_id' => $post_id ) )
+			)
+		);
+	}
+
+	/**
+	 * Counts all pending process events.
+	 *
+	 * @return integer
+	 */
+	private function count_pending_actions(): int {
+		return (int) $GLOBALS['wpdb']->get_var(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT COUNT(*) FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE status = 'pending' AND hook = %s",
+				Process_Local_Post_Event::HANDLE
+			)
+		);
+	}
+
+	/**
+	 * Simulates time passing by moving the pending job's due date earlier.
+	 *
+	 * @param integer $post_id The post id.
+	 * @param integer $seconds How much time has passed.
+	 *
+	 * @return void
+	 */
+	private function rewind_pending_action( int $post_id, int $seconds ): void {
+		$action = $this->get_pending_action( $post_id );
+
+		if ( null === $action ) {
+			return;
+		}
+
+		$new_timestamp = \strtotime( $action->scheduled_date_gmt ) - $seconds;
+
+		$GLOBALS['wpdb']->update(
+			$GLOBALS['wpdb']->prefix . 'actionscheduler_actions',
+			array(
+				'scheduled_date_gmt'   => \gmdate( 'Y-m-d H:i:s', $new_timestamp ),
+				'scheduled_date_local' => \gmdate( 'Y-m-d H:i:s', $new_timestamp ),
+				'schedule'             => \preg_replace( '/i:\d{9,};/', 'i:' . $new_timestamp . ';', $action->schedule ),
+			),
+			array( 'action_id' => $action->action_id ),
+			array( '%s', '%s', '%s' ),
+			array( '%d' )
+		);
 	}
 
 }

--- a/tests/Event/Test_Scan_Posts_Event.php
+++ b/tests/Event/Test_Scan_Posts_Event.php
@@ -125,4 +125,93 @@ class Test_Scan_Posts_Event extends \WP_UnitTestCase {
 			'The excluded post should not have been processed.'
 		);
 	}
+
+	/**
+	 * @testdox While the event is still running, its own call to reschedule itself is blocked by the already scheduled guard.
+	 *
+	 * @return void
+	 */
+	public function test_reschedule_is_blocked_while_the_event_is_running(): void {
+		\update_option( Settings::PROCESS_LINKS, true );
+		\update_option( Settings::SCAN_EXISTING_POSTS, true );
+
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		$this->assertSame( 1, $this->count_actions( 'pending' ) );
+
+		// Mark the action as running, exactly as Action Scheduler does before it calls the event.
+		$action_id = (int) $GLOBALS['wpdb']->get_var(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT action_id FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE hook = %s AND status = 'pending'",
+				Scan_Posts_Event::HANDLE
+			)
+		);
+
+		\ActionScheduler::store()->log_execution( $action_id );
+
+		$this->assertSame( 0, $this->count_actions( 'pending' ) );
+		$this->assertSame( 1, $this->count_actions( 'in-progress' ) );
+
+		// This is the call the event makes on its last line.
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		// Nothing was queued, because the running action counts as already scheduled.
+		$this->assertSame( 0, $this->count_actions( 'pending' ) );
+	}
+
+	/**
+	 * @testdox Once the running event finishes, the init registration re-queues it, so the scan is never left unscheduled.
+	 *
+	 * @return void
+	 */
+	public function test_the_scan_is_always_requeued_once_it_finishes(): void {
+		\update_option( Settings::PROCESS_LINKS, true );
+		\update_option( Settings::SCAN_EXISTING_POSTS, true );
+
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		$action_id = (int) $GLOBALS['wpdb']->get_var(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT action_id FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE hook = %s AND status = 'pending'",
+				Scan_Posts_Event::HANDLE
+			)
+		);
+
+		// Running, so its own reschedule is blocked.
+		\ActionScheduler::store()->log_execution( $action_id );
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		$this->assertSame( 0, $this->count_actions( 'pending' ) );
+
+		// The run finishes.
+		\ActionScheduler::store()->mark_complete( $action_id );
+
+		// Event_Controller calls this on init for every admin and cron request.
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		$this->assertSame( 1, $this->count_actions( 'pending' ) );
+
+		// Repeated init calls do not stack them up.
+		Scan_Posts_Event::add_to_action_scheduler();
+		Scan_Posts_Event::add_to_action_scheduler();
+
+		$this->assertSame( 1, $this->count_actions( 'pending' ) );
+	}
+
+	/**
+	 * Counts the scan events with a given status.
+	 *
+	 * @param string $status The action scheduler status.
+	 *
+	 * @return integer
+	 */
+	private function count_actions( string $status ): int {
+		return (int) $GLOBALS['wpdb']->get_var(
+			$GLOBALS['wpdb']->prepare(
+				"SELECT COUNT(*) FROM {$GLOBALS['wpdb']->prefix}actionscheduler_actions WHERE hook = %s AND status = %s",
+				Scan_Posts_Event::HANDLE,
+				$status
+			)
+		);
+	}
 }


### PR DESCRIPTION
Two fixes from issue #371.

## S020 — the auto-archiver never ran

`Scan_Own_Posts_Event` runs every 15 minutes and picks posts with no `OWN_LINK_LAST_PROCESSED` marker. It passed each one to `add_own_post_to_wayback_machine()`, which queued the archive job an hour out — and the first thing that does is cancel any job already waiting for that post.

So each pass cancelled the pending job and re-scheduled it an hour later. The job never became due, the marker was never written, and the same posts stayed at the front of the queue forever.

Two changes:

- The scan excludes posts that already have a pending or running job, via `post__not_in`, so a batch is always posts that need work.
- The scan queues with no delay. A post the scan picked is already overdue; the one hour delay exists for the save hook, to let you finish editing. `add_own_post_to_wayback_machine()` takes an optional delay, and the save hook still gets the default hour.

## T061 — dead self-reschedule

The last line of `Scan_Posts_Event::__invoke()` called `add_to_action_scheduler()` to queue the next batch. `as_has_scheduled_action()` counts `in-progress` as scheduled, and the event's own action is `in-progress` while it runs, so that call could never schedule anything. Removed.

The scan is unaffected — `Event_Controller` re-queues it on `init` for every admin and cron request, which is what has been keeping it running.

The call in the offline branch is left in place: it documents why the event bailed.

## Testing

- `test_scan_queues_posts_with_no_delay`
- `test_posts_already_in_the_queue_are_not_rescanned` — four scan passes with 15 minutes of simulated time each, the job keeps its action id and counts down to due
- `test_queued_posts_do_not_use_up_the_batch`
- `test_reschedule_is_blocked_while_the_event_is_running`
- `test_the_scan_is_always_requeued_once_it_finishes`

All three S020 tests were run against the unfixed code first and fail there.

Full suite: 467 tests, 1237 assertions. phpcs clean.