### PR TITLE
Add a "Last Archived" column to the posts list screen (#351)

### DIFF
--- a/e2e/fixtures/archived-column-shared.php
+++ b/e2e/fixtures/archived-column-shared.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shared names for the "Last Archived" column seeder and its clean up.
+ *
+ * Loaded by seed-archived-column.php and clean-archived-column.php.
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+const IAWMLF_E2E_ARCHIVED_COLUMN_BACKUP = 'iawmlf_e2e_archived_column_backup';
+const IAWMLF_E2E_ARCHIVED_COLUMN_POSTS  = 'iawmlf_e2e_archived_column_posts';
+
+// 2025-01-02 03:04:05 UTC. Fixed so the spec can assert an exact rendered date.
+const IAWMLF_E2E_ARCHIVED_COLUMN_TIMESTAMP = 1735787045;
+
+/**
+ * The options the seeder overwrites, and the clean up restores.
+ *
+ * @return string[]
+ */
+function iawmlf_e2e_archived_column_options(): array {
+	return array(
+		Settings::POST_ACTIVATION_ONBOARDING_KEY,
+		Settings::SETUP_WIZARD_COMPLETED_KEY,
+		Settings::SETUP_WIZARD_STEP_KEY,
+		Settings::ALLOWED_OWN_CONTENT_POST_TYPES,
+		Settings::AUTO_ARCHIVER_EXCLUDED_POSTS,
+	);
+}

--- a/e2e/fixtures/clean-archived-column.php
+++ b/e2e/fixtures/clean-archived-column.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * E2E clean up for seed-archived-column.php.
+ *
+ * Deletes the posts the seeder created, restores every option it overwrote to
+ * the value it held before, and clears the admin's saved column preference for
+ * the posts list so the next run starts from the defaults again.
+ *
+ * Run via: wp eval-file e2e/fixtures/clean-archived-column.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/archived-column-shared.php';
+
+// Remove the posts the seeder created.
+foreach ( (array) get_option( IAWMLF_E2E_ARCHIVED_COLUMN_POSTS, array() ) as $post_id ) {
+	wp_delete_post( (int) $post_id, true );
+}
+delete_option( IAWMLF_E2E_ARCHIVED_COLUMN_POSTS );
+
+// The spec ticks the Screen Options box, which saves a per-user preference.
+// Core writes it unprefixed via update_user_meta, get_user_option() reads the
+// blog-prefixed key first, so both have to go.
+global $wpdb;
+
+$admin = get_user_by( 'login', 'admin' );
+if ( $admin ) {
+	delete_user_meta( (int) $admin->ID, 'manageedit-postcolumnshidden' );
+	delete_user_meta( (int) $admin->ID, $wpdb->get_blog_prefix() . 'manageedit-postcolumnshidden' );
+}
+
+$backup = get_option( IAWMLF_E2E_ARCHIVED_COLUMN_BACKUP, array() );
+
+foreach ( iawmlf_e2e_archived_column_options() as $option ) {
+	// Absent before means absent after.
+	if ( ! is_array( $backup ) || ! array_key_exists( $option, $backup ) || null === $backup[ $option ] ) {
+		delete_option( $option );
+		continue;
+	}
+
+	update_option( $option, $backup[ $option ] );
+}
+
+delete_option( IAWMLF_E2E_ARCHIVED_COLUMN_BACKUP );
+
+echo "CLEANED=1\n";

--- a/e2e/fixtures/hide-archived-column.php
+++ b/e2e/fixtures/hide-archived-column.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * E2E helper: clear the admin's saved column preference for the posts list.
+ *
+ * With no saved preference WordPress falls back to the defaults, which is where
+ * the plugin's default_hidden_columns filter hides the archived column.
+ *
+ * Run via: wp eval-file e2e/fixtures/hide-archived-column.php
+ */
+
+global $wpdb;
+
+$admin = get_user_by( 'login', 'admin' );
+if ( ! $admin ) {
+	fwrite( STDERR, "No 'admin' user found.\n" );
+	exit( 1 );
+}
+
+// Core's Screen Options handler saves this unprefixed via update_user_meta, but
+// get_user_option() reads the blog-prefixed key first. Clear both.
+delete_user_meta( (int) $admin->ID, 'manageedit-postcolumnshidden' );
+delete_user_meta( (int) $admin->ID, $wpdb->get_blog_prefix() . 'manageedit-postcolumnshidden' );
+
+echo "HIDDEN=1\n";

--- a/e2e/fixtures/seed-archived-column.php
+++ b/e2e/fixtures/seed-archived-column.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * E2E seeder: the "Last Archived" column on the posts list screen.
+ *
+ * Sets up everything the spec needs, and does not depend on any other spec
+ * having run first:
+ *
+ *   - Onboarding is marked complete, or every admin page redirects to the wizard.
+ *   - 'post' is an auto archived post type, so the column is registered.
+ *   - Three posts: one with a known archive date, one never archived, and one
+ *     excluded from auto archiving.
+ *
+ * Anything overwritten is stashed so clean-archived-column.php can restore it.
+ *
+ * Run via: wp eval-file e2e/fixtures/seed-archived-column.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/archived-column-shared.php';
+
+// Stash the options this seeder overwrites, so the state can be put back.
+$backup = array();
+foreach ( iawmlf_e2e_archived_column_options() as $option ) {
+	$backup[ $option ] = get_option( $option, null );
+}
+update_option( IAWMLF_E2E_ARCHIVED_COLUMN_BACKUP, $backup );
+
+// Onboarding must be complete or every admin page redirects to the setup wizard.
+update_option( Settings::POST_ACTIVATION_ONBOARDING_KEY, Settings::ONBOARDING_COMPLETED_OPTION );
+update_option( Settings::SETUP_WIZARD_COMPLETED_KEY, true );
+update_option( Settings::SETUP_WIZARD_STEP_KEY, 'complete' );
+
+// The column only appears for post types that get auto archived.
+update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'post' ) );
+
+/**
+ * Creates a published post for the spec.
+ *
+ * @param string $title The post title.
+ *
+ * @return int
+ */
+function iawmlf_e2e_archived_column_create_post( string $title ): int {
+	$post_id = wp_insert_post(
+		array(
+			'post_title'   => $title,
+			'post_content' => 'IAWMLF e2e archived column probe.',
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+		),
+		true
+	);
+
+	if ( is_wp_error( $post_id ) ) {
+		fwrite( STDERR, 'Could not create post: ' . $post_id->get_error_message() . "\n" );
+		exit( 1 );
+	}
+
+	return (int) $post_id;
+}
+
+$archived_id = iawmlf_e2e_archived_column_create_post( 'IAWMLF e2e archived post' );
+$never_id    = iawmlf_e2e_archived_column_create_post( 'IAWMLF e2e never archived post' );
+$excluded_id = iawmlf_e2e_archived_column_create_post( 'IAWMLF e2e excluded post' );
+
+update_post_meta( $archived_id, Settings::OWN_LINK_LAST_PROCESSED, IAWMLF_E2E_ARCHIVED_COLUMN_TIMESTAMP );
+
+// The excluded post has a date too, to prove exclusion wins over it.
+update_post_meta( $excluded_id, Settings::OWN_LINK_LAST_PROCESSED, IAWMLF_E2E_ARCHIVED_COLUMN_TIMESTAMP );
+update_option( Settings::AUTO_ARCHIVER_EXCLUDED_POSTS, array( $excluded_id ) );
+
+// Remember what to delete on clean up.
+update_option( IAWMLF_E2E_ARCHIVED_COLUMN_POSTS, array( $archived_id, $never_id, $excluded_id ) );
+
+// Output for the playwright spec. Each on its own line, KEY=VALUE.
+echo 'ARCHIVED_POST_ID=' . $archived_id . "\n";
+echo 'NEVER_POST_ID=' . $never_id . "\n";
+echo 'EXCLUDED_POST_ID=' . $excluded_id . "\n";
+echo 'EXPECTED_DATE=' . wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), IAWMLF_E2E_ARCHIVED_COLUMN_TIMESTAMP ) . "\n";

