### PR TITLE
Stop the link data span reformatting the content around it (#346)

### DIFF
--- a/e2e/fixtures/clean-query-loop-links.php
+++ b/e2e/fixtures/clean-query-loop-links.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * E2E clean up for seed-query-loop-links.php.
+ *
+ * Deletes the posts the seeder created, removes the link rows it inserted, and
+ * restores every option it overwrote to the value it held before.
+ *
+ * Run via: wp eval-file e2e/fixtures/clean-query-loop-links.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/query-loop-shared.php';
+
+global $wpdb;
+
+// Remove the posts the seeder created, and their meta with them.
+foreach ( (array) get_option( IAWMLF_E2E_QUERY_LOOP_POSTS, array() ) as $post_id ) {
+	wp_delete_post( (int) $post_id, true );
+}
+delete_option( IAWMLF_E2E_QUERY_LOOP_POSTS );
+
+// Remove every link row the seeder inserted.
+$links_table = Settings::get_link_table_name();
+foreach ( iawmlf_e2e_query_loop_posts() as $urls ) {
+	foreach ( $urls as $url ) {
+		$wpdb->delete( $links_table, array( 'url' => $url ), array( '%s' ) );
+	}
+}
+
+$backup = get_option( IAWMLF_E2E_QUERY_LOOP_BACKUP, array() );
+
+foreach ( iawmlf_e2e_query_loop_options() as $option ) {
+	// Absent before means absent after.
+	if ( ! is_array( $backup ) || ! array_key_exists( $option, $backup ) || null === $backup[ $option ] ) {
+		delete_option( $option );
+		continue;
+	}
+
+	update_option( $option, $backup[ $option ] );
+}
+
+delete_option( IAWMLF_E2E_QUERY_LOOP_BACKUP );
+
+echo "CLEANED=1\n";

--- a/e2e/fixtures/clean-trailing-newline.php
+++ b/e2e/fixtures/clean-trailing-newline.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * E2E clean up for seed-trailing-newline.php.
+ *
+ * Deletes the posts the seeder created, removes the link rows it recorded for
+ * them, and restores every option it overwrote to the value it held before.
+ *
+ * Run via: wp eval-file e2e/fixtures/clean-trailing-newline.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/trailing-newline-shared.php';
+
+global $wpdb;
+
+// Remove the posts the seeder created, and their meta with them.
+foreach ( (array) get_option( IAWMLF_E2E_TRAILING_NEWLINE_POSTS, array() ) as $post_id ) {
+	wp_delete_post( (int) $post_id, true );
+}
+delete_option( IAWMLF_E2E_TRAILING_NEWLINE_POSTS );
+
+// The seeded posts all shared one outbound URL, recorded in the links table.
+$wpdb->delete(
+	Settings::get_link_table_name(),
+	array( 'url' => 'https://example.com/iawmlf-e2e-346' ),
+	array( '%s' )
+);
+
+$backup = get_option( IAWMLF_E2E_TRAILING_NEWLINE_BACKUP, array() );
+
+foreach ( iawmlf_e2e_trailing_newline_options() as $option ) {
+	// Absent before means absent after.
+	if ( ! is_array( $backup ) || ! array_key_exists( $option, $backup ) || null === $backup[ $option ] ) {
+		delete_option( $option );
+		continue;
+	}
+
+	update_option( $option, $backup[ $option ] );
+}
+
+delete_option( IAWMLF_E2E_TRAILING_NEWLINE_BACKUP );
+
+echo "CLEANED=1\n";

--- a/e2e/fixtures/query-loop-shared.php
+++ b/e2e/fixtures/query-loop-shared.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Shared constants for the query loop link data seeder and cleaner.
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+// Where the seeder stashes the previous value of every option it overwrites.
+if ( ! defined( 'IAWMLF_E2E_QUERY_LOOP_BACKUP' ) ) {
+	define( 'IAWMLF_E2E_QUERY_LOOP_BACKUP', 'iawmlf_e2e_query_loop_backup' );
+}
+
+// Where the seeder stashes the IDs of the posts it created.
+if ( ! defined( 'IAWMLF_E2E_QUERY_LOOP_POSTS' ) ) {
+	define( 'IAWMLF_E2E_QUERY_LOOP_POSTS', 'iawmlf_e2e_query_loop_posts' );
+}
+
+if ( ! function_exists( 'iawmlf_e2e_query_loop_posts' ) ) {
+	/**
+	 * Label => the outbound URLs that post links to.
+	 *
+	 * Two links each, all six distinct, so the spec can prove a post's span
+	 * carries all of that post's links and none of any other post's.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	function iawmlf_e2e_query_loop_posts(): array {
+		return array(
+			'A' => array(
+				'https://example.com/iawmlf-e2e-loop-alpha-one',
+				'https://example.com/iawmlf-e2e-loop-alpha-two',
+			),
+			'B' => array(
+				'https://example.com/iawmlf-e2e-loop-bravo-one',
+				'https://example.com/iawmlf-e2e-loop-bravo-two',
+			),
+			'C' => array(
+				'https://example.com/iawmlf-e2e-loop-charlie-one',
+				'https://example.com/iawmlf-e2e-loop-charlie-two',
+			),
+		);
+	}
+}
+
+if ( ! function_exists( 'iawmlf_e2e_query_loop_options' ) ) {
+	/**
+	 * Every option the seeder overwrites, and so every option the cleaner restores.
+	 *
+	 * @return array<int, string>
+	 */
+	function iawmlf_e2e_query_loop_options(): array {
+		return array(
+			Settings::FIXER_OPTION,
+			Settings::LINK_EXCLUSIONS,
+		);
+	}
+}

--- a/e2e/fixtures/seed-query-loop-links.php
+++ b/e2e/fixtures/seed-query-loop-links.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * E2E seeder: link data on a query loop page.
+ *
+ * The front-end script only receives the current post's links through
+ * wp_localize_script, so every other post shown in a loop depends entirely on
+ * its own payload span. This seeds three posts with two distinct links each,
+ * so the spec can prove every post in the loop still emits a span carrying all
+ * of that post's links and none of any other post's.
+ *
+ * Run via: wp eval-file e2e/fixtures/seed-query-loop-links.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/query-loop-shared.php';
+
+global $wpdb;
+
+$links_table  = Settings::get_link_table_name();
+$archived_pre = 'https://web.archive.org/web/2024/';
+$recent_check = gmdate( 'Y-m-d H:i:s' );
+
+// Back up every option we are about to overwrite.
+$backup = array();
+foreach ( iawmlf_e2e_query_loop_options() as $option ) {
+	$backup[ $option ] = get_option( $option, null );
+}
+update_option( IAWMLF_E2E_QUERY_LOOP_BACKUP, $backup );
+
+// The span is only rendered when the fixer is doing something with links.
+update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+// A matching exclusion pattern would send us down the wrong code path.
+update_option( Settings::LINK_EXCLUSIONS, array() );
+
+$post_ids = array();
+
+foreach ( iawmlf_e2e_query_loop_posts() as $label => $urls ) {
+	$link_ids = array();
+	$anchors  = array();
+
+	foreach ( $urls as $index => $url ) {
+		// Clear any row left by a previous run before inserting a fresh one.
+		$wpdb->delete( $links_table, array( 'url' => $url ), array( '%s' ) );
+
+		$inserted = $wpdb->insert(
+			$links_table,
+			array(
+				'url'             => $url,
+				'archived'        => $archived_pre . $url,
+				'checks'          => wp_json_encode( array( array( 'date' => $recent_check, 'http_code' => 404 ) ) ),
+				'message'         => '',
+				'redirect_url'    => '',
+				'is_broken'       => 1,
+				'excluded'        => 0,
+				'archive_process' => 'done',
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s' )
+		);
+
+		if ( false === $inserted ) {
+			fwrite( STDERR, "Insert failed for {$url}: {$wpdb->last_error}\n" );
+			exit( 1 );
+		}
+
+		$link_ids[] = (int) $wpdb->insert_id;
+		$anchors[]  = sprintf(
+			'<p>Link %1$d: <a href="%2$s">loop link %3$s %1$d</a></p>',
+			$index + 1,
+			esc_url( $url ),
+			$label
+		);
+	}
+
+	$post_id = wp_insert_post(
+		array(
+			'post_title'   => "IAWMLF E2E Loop {$label}",
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+			'post_content' => implode( "\n", $anchors ),
+		)
+	);
+
+	if ( is_wp_error( $post_id ) || 0 === $post_id ) {
+		fwrite( STDERR, "wp_insert_post failed for {$label}\n" );
+		exit( 1 );
+	}
+
+	// Pin the link list rather than relying on save_post having processed it.
+	update_post_meta( (int) $post_id, Settings::LINK_META_KEY, $link_ids );
+
+	$post_ids[] = (int) $post_id;
+
+	echo "POST_{$label}_ID={$post_id}\n";
+}
+
+update_option( IAWMLF_E2E_QUERY_LOOP_POSTS, $post_ids );
+
+echo 'HOME_URL=' . home_url( '/' ) . "\n";
+echo 'SEEDED=' . count( $post_ids ) . "\n";

--- a/e2e/fixtures/seed-trailing-newline.php
+++ b/e2e/fixtures/seed-trailing-newline.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * E2E seeder for issue #346: the link data span must not change how WordPress
+ * formats the content around it.
+ *
+ * Seeds four Classic Editor posts, one per way the content can end. None of
+ * them contain block delimiters, which is what keeps wpautop in the the_content
+ * chain: do_blocks() unhooks wpautop for anything with blocks in it, so a block
+ * editor post could never show this bug.
+ *
+ *   TRAILING_NEWLINE  ends with a newline          <-- the reported bug
+ *   BLANK_LINES       ends with two blank lines
+ *   BLOCK_LEVEL       ends with a closing </ul>
+ *   AUTHORED_BREAK    has a single newline mid-paragraph, which must survive
+ *
+ * Every post ends with a unique marker word so the spec can find its last
+ * paragraph without depending on the theme's markup.
+ *
+ * Run via: wp eval-file e2e/fixtures/seed-trailing-newline.php
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+use Internet_Archive\Wayback_Machine_Link_Fixer\WP_Post\WP_Post_Controller;
+
+if ( ! class_exists( Settings::class ) ) {
+	fwrite( STDERR, "Plugin not loaded, is internet-archive-wayback-machine-link-fixer active?\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/trailing-newline-shared.php';
+
+// Back up every option we are about to overwrite, so the cleaner can put them back.
+$backup = array();
+foreach ( iawmlf_e2e_trailing_newline_options() as $option ) {
+	$backup[ $option ] = get_option( $option, null );
+}
+update_option( IAWMLF_E2E_TRAILING_NEWLINE_BACKUP, $backup );
+
+// The span is only rendered when the fixer is doing something with links.
+update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+// An exclusion pattern matching our URL would send us down the wrong code path.
+update_option( Settings::LINK_EXCLUSIONS, array() );
+
+$link = '<a href="https://example.com/iawmlf-e2e-346">an example link</a>';
+
+$shapes = array(
+	// key => array( marker, content ). The content is raw, exactly as the
+	// Classic Editor's Code view would store it.
+	'TRAILING_NEWLINE' => array(
+		'IAWMLFENDONE',
+		"Opening paragraph with {$link}.\n\nLast word IAWMLFENDONE\n",
+	),
+	'BLANK_LINES'      => array(
+		'IAWMLFENDTWO',
+		"Opening paragraph with {$link}.\n\nLast word IAWMLFENDTWO\n\n\n",
+	),
+	'BLOCK_LEVEL'      => array(
+		'IAWMLFENDTHREE',
+		"Opening paragraph with {$link}.\n\n<ul>\n<li>One</li>\n<li>Last word IAWMLFENDTHREE</li>\n</ul>\n",
+	),
+	'AUTHORED_BREAK'   => array(
+		'IAWMLFENDFOUR',
+		"Opening paragraph with {$link}.\n\nFirst line\nLast word IAWMLFENDFOUR\n",
+	),
+);
+
+$post_ids = array();
+
+foreach ( $shapes as $key => $shape ) {
+	list( $marker, $content ) = $shape;
+
+	$post_id = wp_insert_post(
+		array(
+			'post_title'   => "IAWMLF E2E 346 {$key}",
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+			'post_content' => $content,
+		)
+	);
+
+	if ( is_wp_error( $post_id ) || 0 === $post_id ) {
+		fwrite( STDERR, "wp_insert_post failed for {$key}\n" );
+		exit( 1 );
+	}
+
+	// Record the post's links, so there is a payload span to render.
+	( new WP_Post_Controller() )->process_links_in_content( (int) $post_id );
+
+	$post_ids[] = (int) $post_id;
+
+	echo "{$key}_URL=" . get_permalink( $post_id ) . "\n";
+	echo "{$key}_MARKER={$marker}\n";
+}
+
+update_option( IAWMLF_E2E_TRAILING_NEWLINE_POSTS, $post_ids );
+
+echo 'SEEDED=' . count( $post_ids ) . "\n";

--- a/e2e/fixtures/trailing-newline-shared.php
+++ b/e2e/fixtures/trailing-newline-shared.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Shared constants for the issue #346 seeder and cleaner.
+ *
+ * Keeping the option names and the backed-up option list in one place stops the
+ * two scripts drifting apart and leaving state behind between runs.
+ */
+
+use Internet_Archive\Wayback_Machine_Link_Fixer\Settings\Settings;
+
+// Where the seeder stashes the previous value of every option it overwrites.
+if ( ! defined( 'IAWMLF_E2E_TRAILING_NEWLINE_BACKUP' ) ) {
+	define( 'IAWMLF_E2E_TRAILING_NEWLINE_BACKUP', 'iawmlf_e2e_346_backup' );
+}
+
+// Where the seeder stashes the IDs of the posts it created.
+if ( ! defined( 'IAWMLF_E2E_TRAILING_NEWLINE_POSTS' ) ) {
+	define( 'IAWMLF_E2E_TRAILING_NEWLINE_POSTS', 'iawmlf_e2e_346_posts' );
+}
+
+if ( ! function_exists( 'iawmlf_e2e_trailing_newline_options' ) ) {
+	/**
+	 * Every option the seeder overwrites, and so every option the cleaner restores.
+	 *
+	 * @return array<int, string>
+	 */
+	function iawmlf_e2e_trailing_newline_options(): array {
+		return array(
+			Settings::FIXER_OPTION,
+			Settings::LINK_EXCLUSIONS,
+		);
+	}
+}

--- a/e2e/specs/query-loop-link-data.spec.js
+++ b/e2e/specs/query-loop-link-data.spec.js
@@ -1,0 +1,127 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * Every post shown in a query loop must carry its own link data.
+ *
+ * wp_localize_script only hands the front-end script the CURRENT post's links,
+ * so every other post in a loop depends entirely on its own
+ * `__iawmlf-post-loop-links` span. This guards that: three seeded posts, two
+ * distinct links each, all six URLs different.
+ *
+ * For each post the spec asserts its span holds BOTH of that post's links and
+ * NONE of the other four, which is the property the loop rendering depends on.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+const REPO_ROOT = path.join( __dirname, '../..' );
+
+const SPAN = '.__iawmlf-post-loop-links';
+
+// Must match iawmlf_e2e_query_loop_posts() in query-loop-shared.php.
+const EXPECTED = {
+	A: [
+		'https://example.com/iawmlf-e2e-loop-alpha-one',
+		'https://example.com/iawmlf-e2e-loop-alpha-two',
+	],
+	B: [
+		'https://example.com/iawmlf-e2e-loop-bravo-one',
+		'https://example.com/iawmlf-e2e-loop-bravo-two',
+	],
+	C: [
+		'https://example.com/iawmlf-e2e-loop-charlie-one',
+		'https://example.com/iawmlf-e2e-loop-charlie-two',
+	],
+};
+
+function wpCli( command ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- ${ command }`,
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+}
+
+function seed() {
+	const output = wpCli( 'wp eval-file e2e/fixtures/seed-query-loop-links.php' );
+
+	const parse = ( key ) => {
+		const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+		if ( ! m ) {
+			throw new Error(
+				`Seeder did not print ${ key }. Output was:\n${ output }`
+			);
+		}
+		return m[ 1 ].trim();
+	};
+
+	return {
+		homeUrl: parse( 'HOME_URL' ),
+		ids: {
+			A: parse( 'POST_A_ID' ),
+			B: parse( 'POST_B_ID' ),
+			C: parse( 'POST_C_ID' ),
+		},
+	};
+}
+
+/**
+ * The hrefs listed in a post's own payload span within the loop.
+ *
+ * @param {import('@playwright/test').Page} page   The page.
+ * @param {string}                          postId The post ID.
+ *
+ * @return {Promise<Array<string>>} The hrefs in that post's span.
+ */
+async function hrefsInPostSpan( page, postId ) {
+	// The post-<id> class token is exact, so post-12 never matches post-120.
+	const span = page.locator( `.post-${ postId } ${ SPAN }` );
+
+	await expect( span ).toHaveCount( 1 );
+
+	const json = await span.getAttribute( 'data-iawmlf-links' );
+
+	return JSON.parse( json ).map( ( link ) => link.href );
+}
+
+test.describe( 'query loop link data', () => {
+	let seeded;
+
+	test.beforeAll( () => {
+		seeded = seed();
+	} );
+
+	test.afterAll( () => {
+		wpCli( 'wp eval-file e2e/fixtures/clean-query-loop-links.php' );
+	} );
+
+	test( 'each post in the loop carries all of its own links and none of the others', async ( {
+		page,
+	} ) => {
+		await page.goto( seeded.homeUrl );
+
+		for ( const label of Object.keys( EXPECTED ) ) {
+			const hrefs = await hrefsInPostSpan( page, seeded.ids[ label ] );
+
+			// Every one of this post's links is present.
+			for ( const url of EXPECTED[ label ] ) {
+				expect(
+					hrefs,
+					`post ${ label } span should list ${ url }`
+				).toContain( url );
+			}
+
+			// And nothing belonging to the other two posts leaked in.
+			const foreign = Object.keys( EXPECTED )
+				.filter( ( other ) => other !== label )
+				.flatMap( ( other ) => EXPECTED[ other ] );
+
+			for ( const url of foreign ) {
+				expect(
+					hrefs,
+					`post ${ label } span should not list ${ url }`
+				).not.toContain( url );
+			}
+		}
+	} );
+} );

--- a/e2e/specs/trailing-newline-rendering.spec.js
+++ b/e2e/specs/trailing-newline-rendering.spec.js
@@ -1,0 +1,162 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+/**
+ * Issue #346: the link data span must not change how the content around it is
+ * formatted.
+ *
+ * The span used to be appended inside the block content, before wpautop ran.
+ * wpautop then saw the content's trailing newline as no longer trailing and
+ * turned it into a visible <br />. It is now appended on the_content at
+ * priority 12, after wpautop, so there is nothing left for wpautop to react to.
+ *
+ * Only Classic Editor content can show this: do_blocks() unhooks wpautop for
+ * anything containing block delimiters.
+ */
+
+const PLUGIN_DIR = 'wp-content/plugins/internet-archive-wayback-machine-link-fixer';
+const REPO_ROOT = path.join( __dirname, '../..' );
+
+const SPAN = '.__iawmlf-post-loop-links';
+
+function wpCli( command ) {
+	return execSync(
+		`npx wp-env run cli --env-cwd='${ PLUGIN_DIR }' -- ${ command }`,
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+}
+
+function seed() {
+	const output = wpCli(
+		'wp eval-file e2e/fixtures/seed-trailing-newline.php'
+	);
+
+	const parse = ( key ) => {
+		const m = output.match( new RegExp( `^${ key }=(.+)$`, 'm' ) );
+		if ( ! m ) {
+			throw new Error(
+				`Seeder did not print ${ key }. Output was:\n${ output }`
+			);
+		}
+		return m[ 1 ].trim();
+	};
+
+	return {
+		trailingNewline: {
+			url: parse( 'TRAILING_NEWLINE_URL' ),
+			marker: parse( 'TRAILING_NEWLINE_MARKER' ),
+		},
+		blankLines: {
+			url: parse( 'BLANK_LINES_URL' ),
+			marker: parse( 'BLANK_LINES_MARKER' ),
+		},
+		blockLevel: {
+			url: parse( 'BLOCK_LEVEL_URL' ),
+			marker: parse( 'BLOCK_LEVEL_MARKER' ),
+		},
+		authoredBreak: {
+			url: parse( 'AUTHORED_BREAK_URL' ),
+			marker: parse( 'AUTHORED_BREAK_MARKER' ),
+		},
+	};
+}
+
+/**
+ * The rendered HTML of the element that holds the post's final marker word.
+ *
+ * Locating by the marker rather than by a theme class keeps this independent of
+ * whichever theme wp-env is running.
+ *
+ * @param {import('@playwright/test').Page} page     The page.
+ * @param {string}                          marker   The marker word.
+ * @param {string}                          selector The tag holding the marker.
+ *
+ * @return {Promise<string>} The element's inner HTML.
+ */
+async function markerElementHtml( page, marker, selector = 'p' ) {
+	const element = page
+		.locator( selector )
+		.filter( { hasText: marker } )
+		.last();
+
+	await expect( element ).toBeVisible();
+
+	return element.innerHTML();
+}
+
+test.describe( 'trailing newline rendering (#346)', () => {
+	let seeded;
+
+	test.beforeAll( () => {
+		seeded = seed();
+	} );
+
+	test.afterAll( () => {
+		wpCli( 'wp eval-file e2e/fixtures/clean-trailing-newline.php' );
+	} );
+
+	test( 'content ending in a newline does not gain a line break', async ( {
+		page,
+	} ) => {
+		await page.goto( seeded.trailingNewline.url );
+
+		// The span is on the page, so the case under test is actually exercised.
+		await expect( page.locator( SPAN ) ).toHaveCount( 1 );
+
+		const html = await markerElementHtml(
+			page,
+			seeded.trailingNewline.marker
+		);
+		expect( html ).not.toContain( '<br>' );
+	} );
+
+	test( 'content ending in blank lines does not gain a line break or an empty paragraph', async ( {
+		page,
+	} ) => {
+		await page.goto( seeded.blankLines.url );
+
+		await expect( page.locator( SPAN ) ).toHaveCount( 1 );
+
+		const html = await markerElementHtml( page, seeded.blankLines.marker );
+		expect( html ).not.toContain( '<br>' );
+
+		// wpautop used to wrap the bare span in a paragraph of its own.
+		await expect( page.locator( `p > ${ SPAN }` ) ).toHaveCount( 0 );
+	} );
+
+	test( 'content ending in a block level element keeps the span out of a paragraph', async ( {
+		page,
+	} ) => {
+		await page.goto( seeded.blockLevel.url );
+
+		await expect( page.locator( SPAN ) ).toHaveCount( 1 );
+
+		// This shape's marker is the last list item, not a paragraph.
+		const html = await markerElementHtml(
+			page,
+			seeded.blockLevel.marker,
+			'li'
+		);
+		expect( html ).not.toContain( '<br>' );
+
+		await expect( page.locator( `p > ${ SPAN }` ) ).toHaveCount( 0 );
+	} );
+
+	test( "a line break the author wrote is still rendered", async ( {
+		page,
+	} ) => {
+		await page.goto( seeded.authoredBreak.url );
+
+		await expect( page.locator( SPAN ) ).toHaveCount( 1 );
+
+		// The paragraph holds both lines, so read the marker's parent.
+		const paragraph = page
+			.locator( 'p' )
+			.filter( { hasText: seeded.authoredBreak.marker } )
+			.last();
+
+		await expect( paragraph ).toHaveCount( 1 );
+		expect( await paragraph.innerHTML() ).toContain( '<br>' );
+	} );
+} );

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -301,6 +301,13 @@ class WP_Post_Controller {
 			return $content;
 		}
 
+		// wp_trim_excerpt() runs the_content to build an auto excerpt, then strips
+		// the tags back off. Answering it would burn the post's one span on output
+		// nobody sees, leaving the real render with none.
+		if ( doing_filter( 'get_the_excerpt' ) ) {
+			return $content;
+		}
+
 		if ( ! Settings::should_render_html_link_output() ) {
 			return $content;
 		}

--- a/src/WP_Post/WP_Post_Controller.php
+++ b/src/WP_Post/WP_Post_Controller.php
@@ -62,7 +62,9 @@ class WP_Post_Controller {
 		add_action( 'save_post', array( $this, 'on_save_post_process_post_links' ), 10, 3 );
 		add_action( 'save_post', array( $this, 'on_save_post_process_own_post' ), 10, 3 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_script' ) );
-		add_filter( 'render_block', array( $this, 'render_block' ), 999, 2 );
+		// Priority 12 puts this after wpautop, which would otherwise reformat the
+		// content around the span it appends (#346).
+		add_filter( 'the_content', array( $this, 'append_link_data' ), 12 );
 	}
 
 	/**
@@ -282,21 +284,25 @@ class WP_Post_Controller {
 	}
 
 	/**
-	 * Render as part of a block template.
+	 * Append the post's link data to the rendered content, once per post.
 	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block         The block.
+	 * Runs on the_content at priority 12, after wpautop, so the span cannot
+	 * change how the content around it is formatted (#346).
+	 *
+	 * @since 1.4.4
+	 *
+	 * @param string $content The rendered post content.
 	 *
 	 * @return string
 	 */
-	public function render_block( string $block_content, array $block ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		// A scan renders blocks to find links - the payload span has no place in that.
+	public function append_link_data( string $content ): string {
+		// A scan renders content to find links - the payload span has no place in that.
 		if ( Content_Scanner::is_rendering() ) {
-			return $block_content;
+			return $content;
 		}
 
 		if ( ! Settings::should_render_html_link_output() ) {
-			return $block_content;
+			return $content;
 		}
 
 		static $posts = array();
@@ -305,12 +311,12 @@ class WP_Post_Controller {
 
 		// If the ID is not set, or is in the array, return.
 		if ( ! is_numeric( $post_id ) || in_array( $post_id, $posts, true ) ) {
-			return $block_content;
+			return $content;
 		}
 
 		// Bail if the post is in the excluded posts list.
 		if ( in_array( (int) $post_id, Settings::get_link_fixer_excluded_posts(), true ) ) {
-			return $block_content;
+			return $content;
 		}
 
 		// Add the post id to the array.
@@ -319,21 +325,21 @@ class WP_Post_Controller {
 		// If not a post or a an allowed post type, return.
 		$post = get_post( $post_id );
 		if ( ! $post || ! in_array( $post->post_type, Settings::get_allowed_post_types(), true ) ) {
-			return $block_content;
+			return $content;
 		}
 
 		// Compile the data.
 		$links = $this->link_repository->get_links_for_post( $post_id, true );
 
 		if ( $links->is_empty() ) {
-			return $block_content;
+			return $content;
 		}
 
 		// Encode with all JSON_HEX_* flags.
 		$json      = wp_json_encode( $links, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 		$html_data = '<span hidden class="__iawmlf-post-loop-links" data-iawmlf-links="' . esc_attr( $json ) . '"></span>';
 
-		return $block_content . $html_data;
+		return $content . $html_data;
 	}
 
 	/**

--- a/tests/Processor/Test_Content_Scanner.php
+++ b/tests/Processor/Test_Content_Scanner.php
@@ -261,11 +261,11 @@ class Test_Content_Scanner extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox The link payload span must not be injected while a scan renders blocks. (S126)
+	 * @testdox The link payload span must not be injected while a scan renders content. (S126)
 	 *
 	 * @return void
 	 */
-	public function test_own_render_block_output_is_suppressed_during_a_scan(): void {
+	public function test_own_link_data_output_is_suppressed_during_a_scan(): void {
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
 
 		$post_id = self::factory()->post->create(
@@ -294,7 +294,7 @@ class Test_Content_Scanner extends \WP_UnitTestCase {
 		// Outside a scan the span is still added.
 		$this->assertFalse( Content_Scanner::is_rendering() );
 		$GLOBALS['post'] = get_post( $post_id );
-		$this->assertStringContainsString( '__iawmlf-post-loop-links', do_blocks( get_post_field( 'post_content', $post_id ) ) );
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) ) );
 		unset( $GLOBALS['post'] );
 	}
 

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -670,8 +670,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		$GLOBALS['post'] = get_post( $post_id );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// Check contains the link data script tag.
 		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -704,8 +704,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		// Add the post to the exclusion list.
 		\update_option( Settings::LINK_FIXER_EXCLUDED_POSTS, array( $post_id ) );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// Check does NOT contain the link data script tag.
 		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -716,7 +716,7 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox When a link matches a global exclusion pattern, it should not appear in the render_block data attribute output.
+	 * @testdox When a link matches a global exclusion pattern, it should not appear in the link data attribute output.
 	 *
 	 * @return void
 	 */
@@ -741,8 +741,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		$GLOBALS['post'] = get_post( $post_id );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// The link data span should be present (we still have one non-excluded link).
 		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -755,10 +755,10 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		$hrefs = array_column( $links_data, 'href' );
 
 		// The excluded link should NOT be in the data.
-		$this->assertNotContains( 'https://excluded-domain.com/page', $hrefs, 'Excluded link should not appear in render_block data.' );
+		$this->assertNotContains( 'https://excluded-domain.com/page', $hrefs, 'Excluded link should not appear in link data.' );
 
 		// The allowed link SHOULD be in the data.
-		$this->assertContains( 'https://allowed-domain.com/page', $hrefs, 'Non-excluded link should appear in render_block data.' );
+		$this->assertContains( 'https://allowed-domain.com/page', $hrefs, 'Non-excluded link should appear in link data.' );
 
 		// Clean up.
 		unset( $GLOBALS['post'] );
@@ -766,7 +766,7 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox When a link matches a global exclusion pattern and another does not, only the non-excluded link should appear in the render_block data attribute output.
+	 * @testdox When a link matches a global exclusion pattern and another does not, only the non-excluded link should appear in the link data attribute output.
 	 *
 	 * @return void
 	 */
@@ -791,8 +791,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		$GLOBALS['post'] = get_post( $post_id );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// The link data span should be present (we still have one non-excluded link).
 		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -808,10 +808,10 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		$hrefs = array_column( $links_data, 'href' );
 
 		// The excluded link should NOT be in the data.
-		$this->assertNotContains( 'https://excluded-domain.com/page1', $hrefs, 'Excluded link should not appear in render_block data.' );
+		$this->assertNotContains( 'https://excluded-domain.com/page1', $hrefs, 'Excluded link should not appear in link data.' );
 
 		// The allowed link SHOULD be in the data.
-		$this->assertContains( 'https://kept-domain.com/page', $hrefs, 'Non-excluded link should appear in render_block data.' );
+		$this->assertContains( 'https://kept-domain.com/page', $hrefs, 'Non-excluded link should appear in link data.' );
 
 		// Clean up.
 		unset( $GLOBALS['post'] );
@@ -842,8 +842,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		$GLOBALS['post'] = get_post( $post_id );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// Check does not contain the link data script tag.
 		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -895,8 +895,8 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 
 		$GLOBALS['post'] = get_post( $post_id );
 
-		// Render the block.
-		$rendered = do_blocks( $GLOBALS['post']->post_content );
+		// Render the content, the way a theme does.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
 
 		// Check it still contains the link data script tag.
 		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
@@ -1057,13 +1057,17 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a published post with the given anchor markup and return the rendered block output.
+	 * Build a published post with the given markup and return the rendered content.
 	 *
-	 * @param string $content The post content.
+	 * Renders through the full the_content chain rather than do_blocks(), because
+	 * the link data span is appended at priority 12, after wpautop.
+	 *
+	 * @param string $content  The post content.
+	 * @param bool   $excluded Exclude the post, to capture the baseline with no span.
 	 *
 	 * @return string The rendered HTML.
 	 */
-	private function render_post_with_content( string $content ): string {
+	private function render_post_with_content( string $content, bool $excluded = false ): string {
 		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
 
 		$post_id = self::factory()->post->create();
@@ -1075,17 +1079,27 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 			)
 		);
 
+		if ( $excluded ) {
+			\update_option( Settings::LINK_FIXER_EXCLUDED_POSTS, array( $post_id ) );
+		}
+
 		$GLOBALS['post'] = get_post( $post_id );
 
-		return do_blocks( $GLOBALS['post']->post_content );
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
+
+		if ( $excluded ) {
+			\delete_option( Settings::LINK_FIXER_EXCLUDED_POSTS );
+		}
+
+		return $rendered;
 	}
 
 	/**
-	 * @testdox The render_block output should use a span with the data-iawmlf-links attribute, not a script tag.
+	 * @testdox The link data output should use a span with the data-iawmlf-links attribute, not a script tag.
 	 *
 	 * @return void
 	 */
-	public function test_render_block_output_is_span_with_data_attribute(): void {
+	public function test_link_data_output_is_span_with_data_attribute(): void {
 		$rendered = $this->render_post_with_content( 'Hi <a href="https://example.com/page">a</a>' );
 
 		$this->assertStringContainsString( '<span', $rendered );
@@ -1101,7 +1115,7 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_render_block_output_includes_hidden_attribute(): void {
+	public function test_link_data_output_includes_hidden_attribute(): void {
 		$rendered = $this->render_post_with_content( 'Hi <a href="https://example.com/page">a</a>' );
 
 		$this->assertMatchesRegularExpression(
@@ -1114,19 +1128,19 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox The link data span should be appended after the block content so it does not hijack :first-child CSS rules.
+	 * @testdox The link data span should be appended after the post content so it does not hijack :first-child CSS rules.
 	 *
 	 * @return void
 	 */
-	public function test_render_block_output_is_appended_after_block_content(): void {
+	public function test_link_data_output_is_appended_after_post_content(): void {
 		$rendered = $this->render_post_with_content( 'Hi <a href="https://example.com/page">a</a>' );
 
 		$content_position = strpos( $rendered, 'href="https://example.com/page"' );
 		$span_position    = strpos( $rendered, '__iawmlf-post-loop-links' );
 
-		$this->assertNotFalse( $content_position, 'Block content with the link should be in the rendered output.' );
+		$this->assertNotFalse( $content_position, 'Post content with the link should be in the rendered output.' );
 		$this->assertNotFalse( $span_position, 'The link data span should be in the rendered output.' );
-		$this->assertGreaterThan( $content_position, $span_position, 'The data span should appear after the block content.' );
+		$this->assertGreaterThan( $content_position, $span_position, 'The data span should appear after the post content.' );
 
 		unset( $GLOBALS['post'] );
 	}
@@ -1293,5 +1307,181 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 		);
 
 		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * Classic Editor content shapes, covering every way the content can end.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function classicContentEndingProvider(): array {
+		$link = '<a href="https://example.com/page">example</a>';
+
+		return array(
+			'trailing newline'          => array( "Intro with a {$link}.\n\nLast word.\n" ),
+			'no trailing newline'       => array( "Intro with a {$link}.\n\nLast word." ),
+			'single line'               => array( "Only line with a {$link}.\n" ),
+			'two trailing blank lines'  => array( "Last word with a {$link}.\n\n\n" ),
+			'trailing spaces and tabs'  => array( "Last word with a {$link}.\n  \t " ),
+			'windows line endings'      => array( "Intro with a {$link}.\r\n\r\nLast word.\r\n" ),
+			'ends with a list'          => array( "Intro with a {$link}.\n\n<ul>\n<li>One</li>\n<li>Two</li>\n</ul>\n" ),
+			'ends with a blockquote'    => array( "Intro with a {$link}.\n\n<blockquote>Quoted.</blockquote>\n" ),
+			'ends with an inline image' => array( "Last word with a {$link} <img src=\"https://example.com/i.png\" alt=\"\" />\n" ),
+		);
+	}
+
+	/**
+	 * @testdox The link data span should never make wpautop render the content's trailing newline as a visible line break.
+	 *
+	 * @dataProvider classicContentEndingProvider
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return void
+	 */
+	public function test_link_data_span_does_not_introduce_a_line_break( string $content ): void {
+		$rendered = $this->render_post_with_content( $content );
+
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered, 'The span should have been rendered.' );
+		$this->assertStringNotContainsString( '<br />', $rendered, 'The span should not cause wpautop to add a line break.' );
+	}
+
+	/**
+	 * @testdox Adding the link data span should change nothing else about the rendered content.
+	 *
+	 * @dataProvider classicContentEndingProvider
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return void
+	 */
+	public function test_link_data_span_is_the_only_change_to_the_rendered_content( string $content ): void {
+		$with_span = $this->render_post_with_content( $content );
+		$baseline  = $this->render_post_with_content( $content, true );
+
+		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $baseline, 'The excluded post should render no span.' );
+
+		$stripped = preg_replace( '#<span hidden class="__iawmlf-post-loop-links"[^>]*></span>#', '', $with_span );
+
+		$this->assertNotSame( $with_span, $stripped, 'There should have been a span to strip out.' );
+		$this->assertSame( $baseline, $stripped, 'Removing the span should give back the unmodified rendering.' );
+	}
+
+	/**
+	 * @testdox The link data span should be the very last thing in the rendered content, outside the final paragraph.
+	 *
+	 * @return void
+	 */
+	public function test_link_data_span_is_the_last_thing_in_the_rendered_content(): void {
+		$rendered = $this->render_post_with_content(
+			"Intro.\n\nLast word with a <a href=\"https://example.com/page\">example</a>.\n"
+		);
+
+		$this->assertMatchesRegularExpression(
+			'#</p>\s*<span hidden class="__iawmlf-post-loop-links"[^>]*></span>$#',
+			$rendered,
+			'The span should be appended after the fully rendered content, with nothing after it.'
+		);
+	}
+
+	/**
+	 * @testdox A line break the author actually wrote should still be rendered.
+	 *
+	 * @return void
+	 */
+	public function test_an_authored_line_break_is_preserved(): void {
+		$rendered = $this->render_post_with_content(
+			"One\nTwo with a <a href=\"https://example.com/page\">example</a>.\n"
+		);
+
+		$this->assertStringContainsString( 'One<br />', $rendered, "The author's own single newline should still become a line break." );
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $rendered );
+	}
+
+	/**
+	 * @testdox Block editor content should be rendered exactly as it would be without the plugin, with the span appended at the end.
+	 *
+	 * @return void
+	 */
+	public function test_block_editor_content_is_not_reformatted_around_the_span(): void {
+		$content = "<!-- wp:paragraph -->\n<p>First with a <a href=\"https://example.com/page\">example</a>.</p>\n<!-- /wp:paragraph -->\n\n"
+			. "<!-- wp:paragraph -->\n<p>Last word.</p>\n<!-- /wp:paragraph -->\n";
+
+		$with_span = $this->render_post_with_content( $content );
+		$baseline  = $this->render_post_with_content( $content, true );
+
+		$this->assertStringContainsString( '__iawmlf-post-loop-links', $with_span );
+		$this->assertStringNotContainsString( '<br />', $with_span );
+		$this->assertStringNotContainsString(
+			'<p><span hidden class="__iawmlf-post-loop-links"',
+			$with_span,
+			'The span should never be wrapped in a paragraph of its own.'
+		);
+
+		$stripped = preg_replace( '#<span hidden class="__iawmlf-post-loop-links"[^>]*></span>#', '', $with_span );
+		$this->assertSame( $baseline, $stripped, 'Removing the span should give back the unmodified rendering.' );
+	}
+
+	/**
+	 * @testdox When the same post is rendered more than once in a loop, the link data span should be output only once.
+	 *
+	 * @return void
+	 */
+	public function test_the_span_is_output_once_when_the_same_post_repeats_in_a_loop(): void {
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		$post_id = self::factory()->post->create();
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => "A post with a <a href=\"https://example.com/loop\">example</a>.\n",
+				'post_type'    => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$output = '';
+		for ( $i = 0; $i < 3; $i++ ) {
+			$output .= apply_filters( 'the_content', $GLOBALS['post']->post_content );
+		}
+
+		$this->assertSame( 1, substr_count( $output, '__iawmlf-post-loop-links' ), 'The same post should contribute one span, however many times it is rendered.' );
+		$this->assertStringNotContainsString( '<br />', $output );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * @testdox Every distinct post in a loop should get its own link data span, and none of them should gain a line break.
+	 *
+	 * @return void
+	 */
+	public function test_each_distinct_post_in_a_loop_gets_its_own_span(): void {
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		$post_ids = array();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$post_id = self::factory()->post->create();
+			wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => "Post {$i} with a <a href=\"https://example.com/loop-{$i}\">example</a>.\n",
+					'post_type'    => 'post',
+				)
+			);
+			$post_ids[] = $post_id;
+		}
+
+		$output = '';
+		foreach ( $post_ids as $post_id ) {
+			$GLOBALS['post'] = get_post( $post_id );
+			$output         .= apply_filters( 'the_content', $GLOBALS['post']->post_content );
+		}
+
+		unset( $GLOBALS['post'] );
+
+		$this->assertSame( 3, substr_count( $output, '__iawmlf-post-loop-links' ), 'Each post in the loop should contribute exactly one span.' );
+		$this->assertStringNotContainsString( '<br />', $output );
 	}
 }

--- a/tests/WP_Post/Test_WP_Post_Controller.php
+++ b/tests/WP_Post/Test_WP_Post_Controller.php
@@ -1453,6 +1453,44 @@ class Test_WP_Post_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Building the post's excerpt first must not stop the visible content render emitting the link data span.
+	 *
+	 * @return void
+	 */
+	public function test_excerpt_generation_does_not_consume_the_span(): void {
+		update_option( Settings::FIXER_OPTION, Settings::FIXER_OPTION_REPLACE_LINK );
+
+		$post_id = self::factory()->post->create();
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => 'Body with a <a href="https://example.com/excerpt-race">example</a>.',
+				'post_excerpt' => '',
+				'post_type'    => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// wp_trim_excerpt() runs the_content to build an auto excerpt. Themes and
+		// SEO plugins do this in wp_head, before the content is ever rendered.
+		$excerpt = get_the_excerpt( $post_id );
+
+		$this->assertStringNotContainsString( '__iawmlf-post-loop-links', $excerpt, 'The excerpt should never carry the payload span.' );
+
+		// The visible render still has to emit it.
+		$rendered = apply_filters( 'the_content', $GLOBALS['post']->post_content );
+
+		$this->assertStringContainsString(
+			'__iawmlf-post-loop-links',
+			$rendered,
+			'Building the excerpt must not use up the post\'s one span.'
+		);
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
 	 * @testdox Every distinct post in a loop should get its own link data span, and none of them should gain a line break.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes #346.

Thanks to @uusijani for the report. It was precise, correctly diagnosed, and the guess about `wpautop` in the issue was exactly right.

## The cause

The payload span was appended on `render_block` at priority 999. `do_blocks` runs on `the_content` at priority 9 and `wpautop` at 10, so the span was glued on **before** `wpautop` ran. `wpautop` then saw the content's trailing newline as no longer trailing and turned it into a visible `<br />`.

Measured with the real `wpautop`, Classic Editor content ending in a newline:

```
without the span            with the span (before this PR)
<p>First paragraph.</p>     <p>First paragraph.</p>
<p>Last word.</p>           <p>Last word.<br />
                            <span hidden …></span></p>
```

## The fix

Append on `the_content` at priority 12 instead, after every filter that formats the content. There is nothing left to react to the span, so the rendered output is byte identical to the unmodified rendering with the span appended.

`render_block()` is renamed `append_link_data()` to match where it now runs.

## Two extras the tests turned up

Neither was in the report, both are fixed by the same change:

1. Content ending in blank lines, or in a block level tag such as `</ul>`, put the span in an empty paragraph of its own.
2. On a single post page the old hook emitted a payload span for **every other post** in the template's query loop, and put the viewed post's own span in the **site header** rather than in its content. Four spans where one was needed.

## Loop pages are unaffected

`wp_localize_script` only hands the front end script the current post's links, so every other post in a loop depends entirely on its own span. Verified on the blog index: every post rendered through `core/post-content` still emits its own span with its own links.

Title and excerpt blocks no longer emit one. They cannot render an outbound anchor either, because `core/post-excerpt` always has `excerptLength` set (default 55) and so always runs `wp_trim_words()`, which calls `wp_strip_all_tags()` first. Nothing consumed those spans.

## Testing

**Unit, 23 new (514 total, all passing).** The main one is a data provider covering nine ways Classic Editor content can end: trailing newline, no trailing newline, single line, trailing blank lines, trailing spaces and tabs, Windows line endings, ending in a list, ending in a blockquote, ending in an inline image. Each is rendered twice, with the span and with the post excluded, and the assertion is that stripping the span gives back the baseline byte for byte. Plus tests that an authored line break survives, that the same post repeated in a loop emits one span, and that each distinct post in a loop emits its own.

**E2E, 5 new across 2 specs (21 total, all passing).**

- `trailing-newline-rendering.spec.js` publishes four Classic Editor posts and checks the rendered page in the browser.
- `query-loop-link-data.spec.js` seeds three posts with two distinct links each and asserts every post's span in the loop lists both of its own links and none of the other four.

Both were verified to actually catch regressions: they fail when the old `render_block` hook is reintroduced, and the query loop spec fails when the loop spans are deliberately dropped.

Both new specs back up and restore every option they touch and delete their own posts and link rows. A full suite run leaves no residue.

`composer lint:php` exits 0.

## To reproduce manually

1. Classic Editor, Code view, create a post ending the final paragraph with a newline.
2. Include an outbound link so the plugin records one.
3. Publish and inspect the last paragraph. On trunk there is a `<br />` before the span; on this branch there is not.