--- a/e2e/fixtures/show-archived-column.php
+++ b/e2e/fixtures/show-archived-column.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * E2E helper: save a posts list column preference for the admin that shows the
+ * archived column.
+ *
+ * Saving any preference stops WordPress consulting the defaults, so the
+ * plugin's default_hidden_columns filter no longer applies.
+ *
+ * Run via: wp eval-file e2e/fixtures/show-archived-column.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\WP_Post\WP_Post_Table_Controller;
+
+if ( ! class_exists( WP_Post_Table_Controller::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+global $wpdb;
+
+$admin = get_user_by( 'login', 'admin' );
+if ( ! $admin ) {
+	fwrite( STDERR, "No 'admin' user found.\n" );
+	exit( 1 );
+}
+
+// An empty list means nothing is hidden, the archived column included. Written
+// the way core's Screen Options handler writes it, unprefixed via user meta.
+delete_user_meta( (int) $admin->ID, $wpdb->get_blog_prefix() . 'manageedit-postcolumnshidden' );
+update_user_meta( (int) $admin->ID, 'manageedit-postcolumnshidden', array() );
+
+echo 'SHOWN=' . WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY . "\n";

--- a/e2e/specs/post-list-archived-column.spec.js
+++ b/e2e/specs/post-list-archived-column.spec.js
@@ -1,0 +1,141 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * The "Last Archived" column on the posts list screen (#351).
+ *
+ * The column reports Settings::OWN_LINK_LAST_PROCESSED, the timestamp written
+ * once a post's own permalink has been snapshotted.
+ *
+ * It is registered on the post types that get auto archived, offered as a
+ * Screen Options checkbox, and hidden until the user ticks that box. Once
+ * ticked the preference is saved per user, so the assertions below re-load the
+ * page to prove the choice survived rather than trusting the live DOM.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+const REPO_ROOT = path.join( __dirname, '../..' );
+
+const LIST_PATH = '/wp-admin/edit.php?post_type=post';
+const COLUMN_KEY = 'wayback_archived';
+
+function wpCli( command ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- ${ command }`,
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+}
+
+function seed() {
+	const output = wpCli( 'wp eval-file e2e/fixtures/seed-archived-column.php' );
+
+	const parse = ( key ) => {
+		const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+		if ( ! m ) {
+			throw new Error( `Seeder did not print ${ key }. Output was:\n${ output }` );
+		}
+		return m[ 1 ].trim();
+	};
+
+	return {
+		archivedId: parse( 'ARCHIVED_POST_ID' ),
+		neverId: parse( 'NEVER_POST_ID' ),
+		excludedId: parse( 'EXCLUDED_POST_ID' ),
+		expectedDate: parse( 'EXPECTED_DATE' ),
+	};
+}
+
+// Each test sets the admin's column preference itself, so neither depends on
+// the other having run first.
+const clearColumnPreference = () =>
+	wpCli( 'wp eval-file e2e/fixtures/hide-archived-column.php' );
+const showColumn = () =>
+	wpCli( 'wp eval-file e2e/fixtures/show-archived-column.php' );
+
+/**
+ * The archived cell for a given post row.
+ *
+ * @param {import('@playwright/test').Page} page    The page.
+ * @param {string}                          postId  The post ID.
+ *
+ * @return {import('@playwright/test').Locator} The cell.
+ */
+const archivedCell = ( page, postId ) =>
+	page.locator( `#post-${ postId } td.${ COLUMN_KEY }` );
+
+test.describe( 'posts list last archived column', () => {
+	let seeded;
+
+	test.beforeAll( () => {
+		seeded = seed();
+	} );
+
+	test.afterAll( () => {
+		wpCli( 'wp eval-file e2e/fixtures/clean-archived-column.php' );
+	} );
+
+	test( 'the column is offered in Screen Options and hidden until it is ticked', async ( {
+		page,
+	} ) => {
+		clearColumnPreference();
+		await page.goto( LIST_PATH );
+
+		const header = page.locator( `th#${ COLUMN_KEY }` );
+		const toggle = page.locator( `#${ COLUMN_KEY }-hide` );
+
+		// The column is registered, so the header and the Screen Options checkbox both exist.
+		await expect( header ).toHaveCount( 1 );
+		await expect( toggle ).toHaveCount( 1 );
+		await expect( toggle ).toHaveAttribute( 'value', COLUMN_KEY );
+
+		// Unticked and the header carries the hidden class: hidden by default.
+		await expect( toggle ).not.toBeChecked();
+		await expect( header ).toHaveClass( /\bhidden\b/ );
+
+		// Tick it in Screen Options.
+		await page.locator( '#show-settings-link' ).click();
+		await expect( toggle ).toBeVisible();
+		await toggle.check();
+
+		// The preference is saved per user, so it must survive a reload.
+		await page.goto( LIST_PATH );
+		await expect( page.locator( `#${ COLUMN_KEY }-hide` ) ).toBeChecked();
+		await expect( page.locator( `th#${ COLUMN_KEY }` ) ).not.toHaveClass(
+			/\bhidden\b/
+		);
+		await expect( page.locator( `th#${ COLUMN_KEY }` ) ).toHaveText(
+			'Last Archived'
+		);
+	} );
+
+	test( 'each row reports its own archive state', async ( { page } ) => {
+		showColumn();
+		await page.goto( LIST_PATH );
+
+		// A post with an archive date shows it, in the site's date and time format.
+		await expect( archivedCell( page, seeded.archivedId ) ).toContainText(
+			seeded.expectedDate
+		);
+		await expect(
+			archivedCell( page, seeded.archivedId ).locator( 'time' )
+		).toHaveAttribute( 'datetime', '2025-01-02T03:04:05+00:00' );
+
+		// A post that has never been archived says so, with no date.
+		await expect( archivedCell( page, seeded.neverId ) ).toContainText(
+			'Never archived'
+		);
+		await expect(
+			archivedCell( page, seeded.neverId ).locator( 'time' )
+		).toHaveCount( 0 );
+
+		// A post excluded from auto archiving says so, even though it has a stored date.
+		const excluded = archivedCell( page, seeded.excludedId );
+		await expect( excluded ).toContainText( 'Excluded post' );
+		await expect( excluded ).not.toContainText( seeded.expectedDate );
+		await expect( excluded.locator( 'a' ) ).toHaveAttribute(
+			'href',
+			/page=iawmlf_settings/
+		);
+	} );
+} );

--- a/languages/internet-archive-wayback-machine-link-fixer.pot
+++ b/languages/internet-archive-wayback-machine-link-fixer.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-09-03T20:38:18+00:00\n"
+"POT-Creation-Date: 2026-09-03T21:54:12+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: internet-archive-wayback-machine-link-fixer\n"
@@ -350,7 +350,7 @@ msgstr ""
 
 #: src/Dashboard/Report_Page.php:102
 #: src/Dashboard/Report_Page.php:228
-#: src/WP_Post/WP_Post_Table_Controller.php:128
+#: src/WP_Post/WP_Post_Table_Controller.php:117
 msgid "Links"
 msgstr ""
 
@@ -1101,19 +1101,28 @@ msgstr ""
 msgid "The service is offline.%s"
 msgstr ""
 
-#: src/WP_Post/WP_Post_Table_Controller.php:151
+#: src/WP_Post/WP_Post_Table_Controller.php:122
+msgid "Last Archived"
+msgstr ""
+
+#: src/WP_Post/WP_Post_Table_Controller.php:163
+#: src/WP_Post/WP_Post_Table_Controller.php:250
 msgid "Excluded post"
 msgstr ""
 
-#: src/WP_Post/WP_Post_Table_Controller.php:161
-#: src/WP_Post/WP_Post_Table_Controller.php:176
+#: src/WP_Post/WP_Post_Table_Controller.php:173
+#: src/WP_Post/WP_Post_Table_Controller.php:188
 msgid "No links found"
 msgstr ""
 
 #. translators: 1: number of broken links, 2: total number of links
-#: src/WP_Post/WP_Post_Table_Controller.php:186
+#: src/WP_Post/WP_Post_Table_Controller.php:198
 #, php-format
 msgid "%1$s broken out of %2$s"
+msgstr ""
+
+#: src/WP_Post/WP_Post_Table_Controller.php:258
+msgid "Never archived"
 msgstr ""
 
 #: templates/admin/dashboard/link-list.php:62

--- a/src/WP_Post/WP_Post_Table_Controller.php
+++ b/src/WP_Post/WP_Post_Table_Controller.php
@@ -27,6 +27,8 @@ class WP_Post_Table_Controller {
 
 	public const LINK_COLUMN_KEY = 'wayback_links';
 
+	public const ARCHIVED_COLUMN_KEY = 'wayback_archived';
+
 	/**
 	 * Cache of links already fetched.
 	 *
@@ -62,6 +64,9 @@ class WP_Post_Table_Controller {
 		add_filter( 'manage_pages_columns', array( $this, 'add_column' ) );
 		add_action( 'manage_pages_custom_column', array( $this, 'render_link_column' ), 10, 2 );
 		add_action( 'manage_posts_custom_column', array( $this, 'render_link_column' ), 10, 2 );
+		add_action( 'manage_pages_custom_column', array( $this, 'render_archived_column' ), 10, 2 );
+		add_action( 'manage_posts_custom_column', array( $this, 'render_archived_column' ), 10, 2 );
+		add_filter( 'default_hidden_columns', array( $this, 'hide_archived_column_by_default' ), 10, 2 );
 	}
 
 	/**
@@ -105,29 +110,36 @@ class WP_Post_Table_Controller {
 	 * @return array
 	 */
 	public function add_column( array $columns ): array {
-		// Get the post type.
-		$screen = get_current_screen();
-		if ( $screen ) {
-			$post_type = $screen->post_type;
-		} else {
-			// Fall back to the request's post_type or the post being edited.
-			$post_type = isset( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				? \sanitize_key( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				: 'post';
+		$post_type = $this->get_current_post_type();
+
+		// Add the links column for any post type whose links are scanned.
+		if ( in_array( $post_type, Settings::get_allowed_post_types(), true ) ) {
+			$columns[ self::LINK_COLUMN_KEY ] = __( 'Links', 'internet-archive-wayback-machine-link-fixer' );
 		}
 
-		// Get the post types from settings.
-		$allowed_post_types = Settings::get_allowed_post_types();
-
-		// If the post type is not in the allowed post types, return the columns.
-		if ( ! in_array( $post_type, $allowed_post_types, true ) ) {
-			return $columns;
+		// Add the archived column for any post type that gets archived.
+		if ( in_array( $post_type, Settings::own_link_allowed_post_types(), true ) ) {
+			$columns[ self::ARCHIVED_COLUMN_KEY ] = __( 'Last Archived', 'internet-archive-wayback-machine-link-fixer' );
 		}
-
-		// Add the column.
-		$columns[ self::LINK_COLUMN_KEY ] = __( 'Links', 'internet-archive-wayback-machine-link-fixer' );
 
 		return $columns;
+	}
+
+	/**
+	 * Gets the post type of the table currently being rendered.
+	 *
+	 * @return string
+	 */
+	private function get_current_post_type(): string {
+		$screen = get_current_screen();
+		if ( $screen ) {
+			return $screen->post_type;
+		}
+
+		// Fall back to the request's post_type or the post being edited.
+		return isset( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? \sanitize_key( $_REQUEST['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			: 'post';
 	}
 
 	/**
@@ -189,6 +201,68 @@ class WP_Post_Table_Controller {
 				),
 				array( 'strong' => array() )
 			)
+		);
+	}
+
+	/**
+	 * Hides the archived column until the user opts in via Screen Options.
+	 *
+	 * Only applies when the user has no saved column preference for the screen,
+	 * so an explicit choice is never overridden.
+	 *
+	 * @param string[]   $hidden Columns hidden by default.
+	 * @param \WP_Screen $screen The screen being rendered.
+	 *
+	 * @return string[]
+	 */
+	public function hide_archived_column_by_default( array $hidden, $screen ): array {
+		if ( ! $screen instanceof \WP_Screen || 'edit' !== $screen->base ) {
+			return $hidden;
+		}
+
+		if ( ! in_array( $screen->post_type, Settings::own_link_allowed_post_types(), true ) ) {
+			return $hidden;
+		}
+
+		$hidden[] = self::ARCHIVED_COLUMN_KEY;
+
+		return $hidden;
+	}
+
+	/**
+	 * Renders the date a post was last archived.
+	 *
+	 * @param string  $column_name The column name.
+	 * @param integer $post_id     The post ID.
+	 *
+	 * @return void
+	 */
+	public function render_archived_column( string $column_name, int $post_id ): void {
+		if ( self::ARCHIVED_COLUMN_KEY !== $column_name ) {
+			return;
+		}
+
+		// If the post is excluded from auto archiving, say so rather than showing it as never archived.
+		if ( in_array( $post_id, Settings::get_auto_archiver_excluded_posts(), true ) ) {
+			printf(
+				'<a href="%1$s"><em>%2$s</em></a>',
+				esc_url( Settings_Page::get_page_url() ),
+				esc_html__( 'Excluded post', 'internet-archive-wayback-machine-link-fixer' )
+			);
+			return;
+		}
+
+		$archived_at = (int) get_post_meta( $post_id, Settings::OWN_LINK_LAST_PROCESSED, true );
+
+		if ( $archived_at <= 0 ) {
+			printf( '<em>%s</em>', esc_html__( 'Never archived', 'internet-archive-wayback-machine-link-fixer' ) );
+			return;
+		}
+
+		printf(
+			'<time datetime="%1$s">%2$s</time>',
+			esc_attr( gmdate( 'c', $archived_at ) ),
+			esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $archived_at ) )
 		);
 	}
 

--- a/tests/WP_Post/Test_WP_Post_Table_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Table_Controller.php
@@ -118,4 +118,205 @@ class Test_WP_Post_Table_Controller extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'No links found', $output );
 	}
+
+	/**
+	 * Renders a column and returns its markup.
+	 *
+	 * @param string  $column_name The column to render.
+	 * @param integer $post_id     The post ID.
+	 *
+	 * @return string
+	 */
+	private function render_archived_column( string $column_name, int $post_id ): string {
+		$controller = new WP_Post_Table_Controller();
+
+		ob_start();
+		$controller->render_archived_column( $column_name, $post_id );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @testdox It should show the date a post was last archived, using the site's date and time format. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_render_archived_column_shows_the_archive_date(): void {
+		$post_id     = self::factory()->post->create();
+		$archived_at = 1735689600; // 2025-01-01 00:00:00 UTC.
+
+		update_post_meta( $post_id, Settings::OWN_LINK_LAST_PROCESSED, $archived_at );
+
+		$output = $this->render_archived_column( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $post_id );
+
+		$expected = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $archived_at );
+
+		$this->assertStringContainsString( $expected, $output, 'Should show the date in the site format.' );
+		$this->assertStringContainsString( gmdate( 'c', $archived_at ), $output, 'Should carry a machine readable datetime.' );
+	}
+
+	/**
+	 * @testdox It should show "Never archived" when the post has no archive date. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_render_archived_column_shows_never_archived_without_meta(): void {
+		$post_id = self::factory()->post->create();
+
+		$output = $this->render_archived_column( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $post_id );
+
+		$this->assertStringContainsString( 'Never archived', $output );
+		$this->assertStringNotContainsString( '<time', $output, 'Should not render a time element without a date.' );
+	}
+
+	/**
+	 * @testdox It should show "Never archived" when the stored archive date is empty or zero. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_render_archived_column_shows_never_archived_for_a_zero_date(): void {
+		$post_id = self::factory()->post->create();
+
+		update_post_meta( $post_id, Settings::OWN_LINK_LAST_PROCESSED, 0 );
+
+		$output = $this->render_archived_column( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $post_id );
+
+		$this->assertStringContainsString( 'Never archived', $output );
+	}
+
+	/**
+	 * @testdox It should show "Excluded post" with a link to settings when the post is excluded from auto archiving. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_render_archived_column_shows_excluded_post(): void {
+		$post_id = self::factory()->post->create();
+
+		update_post_meta( $post_id, Settings::OWN_LINK_LAST_PROCESSED, time() );
+		update_option( Settings::AUTO_ARCHIVER_EXCLUDED_POSTS, array( $post_id ) );
+
+		$output = $this->render_archived_column( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $post_id );
+
+		$this->assertStringContainsString( 'Excluded post', $output );
+		$this->assertStringContainsString( Settings_Page::get_page_url(), $output, 'Should link to settings page.' );
+		$this->assertStringNotContainsString( '<time', $output, 'An excluded post should not show a date.' );
+
+		delete_option( Settings::AUTO_ARCHIVER_EXCLUDED_POSTS );
+	}
+
+	/**
+	 * @testdox It should render nothing when asked for a different column. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_render_archived_column_ignores_other_columns(): void {
+		$post_id = self::factory()->post->create();
+
+		update_post_meta( $post_id, Settings::OWN_LINK_LAST_PROCESSED, time() );
+
+		$this->assertSame( '', $this->render_archived_column( 'title', $post_id ) );
+		$this->assertSame( '', $this->render_archived_column( WP_Post_Table_Controller::LINK_COLUMN_KEY, $post_id ) );
+	}
+
+	/**
+	 * @testdox The archived column should be offered for post types that get archived, and withheld from those that do not. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_add_column_registers_the_archived_column_for_archived_post_types(): void {
+		$controller = new WP_Post_Table_Controller();
+
+		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'post' ) );
+		$_REQUEST['post_type'] = 'post';
+
+		$columns = $controller->add_column( array( 'title' => 'Title' ) );
+		$this->assertArrayHasKey( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $columns );
+		$this->assertSame( 'Last Archived', $columns[ WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY ] );
+
+		$_REQUEST['post_type'] = 'page';
+
+		$columns = $controller->add_column( array( 'title' => 'Title' ) );
+		$this->assertArrayNotHasKey( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $columns );
+
+		unset( $_REQUEST['post_type'] );
+		delete_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES );
+	}
+
+	/**
+	 * @testdox The links column should still be offered independently of the archived column. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_add_column_keeps_the_links_column_independent(): void {
+		$controller = new WP_Post_Table_Controller();
+
+		// Links are scanned on posts, but posts are not auto archived.
+		update_option( Settings::ALLOWED_POST_TYPES, array( 'post' ) );
+		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'page' ) );
+		$_REQUEST['post_type'] = 'post';
+
+		$columns = $controller->add_column( array( 'title' => 'Title' ) );
+
+		$this->assertArrayHasKey( WP_Post_Table_Controller::LINK_COLUMN_KEY, $columns );
+		$this->assertArrayNotHasKey( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $columns );
+
+		unset( $_REQUEST['post_type'] );
+		delete_option( Settings::ALLOWED_POST_TYPES );
+		delete_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES );
+	}
+
+	/**
+	 * @testdox The archived column should be hidden by default on the list screens it appears on. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_archived_column_is_hidden_by_default(): void {
+		$controller = new WP_Post_Table_Controller();
+
+		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'post' ) );
+
+		$screen            = \WP_Screen::get( 'edit-post' );
+		$screen->post_type = 'post';
+
+		$hidden = $controller->hide_archived_column_by_default( array(), $screen );
+
+		$this->assertContains( WP_Post_Table_Controller::ARCHIVED_COLUMN_KEY, $hidden );
+
+		delete_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES );
+	}
+
+	/**
+	 * @testdox It should leave the hidden column list alone for post types the column is not added to. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_archived_column_default_hiding_ignores_other_post_types(): void {
+		$controller = new WP_Post_Table_Controller();
+
+		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'post' ) );
+
+		$screen            = \WP_Screen::get( 'edit-page' );
+		$screen->post_type = 'page';
+
+		$this->assertSame( array(), $controller->hide_archived_column_by_default( array(), $screen ) );
+
+		delete_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES );
+	}
+
+	/**
+	 * @testdox It should leave the hidden column list alone on screens that are not a post list. (#351)
+	 *
+	 * @return void
+	 */
+	public function test_archived_column_default_hiding_ignores_other_screens(): void {
+		$controller = new WP_Post_Table_Controller();
+
+		update_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES, array( 'post' ) );
+
+		$screen            = \WP_Screen::get( 'post' );
+		$screen->post_type = 'post';
+
+		$this->assertSame( array( 'existing' ), $controller->hide_archived_column_by_default( array( 'existing' ), $screen ) );
+
+		delete_option( Settings::ALLOWED_OWN_CONTENT_POST_TYPES );
+	}
 }


### PR DESCRIPTION
Closes #351.

Adds a column to the posts list screen showing when each post was last snapshotted to the Wayback Machine, so the archive state can be confirmed at a glance without opening the link report.

## What it shows

The date comes from `Settings::OWN_LINK_LAST_PROCESSED`, the timestamp `Process_Local_Post_Event` writes once a post's own permalink has been archived. It is rendered in the site's own date and time format, wrapped in a `<time>` element carrying the machine readable value.

Three states:

| State | Cell |
|---|---|
| Archived | The date and time, in the site's format |
| Never archived | "Never archived" |
| Excluded from auto archiving | "Excluded post", linking to the settings page |

An excluded post says so even when it has a stored date, rather than showing a date that will never move again.

## Where it appears

Registered for the post types in `Settings::own_link_allowed_post_types()`, the auto archive list. This is checked independently of the existing Links column, which uses `Settings::get_allowed_post_types()`, so each column appears on the screens it actually applies to.

## Hidden by default

WordPress offers any registered column as a Screen Options checkbox automatically. The column is added to `default_hidden_columns` so it starts hidden. That filter only runs when the user has no saved column preference, so once someone ticks the box their choice is respected from then on.

## Testing

1. Go to Posts. The list should look unchanged, with no new column.
2. Open Screen Options. There should be a "Last Archived" checkbox, unticked.
3. Tick it. The column appears, and stays visible after a reload.
4. A post that has been archived shows its date. One that has not shows "Never archived".
5. Exclude a post from auto archiving on the settings page. Its cell should read "Excluded post" and link back to settings.
6. Untick the box in Screen Options. The column goes, and stays gone after a reload.

10 unit tests cover the rendering, the column registration and the default hiding. A Playwright spec walks the Screen Options toggle and the three row states, seeding and tearing down its own posts, options and column preference so it does not depend on any other spec.
